### PR TITLE
Validate enum-backed when-values against the schema vocabulary (#113)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ venv.bak/
 # Data and output directories (large files from API)
 data/
 output/
+
+# Classification run outputs (large generated JSON)
+*_classifications.json

--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,5 @@ venv.bak/
 data/
 output/
 
-# Classification run outputs (large generated JSON)
-*_classifications.json
+# Classification run outputs (large generated JSON, written at repo root)
+/*_classifications.json

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -138,6 +138,12 @@ class RuleLoader:
     # listed here would never be applied, so it is treated as an error.
     VALID_THEN_KEYS = set(CLASSIFICATION_FIELDS)
 
+    # assay_type_rules condition keys that infer_assay_type() treats as iterables
+    # (`x not in platform_in`, `any(r in ... for r in matched_rules_any)`). A
+    # scalar string here silently becomes a per-character membership test, so it
+    # must be a list. Keep in sync with rule_engine.RuleEngine.infer_assay_type().
+    LIST_VALUED_ASSAY_CONDITIONS = {"platform_in", "matched_rules_any"}
+
     def __init__(self, rules_path: str | Path | None = None):
         """Initialize the rule loader.
 
@@ -320,6 +326,16 @@ class RuleLoader:
                     f"Assay type rule {assay_id}: 'conditions' must be a mapping, "
                     f"got {type(conditions).__name__}"
                 )
+
+            # List-typed condition keys must be lists; a scalar string would be
+            # iterated character-by-character by infer_assay_type and silently
+            # mis-match (e.g. platform_in: ILLUMINA).
+            for key in self.LIST_VALUED_ASSAY_CONDITIONS:
+                if key in conditions and not isinstance(conditions[key], list):
+                    raise ValueError(
+                        f"Assay type rule {assay_id}: condition '{key}' must be a "
+                        f"list, got {type(conditions[key]).__name__}"
+                    )
 
             rules.append(AssayTypeRule(
                 id=assay_id,

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -306,10 +306,25 @@ class RuleLoader:
         rules = []
 
         for rule_data in rules_data:
+            assay_id = rule_data.get("id", "")
+
+            # Coerce only a null block to {} (a catch-all rule); any other
+            # non-mapping is malformed and must raise rather than crash
+            # infer_assay_type, which assumes conditions is a mapping. Mirrors
+            # the when/then handling in _parse_rules.
+            conditions = rule_data.get("conditions", {})
+            if conditions is None:
+                conditions = {}
+            if not isinstance(conditions, dict):
+                raise ValueError(
+                    f"Assay type rule {assay_id}: 'conditions' must be a mapping, "
+                    f"got {type(conditions).__name__}"
+                )
+
             rules.append(AssayTypeRule(
-                id=rule_data.get("id", ""),
+                id=assay_id,
                 priority=rule_data.get("priority", 0),
-                conditions=rule_data.get("conditions", {}),
+                conditions=conditions,
                 assay_type=rule_data.get("assay_type", ""),
             ))
 

--- a/src/meta_disco/schema_vocab.py
+++ b/src/meta_disco/schema_vocab.py
@@ -25,6 +25,16 @@ SENTINEL_VALUES = frozenset({NOT_APPLICABLE, NOT_CLASSIFIED})
 # this derives from the single source of truth rather than re-listing the fields.
 DIMENSION_ENUMS = {field: f"{field}_enum" for field in CLASSIFICATION_FIELDS}
 
+# ``when`` condition keys whose value must be a member of a dimension enum,
+# mapped to that dimension. The rule engine compares these against enum values at
+# match time, so a typo'd value silently never matches rather than erroring — the
+# same class of bug the ``then``-value check guards against. Only ``platform``
+# qualifies today; the other ``when`` keys carry regexes, header field codes,
+# numeric bounds, or booleans, none of which are dimension-enum-backed.
+# ``when.file_format`` is checked against extension_map keys, not a dimension enum
+# (see issue #114). Keep in sync with rule_engine.RuleEngine._rule_matches().
+ENUM_BACKED_WHEN_KEYS = {"platform": "platform"}
+
 
 def default_schema_path() -> Path:
     """Path to the canonical LinkML classification schema."""
@@ -71,3 +81,13 @@ def dimension_values(field: str) -> frozenset[str]:
             f"for dimension {field!r}"
         )
     return enums[enum_name]
+
+
+def value_in_vocabulary(field: str, value: str) -> bool:
+    """True if ``value`` is permissible for the dimension, or a sentinel.
+
+    The membership test the rule drift checks use: a dimension's enum values plus
+    SENTINEL_VALUES. Raises the same errors as ``dimension_values`` for an
+    unrecognized field or a schema missing the expected enum.
+    """
+    return value in (dimension_values(field) | SENTINEL_VALUES)

--- a/src/meta_disco/schema_vocab.py
+++ b/src/meta_disco/schema_vocab.py
@@ -35,6 +35,19 @@ DIMENSION_ENUMS = {field: f"{field}_enum" for field in CLASSIFICATION_FIELDS}
 # (see issue #114). Keep in sync with rule_engine.RuleEngine._rule_matches().
 ENUM_BACKED_WHEN_KEYS = {"platform": "platform"}
 
+# assay_type_rules ``conditions`` keys whose value(s) must be dimension-enum
+# members, mapped to (dimension, is_list). The same antecedent-value class as
+# ENUM_BACKED_WHEN_KEYS, but in the separate assay-inference block. Excluded
+# (intentionally): data_modality_contains (substring match, not full-enum
+# membership), file_format / file_format_not (extension_map, not a dimension
+# enum — see #114), matched_rules_any (rule ids), and numeric size bounds.
+# Keep in sync with rule_engine.RuleEngine.infer_assay_type().
+ENUM_BACKED_ASSAY_CONDITIONS = {
+    "data_modality": ("data_modality", False),
+    "platform": ("platform", False),
+    "platform_in": ("platform", True),
+}
+
 
 def default_schema_path() -> Path:
     """Path to the canonical LinkML classification schema."""
@@ -83,11 +96,14 @@ def dimension_values(field: str) -> frozenset[str]:
     return enums[enum_name]
 
 
-def value_in_vocabulary(field: str, value: str) -> bool:
+def value_in_vocabulary(field: str, value: object) -> bool:
     """True if ``value`` is permissible for the dimension, or a sentinel.
 
     The membership test the rule drift checks use: a dimension's enum values plus
-    SENTINEL_VALUES. Raises the same errors as ``dimension_values`` for an
+    SENTINEL_VALUES. Permissible values are always strings, so a non-string value
+    (e.g. a list from a malformed rule like ``platform: [ILLUMINA, PACBIO]``) is
+    reported as not-in-vocabulary rather than raising ``TypeError`` on the set
+    membership test. Raises the same errors as ``dimension_values`` for an
     unrecognized field or a schema missing the expected enum.
     """
-    return value in (dimension_values(field) | SENTINEL_VALUES)
+    return isinstance(value, str) and value in (dimension_values(field) | SENTINEL_VALUES)

--- a/tests/test_rule_vocabulary.py
+++ b/tests/test_rule_vocabulary.py
@@ -19,6 +19,22 @@ from src.meta_disco import schema_vocab
 from src.meta_disco.rule_loader import RuleLoader, get_unified_rules
 
 
+def _when_value_violations(rules):
+    """Enum-backed `when` condition values not in the schema vocabulary.
+
+    The single detection path for the antecedent-value check — exercised by both
+    the suite-wide test and the negative test, so the latter load-bears on the
+    real logic rather than re-deriving the membership assertion.
+    """
+    violations = []
+    for rule in rules.rules:
+        for key, dimension in schema_vocab.ENUM_BACKED_WHEN_KEYS.items():
+            value = (rule.when or {}).get(key)
+            if value is not None and not schema_vocab.value_in_vocabulary(dimension, value):
+                violations.append(f"{rule.id}: when.{key}={value!r}")
+    return violations
+
+
 def test_rule_then_values_in_vocabulary():
     """Every value a rule emits must be in the schema vocabulary (or a sentinel)."""
     rules = get_unified_rules()
@@ -27,8 +43,7 @@ def test_rule_then_values_in_vocabulary():
         for field, value in (rule.then or {}).items():
             if field not in schema_vocab.DIMENSION_ENUMS or value is None:
                 continue
-            allowed = schema_vocab.dimension_values(field) | schema_vocab.SENTINEL_VALUES
-            if value not in allowed:
+            if not schema_vocab.value_in_vocabulary(field, value):
                 violations.append(f"{rule.id}: {field}={value!r}")
 
     assert not violations, (
@@ -38,14 +53,44 @@ def test_rule_then_values_in_vocabulary():
     )
 
 
+def test_rule_when_values_in_vocabulary():
+    """Enum-backed `when` condition values must also be in the schema vocabulary.
+
+    Mirrors the `then`-value check for the antecedent side (issue #113). Only
+    `when` keys in ENUM_BACKED_WHEN_KEYS are dimension-enum-backed; the rest
+    (regexes, header codes, numeric bounds, booleans) are not checkable this way.
+    """
+    violations = _when_value_violations(get_unified_rules())
+    assert not violations, (
+        "Rules use `when` condition values not in the LinkML schema vocabulary.\n"
+        "Add them to classification.yaml or fix the rule:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_when_value_check_rejects_bogus_platform(tmp_path):
+    """The when-value drift check catches a typo'd enum-backed value (issue #113).
+
+    Runs the real scan (_when_value_violations) over a rule whose when.platform is
+    bogus. The loader accepts the *key* (`platform` is a valid when key); this is
+    the *value* gap #113 closes.
+    """
+    path = _write_rules_file(tmp_path, {
+        "id": "bogus_when_platform", "tier": 2, "scope": "filename",
+        "when": {"platform": "ILUMINA"},  # typo: should be ILLUMINA
+        "then": {"data_modality": "genomic"},
+    })
+    violations = _when_value_violations(RuleLoader(path).load())
+    assert violations == ["bogus_when_platform: when.platform='ILUMINA'"]
+
+
 def test_assay_type_inference_values_in_vocabulary():
     """assay_type_rules (the inference block) must also use vocabulary values."""
     rules = get_unified_rules()
-    allowed = schema_vocab.dimension_values("assay_type") | schema_vocab.SENTINEL_VALUES
     violations = [
         f"{r.id}: assay_type={r.assay_type!r}"
         for r in rules.assay_type_rules
-        if r.assay_type and r.assay_type not in allowed
+        if r.assay_type and not schema_vocab.value_in_vocabulary("assay_type", r.assay_type)
     ]
     assert not violations, (
         "assay_type inference rules emit values not in the schema vocabulary:\n  "

--- a/tests/test_rule_vocabulary.py
+++ b/tests/test_rule_vocabulary.py
@@ -185,6 +185,29 @@ def test_loader_accepts_null_assay_conditions(tmp_path):
     assert loaded.assay_type_rules[0].conditions == {}
 
 
+@pytest.mark.parametrize("list_key", ["platform_in", "matched_rules_any"])
+def test_loader_rejects_scalar_list_valued_assay_condition(tmp_path, list_key):
+    # A scalar where a list is expected would be iterated char-by-char by
+    # infer_assay_type and silently mis-match; the loader must reject it.
+    path = _write_assay_rules_file(tmp_path, {
+        "id": "scalar_list", "priority": 1,
+        "conditions": {list_key: "ILLUMINA"},  # should be ["ILLUMINA"]
+        "assay_type": "WGS",
+    })
+    with pytest.raises(ValueError, match=f"condition '{list_key}' must be a list"):
+        RuleLoader(path).load()
+
+
+def test_loader_accepts_list_valued_assay_conditions(tmp_path):
+    path = _write_assay_rules_file(tmp_path, {
+        "id": "list_ok", "priority": 1,
+        "conditions": {"platform_in": ["PACBIO", "ONT"], "matched_rules_any": ["r1"]},
+        "assay_type": "WGS",
+    })
+    loaded = RuleLoader(path).load()
+    assert loaded.assay_type_rules[0].conditions["platform_in"] == ["PACBIO", "ONT"]
+
+
 def test_dimension_values_unknown_field_raises_clear_error():
     with pytest.raises(ValueError, match="Unknown classification dimension"):
         schema_vocab.dimension_values("not_a_field")

--- a/tests/test_rule_vocabulary.py
+++ b/tests/test_rule_vocabulary.py
@@ -98,6 +98,58 @@ def test_assay_type_inference_values_in_vocabulary():
     )
 
 
+def _assay_condition_violations(rules):
+    """Enum-backed assay_type_rules *condition* values not in the vocabulary.
+
+    The antecedent side of the assay-inference block — the same class as
+    _when_value_violations, for the conditions matched in infer_assay_type.
+    """
+    violations = []
+    for rule in rules.assay_type_rules:
+        conditions = rule.conditions or {}
+        for key, (dimension, is_list) in schema_vocab.ENUM_BACKED_ASSAY_CONDITIONS.items():
+            if key not in conditions:
+                continue
+            raw = conditions[key]
+            values = raw if is_list and isinstance(raw, list) else [raw]
+            for value in values:
+                if not schema_vocab.value_in_vocabulary(dimension, value):
+                    violations.append(f"{rule.id}: conditions.{key}={value!r}")
+    return violations
+
+
+def test_assay_type_condition_values_in_vocabulary():
+    """Enum-backed assay_type_rules *conditions* must use vocabulary values too.
+
+    The antecedent-value gap (#113) also exists in the assay-inference block:
+    data_modality / platform / platform_in are matched against the schema enums
+    in infer_assay_type, so a typo there silently never matches.
+    """
+    violations = _assay_condition_violations(get_unified_rules())
+    assert not violations, (
+        "assay_type_rules conditions use values not in the LinkML schema vocabulary:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_assay_condition_check_rejects_bogus_platform(tmp_path):
+    """The assay-condition drift check catches a typo'd enum-backed value (#113)."""
+    path = tmp_path / "rules.yaml"
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump_all([
+            {"extension_map": {}},
+            {"rules": []},
+            {"validators": {}},
+            {"assay_type_rules": [{
+                "id": "bogus_assay", "priority": 1,
+                "conditions": {"platform_in": ["ILUMINA"]},  # typo: should be ILLUMINA
+                "assay_type": "WGS",
+            }]},
+        ], f)
+    violations = _assay_condition_violations(RuleLoader(path).load())
+    assert violations == ["bogus_assay: conditions.platform_in='ILUMINA'"]
+
+
 def test_dimension_values_unknown_field_raises_clear_error():
     with pytest.raises(ValueError, match="Unknown classification dimension"):
         schema_vocab.dimension_values("not_a_field")

--- a/tests/test_rule_vocabulary.py
+++ b/tests/test_rule_vocabulary.py
@@ -150,6 +150,41 @@ def test_assay_condition_check_rejects_bogus_platform(tmp_path):
     assert violations == ["bogus_assay: conditions.platform_in='ILUMINA'"]
 
 
+def _write_assay_rules_file(tmp_path, assay_rule):
+    """Write a rules file whose fourth document holds a single assay_type_rule."""
+    path = tmp_path / "rules.yaml"
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump_all([
+            {"extension_map": {}},
+            {"rules": []},
+            {"validators": {}},
+            {"assay_type_rules": [assay_rule]},
+        ], f)
+    return path
+
+
+@pytest.mark.parametrize("bad_conditions", ["always", "", [], 0])
+def test_loader_rejects_non_mapping_assay_conditions(tmp_path, bad_conditions):
+    # A non-mapping `conditions` must raise at load time rather than crash
+    # infer_assay_type (which assumes a mapping). Mirrors the when/then guard.
+    path = _write_assay_rules_file(tmp_path, {
+        "id": "bad_conditions", "priority": 1,
+        "conditions": bad_conditions, "assay_type": "WGS",
+    })
+    with pytest.raises(ValueError, match="'conditions' must be a mapping"):
+        RuleLoader(path).load()
+
+
+def test_loader_accepts_null_assay_conditions(tmp_path):
+    # A null `conditions` block is a catch-all rule; coerced to {}, not a crash.
+    path = _write_assay_rules_file(tmp_path, {
+        "id": "null_conditions", "priority": 1,
+        "conditions": None, "assay_type": "WGS",
+    })
+    loaded = RuleLoader(path).load()
+    assert loaded.assay_type_rules[0].conditions == {}
+
+
 def test_dimension_values_unknown_field_raises_clear_error():
     with pytest.raises(ValueError, match="Unknown classification dimension"):
         schema_vocab.dimension_values("not_a_field")


### PR DESCRIPTION
## Summary

Closes the **antecedent-value gap** identified in review of #112. The rule drift
check validated `then` (consequent) values against the LinkML schema enums but
left antecedent values unchecked. This PR validates enum-backed antecedent
values on **both** antecedent paths — rule `when` blocks and `assay_type_rules`
conditions.

| | keys | values |
|---|---|---|
| consequent (`then`) | ✅ loader | ✅ test |
| antecedent (`when`) | ✅ loader | ✅ **this PR** |
| antecedent (`assay_type_rules` conditions) | — | ✅ **this PR** |

The only dimension-enum-backed `when` key is `platform` (`platform_enum`); in the
assay block, `data_modality`, `platform`, and `platform_in` are matched against
their enums in `infer_assay_type`. A typo such as `when: {platform: ILUMINA}` or
`platform_in: [ILUMINA]` previously caused the rule to silently never match; it
now fails the drift check. There are 0 current `when.platform` uses, so the
`when` half is a preventive guardrail; the assay-condition half covers values
that exist today (`genomic`, `ILLUMINA`, `PACBIO`, `ONT`).

## Changes

- `schema_vocab.ENUM_BACKED_WHEN_KEYS` — enum-backed `when` keys → dimension
  (`{"platform": "platform"}`).
- `schema_vocab.ENUM_BACKED_ASSAY_CONDITIONS` — enum-backed assay condition keys
  → `(dimension, is_list)` for `data_modality`, `platform`, `platform_in`.
- `schema_vocab.value_in_vocabulary(field, value)` — shared membership predicate
  (dimension enum + sentinels). `isinstance(value, str)` guard returns False for
  a non-string value (e.g. a malformed list) instead of raising `TypeError`, so
  the drift check reports a clean violation. The `then`-value, `when`-value, and
  `assay_type`-output checks all route through it.
- `test_rule_when_values_in_vocabulary` + `test_assay_type_condition_values_in_vocabulary`,
  each with a negative test that runs the real scan over a bogus rule (not a
  re-derived assertion).
- `.gitignore`: `/*_classifications.json` (root-level generated run outputs).

## Out of scope

- `when.file_format` / assay `file_format` are checked against `extension_map`
  keys — a different vocabulary source, not a dimension enum. Tracked in #114.
- assay condition **keys** (vs values) are not yet validated against an
  allow-list the way `when`/`then` keys are; see review thread on
  `_parse_assay_type_rules` not guarding non-mapping `conditions`.

## Test plan

- `pytest` — 368 passing
- `ruff check` clean
- `/simplify` (4-agent) and `/code-review high` (8-angle) both run; the latter
  surfaced the assay-condition same-class gap and the `TypeError` guard, folded
  in here.

Closes #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
