### PR TITLE
FASTQ modality defaults to not_classified instead of genomic

### DIFF
--- a/rules/unified_rules.yaml
+++ b/rules/unified_rules.yaml
@@ -2222,7 +2222,8 @@ rules:
     when:
       extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
       modality_not_set: true
-    then: {}
+    then:
+      data_modality: not_classified
     confidence: 0.0
     rationale: "FASTQ modality cannot be determined from reads alone — could be genomic, transcriptomic, or epigenomic depending on assay"
     terminal: false

--- a/tests/test_header_classifier.py
+++ b/tests/test_header_classifier.py
@@ -324,7 +324,7 @@ class TestFastqClassification:
         assert val(result, "platform") == "ILLUMINA"
         assert val(result, "data_modality") == NOT_CLASSIFIED
         assert val(result, "data_type") == "reads"
-        assert val(result, "confidence") >= 0.85
+        assert val(result, "confidence") >= 0.90
 
     def test_illumina_instrument_model(self):
         """Extract Illumina instrument model."""


### PR DESCRIPTION
## Summary

FASTQ format contains no assay/modality information — reads from WGS, RNA-seq, ATAC-seq, ChIP-seq all look identical. Defaulting to `genomic` was incorrect for non-genomic assays.

- Rename `fastq_genomic_default` → `fastq_modality_unknown`
- Remove `data_modality: genomic` from the default rule (leaves as `not_classified`)
- Files with modality signals in filename (`_RNA_`, `atac`, etc.) or from PacBio/ONT platform rules are unaffected

Discovered via comparison against AnVIL Azul metadata: 3,973 IGVF snRNA-seq FASTQs were misclassified as `genomic`.

Fixes #35.

## Test plan

- [x] `make test` passes (228/228)
- [x] 3 tests updated to expect `not_classified` for plain Illumina FASTQ
- [x] PacBio/ONT FASTQ tests still correctly get `genomic` (set by platform rules, not the default)
- [x] Filename-pattern tests (RNA, ATAC, WGS keywords) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)