### PR TITLE
Stage 0: output-shape golden guardrail (#117)

### DIFF
--- a/tests/fixtures/golden/expected_output.json
+++ b/tests/fixtures/golden/expected_output.json
@@ -1,0 +1,374 @@
+{
+  "bam": {
+    "classifications": [
+      {
+        "classifications": {
+          "assay_type": {
+            "confidence": 0.0,
+            "evidence": [
+              {
+                "confidence": 0.0,
+                "reason": "No rule determined a value for assay_type",
+                "rule_id": "not_classified",
+                "value": "not_classified"
+              }
+            ],
+            "value": "not_classified"
+          },
+          "data_modality": {
+            "confidence": 0.0,
+            "evidence": [
+              {
+                "confidence": 0.0,
+                "reason": "No rule determined a value for data_modality",
+                "rule_id": "not_classified",
+                "value": "not_classified"
+              }
+            ],
+            "value": "not_classified"
+          },
+          "data_type": {
+            "confidence": 0.0,
+            "evidence": [
+              {
+                "confidence": 0.0,
+                "reason": "No rule determined a value for data_type",
+                "rule_id": "not_classified",
+                "value": "not_classified"
+              }
+            ],
+            "value": "not_classified"
+          },
+          "platform": {
+            "confidence": 0.0,
+            "evidence": [
+              {
+                "confidence": 0.0,
+                "reason": "No rule determined a value for platform",
+                "rule_id": "not_classified",
+                "value": "not_classified"
+              }
+            ],
+            "value": "not_classified"
+          },
+          "reference_assembly": {
+            "confidence": 0.9,
+            "evidence": [
+              {
+                "confidence": 0.9,
+                "reason": "Absence of @SQ lines indicates unaligned reads. Common for PacBio HiFi deliverables before alignment",
+                "rule_id": "unaligned_no_sq",
+                "tier": 3,
+                "value": "not_applicable"
+              }
+            ],
+            "value": "not_applicable"
+          }
+        },
+        "dataset_title": "GOLDEN_FIXTURE",
+        "entry_id": "g-bam-1",
+        "file_format": ".bam",
+        "file_name": "sample.rnaseq.bam",
+        "file_size": 12345678,
+        "md5sum": "golden_bam_rnaseq"
+      }
+    ],
+    "metadata": {
+      "complete": true,
+      "failed": 0,
+      "from_cache": 0,
+      "processed": 1,
+      "successful": 1,
+      "total_to_process": 1
+    }
+  },
+  "fasta": {
+    "classifications": [
+      {
+        "classifications": {
+          "assay_type": {
+            "confidence": 0.3,
+            "evidence": [
+              {
+                "confidence": 0.3,
+                "reason": "FASTA file detected; header inspection needed to determine if de novo assembly, reference genome, or transcript sequences",
+                "rule_id": "fasta_base",
+                "tier": 1,
+                "value": "not_applicable"
+              }
+            ],
+            "value": "not_applicable"
+          },
+          "data_modality": {
+            "confidence": 0.8,
+            "evidence": [
+              {
+                "confidence": 0.8,
+                "reason": "Filename contains assembly/assembler indicator \u2014 de novo assembly",
+                "rule_id": "fasta_assembly_filename",
+                "tier": 2,
+                "value": "genomic"
+              },
+              {
+                "confidence": 0.8,
+                "reason": "Filename contains haplotype/phasing indicator \u2014 de novo assembly",
+                "rule_id": "fasta_haplotype_filename",
+                "tier": 2,
+                "value": "genomic"
+              }
+            ],
+            "value": "genomic"
+          },
+          "data_type": {
+            "confidence": 0.8,
+            "evidence": [
+              {
+                "confidence": 0.3,
+                "reason": "FASTA file detected; header inspection needed to determine if de novo assembly, reference genome, or transcript sequences",
+                "rule_id": "fasta_base",
+                "tier": 1,
+                "value": "sequence"
+              },
+              {
+                "confidence": 0.8,
+                "reason": "Filename contains assembly/assembler indicator \u2014 de novo assembly",
+                "rule_id": "fasta_assembly_filename",
+                "tier": 2,
+                "value": "assembly"
+              },
+              {
+                "confidence": 0.8,
+                "reason": "Filename contains haplotype/phasing indicator \u2014 de novo assembly",
+                "rule_id": "fasta_haplotype_filename",
+                "tier": 2,
+                "value": "assembly"
+              }
+            ],
+            "value": "assembly"
+          },
+          "platform": {
+            "confidence": 0.3,
+            "evidence": [
+              {
+                "confidence": 0.3,
+                "reason": "FASTA file detected; header inspection needed to determine if de novo assembly, reference genome, or transcript sequences",
+                "rule_id": "fasta_base",
+                "tier": 1,
+                "value": "not_applicable"
+              }
+            ],
+            "value": "not_applicable"
+          },
+          "reference_assembly": {
+            "confidence": 0.8,
+            "evidence": [
+              {
+                "confidence": 0.8,
+                "reason": "Filename contains assembly/assembler indicator \u2014 de novo assembly",
+                "rule_id": "fasta_assembly_filename",
+                "tier": 2,
+                "value": "not_applicable"
+              },
+              {
+                "confidence": 0.8,
+                "reason": "Filename contains haplotype/phasing indicator \u2014 de novo assembly",
+                "rule_id": "fasta_haplotype_filename",
+                "tier": 2,
+                "value": "not_applicable"
+              }
+            ],
+            "value": "not_applicable"
+          }
+        },
+        "dataset_title": "GOLDEN_FIXTURE",
+        "entry_id": "g-fasta-1",
+        "file_format": ".fasta",
+        "file_name": "hapdup_contigs.hap1.fasta",
+        "file_size": 2974881710,
+        "md5sum": "golden_fasta_assembly"
+      }
+    ],
+    "metadata": {
+      "complete": true,
+      "failed": 0,
+      "from_cache": 0,
+      "processed": 1,
+      "successful": 1,
+      "total_to_process": 1
+    }
+  },
+  "fastq": {
+    "classifications": [
+      {
+        "classifications": {
+          "archive_accession": null,
+          "archive_source": null,
+          "assay_type": {
+            "confidence": 0.0,
+            "evidence": [
+              {
+                "confidence": 0.0,
+                "reason": "No rule determined a value for assay_type",
+                "rule_id": "not_classified",
+                "value": "not_classified"
+              }
+            ],
+            "value": "not_classified"
+          },
+          "data_modality": {
+            "confidence": 0.0,
+            "evidence": [
+              {
+                "confidence": 0.0,
+                "reason": "FASTQ modality cannot be determined from reads alone \u2014 could be genomic, transcriptomic, or epigenomic depending on assay",
+                "rule_id": "fastq_modality_unknown",
+                "tier": 3,
+                "value": "not_classified"
+              }
+            ],
+            "value": "not_classified"
+          },
+          "data_type": {
+            "confidence": 0.5,
+            "evidence": [
+              {
+                "confidence": 0.5,
+                "reason": "FASTQ files contain raw sequencing reads. Reference not applicable until alignment",
+                "rule_id": "reads_base",
+                "tier": 2,
+                "value": "reads"
+              }
+            ],
+            "value": "reads"
+          },
+          "instrument_hint": null,
+          "instrument_model": null,
+          "is_paired_end": false,
+          "platform": {
+            "confidence": 0.0,
+            "evidence": [
+              {
+                "confidence": 0.0,
+                "reason": "No rule determined a value for platform",
+                "rule_id": "not_classified",
+                "value": "not_classified"
+              }
+            ],
+            "value": "not_classified"
+          },
+          "reference_assembly": {
+            "confidence": 0.5,
+            "evidence": [
+              {
+                "confidence": 0.5,
+                "reason": "FASTQ files contain raw sequencing reads. Reference not applicable until alignment",
+                "rule_id": "reads_base",
+                "tier": 2,
+                "value": "not_applicable"
+              }
+            ],
+            "value": "not_applicable"
+          }
+        },
+        "dataset_title": "GOLDEN_FIXTURE",
+        "entry_id": "g-fastq-1",
+        "file_format": ".fastq.gz",
+        "file_name": "sample.fastq.gz",
+        "file_size": 8000,
+        "md5sum": "golden_fastq"
+      }
+    ],
+    "metadata": {
+      "complete": true,
+      "failed": 0,
+      "from_cache": 0,
+      "processed": 1,
+      "successful": 1,
+      "total_to_process": 1
+    }
+  },
+  "vcf": {
+    "classifications": [
+      {
+        "classifications": {
+          "assay_type": {
+            "confidence": 0.0,
+            "evidence": [
+              {
+                "confidence": 0.0,
+                "reason": "No rule determined a value for assay_type",
+                "rule_id": "not_classified",
+                "value": "not_classified"
+              }
+            ],
+            "value": "not_classified"
+          },
+          "data_modality": {
+            "confidence": 0.85,
+            "evidence": [
+              {
+                "confidence": 0.85,
+                "reason": "VCF files contain variant calls (genomic data)",
+                "rule_id": "variant_default_genomic",
+                "tier": 1,
+                "value": "genomic"
+              }
+            ],
+            "value": "genomic"
+          },
+          "data_type": {
+            "confidence": 0.85,
+            "evidence": [
+              {
+                "confidence": 0.85,
+                "reason": "VCF files contain variant calls (genomic data)",
+                "rule_id": "variant_default_genomic",
+                "tier": 1,
+                "value": "variants"
+              }
+            ],
+            "value": "variants"
+          },
+          "platform": {
+            "confidence": 0.0,
+            "evidence": [
+              {
+                "confidence": 0.0,
+                "reason": "No rule determined a value for platform",
+                "rule_id": "not_classified",
+                "value": "not_classified"
+              }
+            ],
+            "value": "not_classified"
+          },
+          "reference_assembly": {
+            "confidence": 0.0,
+            "evidence": [
+              {
+                "confidence": 0.0,
+                "reason": "No rule determined a value for reference_assembly",
+                "rule_id": "not_classified",
+                "value": "not_classified"
+              }
+            ],
+            "value": "not_classified"
+          }
+        },
+        "dataset_title": "GOLDEN_FIXTURE",
+        "entry_id": "g-vcf-1",
+        "file_format": ".vcf.gz",
+        "file_name": "sample.vcf.gz",
+        "file_size": 5000,
+        "md5sum": "golden_vcf"
+      }
+    ],
+    "metadata": {
+      "complete": true,
+      "failed": 0,
+      "from_cache": 0,
+      "processed": 1,
+      "successful": 1,
+      "total_to_process": 1
+    }
+  }
+}

--- a/tests/test_output_shape.py
+++ b/tests/test_output_shape.py
@@ -21,10 +21,13 @@ Three layers of protection:
 The golden is produced by running the real FileTypeConfig classifiers (so it
 guards the real ``to_output_dict`` record/dimension shape and the pipeline
 envelope) with a per-type stub fetcher — deterministic, no network. The stub
-supplies a placeholder header, so classification runs the filename/extension
-(tier-1/2) path; header-driven (tier-3) evidence variants are not exercised in
-Stage 0. That is acceptable: this guards output *shape*, not classification
-accuracy. Regenerate with::
+supplies a placeholder header with no real content, so tier-3 rules that key on
+*specific* header content (contig lengths, instrument IDs, assembly tokens) do
+not fire — content-driven classification is not exercised. Tier-3 rules that key
+on the *absence* of such content (e.g. ``unaligned_no_sq``,
+``fastq_modality_unknown``) do fire and appear in the golden. That is acceptable:
+this guards output *shape*, not content-driven classification accuracy.
+Regenerate with::
 
     python -m tests.test_output_shape   # writes tests/fixtures/golden/expected_output.json
 

--- a/tests/test_output_shape.py
+++ b/tests/test_output_shape.py
@@ -1,0 +1,202 @@
+"""Golden-fixture + structural guardrail for the classification output shape.
+
+Stage 0 of the sentinel→status migration (epic #116, issue #117). Pins the
+pipeline's output shape so the pure-refactor stages (#118/#119) can prove
+byte-identical output, and the deliberate reshape stages (#120/#121) produce a
+small, reviewable diff against the golden.
+
+Three layers of protection:
+
+1. ``test_output_matches_golden`` — the real pipeline output deep-equals a
+   committed golden JSON. Catches *any* change, byte for byte.
+2. ``test_output_structural_contract`` — an explicit keys+types contract per
+   record and per field, for legible failures.
+3. ``test_output_values_in_vocabulary`` — every emitted field value is a member
+   of the matching LinkML schema enum (or a sentinel / null). This is the slice
+   of the schema that applies to today's output; full record-level JSON-Schema
+   validation lands in Stage 4a (#122), once the output shape matches the schema.
+
+The golden is produced by the real FileTypeConfig classifiers (so it guards the
+real ``to_output_dict`` shape) with a stub fetcher, so the run is deterministic
+and touches no network. Regenerate with::
+
+    python -m tests.test_output_shape   # writes tests/fixtures/golden/expected_output.json
+
+Note: the golden deep-equal is intentionally *value-sensitive* — it pins exact
+values/confidence/reason strings so the migration's pure-refactor stages can prove
+byte-identical output. That couples it to rule content for the duration of epic
+#116; once the shape stabilizes (after #122) this file should be de-tuned to
+shape-only (drop the deep-equal layer, keep the structural + vocabulary layers).
+"""
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+
+from src.meta_disco import schema_vocab
+from src.meta_disco.file_types import FILE_TYPE_REGISTRY
+from src.meta_disco.models import CLASSIFICATION_FIELDS
+from src.meta_disco.pipeline import ClassifyPipeline
+
+FIXTURES = Path(__file__).parent / "fixtures" / "golden"
+GOLDEN_PATH = FIXTURES / "expected_output.json"
+
+# Deterministic synthetic inputs per file type. Filenames target tier-1/2
+# (extension/filename) rules so classification needs no real header and is stable
+# across runs; a stub fetcher supplies a fixed header so no network is touched.
+# Chosen to span the shape surface: a classified value (fasta assembly), sentinels
+# (not_applicable / not_classified), and multi-evidence fields.
+GOLDEN_INPUTS = {
+    "fasta": [
+        {"file_md5sum": "golden_fasta_assembly", "file_name": "hapdup_contigs.hap1.fasta",
+         "file_size": 2974881710, "file_format": ".fasta", "entry_id": "g-fasta-1",
+         "dataset_title": "GOLDEN_FIXTURE"},
+    ],
+    "bam": [
+        {"file_md5sum": "golden_bam_rnaseq", "file_name": "sample.rnaseq.bam",
+         "file_size": 12345678, "file_format": ".bam", "entry_id": "g-bam-1",
+         "dataset_title": "GOLDEN_FIXTURE"},
+    ],
+    "vcf": [
+        {"file_md5sum": "golden_vcf", "file_name": "sample.vcf.gz",
+         "file_size": 5000, "file_format": ".vcf.gz", "entry_id": "g-vcf-1",
+         "dataset_title": "GOLDEN_FIXTURE"},
+    ],
+    "fastq": [
+        {"file_md5sum": "golden_fastq", "file_name": "sample.fastq.gz",
+         "file_size": 8000, "file_format": ".fastq.gz", "entry_id": "g-fastq-1",
+         "dataset_title": "GOLDEN_FIXTURE"},
+    ],
+}
+
+STUB_HEADER = "stub-header-no-network"
+EVIDENCE_KEYS = {"rule_id", "reason", "confidence"}
+FIELD_KEYS = {"value", "confidence", "evidence"}
+RECORD_KEYS = {
+    "file_name", "md5sum", "file_size", "file_format",
+    "dataset_title", "classifications", "entry_id",
+}
+
+
+def _stub_fetcher(evidence_dir, md5, **kwargs):
+    """Deterministic stand-in for the real header fetcher — no network."""
+    return STUB_HEADER
+
+
+def build_output(tmp_path: Path) -> dict:
+    """Run the real classifiers for each file type with a stub fetcher (offline).
+
+    Returns ``{file_type: pipeline_output_dict}``. Uses the production
+    FileTypeConfig (real classifier + ``to_output_dict``) with the fetcher swapped
+    out, so the shape is real but the run is deterministic and network-free.
+    """
+    out = {}
+    for ftype, records in GOLDEN_INPUTS.items():
+        config = dataclasses.replace(FILE_TYPE_REGISTRY[ftype], fetcher=_stub_fetcher)
+        input_path = tmp_path / f"{ftype}_input.json"
+        input_path.write_text(json.dumps({"results": records}))
+        # workers=1 forces sequential processing so the record order in the output
+        # is the input order (the parallel path writes in thread-completion order,
+        # which is nondeterministic) — keeps the deep-equal golden stable even if
+        # an input list ever grows beyond one record.
+        pipeline = ClassifyPipeline(
+            config, input_path, tmp_path / f"{ftype}_out.json",
+            evidence_base=tmp_path / "evidence", workers=1,
+        )
+        pipeline.run()
+        out[ftype] = json.loads((tmp_path / f"{ftype}_out.json").read_text())
+    return out
+
+
+def _all_records(output: dict):
+    """Yield (file_type, record) for every classified record across types."""
+    for ftype, type_output in output.items():
+        for record in type_output["classifications"]:
+            yield ftype, record
+
+
+@pytest.fixture(scope="session")
+def output(tmp_path_factory):
+    """The deterministic pipeline output, built once and shared across the tests.
+
+    All consumers are read-only assertions over the same deterministic dict, so a
+    single session-scoped build is safe and avoids re-running every pipeline per test.
+    """
+    return build_output(tmp_path_factory.mktemp("golden"))
+
+
+def test_golden_inputs_cover_all_file_types():
+    """Every registered file type must be pinned, or its output shape goes unguarded."""
+    assert set(GOLDEN_INPUTS) == set(FILE_TYPE_REGISTRY), (
+        "GOLDEN_INPUTS must cover every FILE_TYPE_REGISTRY type so no output shape is "
+        f"unguarded. Missing: {set(FILE_TYPE_REGISTRY) - set(GOLDEN_INPUTS)}"
+    )
+
+
+def test_output_matches_golden(output):
+    """The real pipeline output must deep-equal the committed golden fixture."""
+    assert GOLDEN_PATH.exists(), (
+        f"Golden fixture missing at {GOLDEN_PATH}. Regenerate with "
+        "`python -m tests.test_output_shape`."
+    )
+    expected = json.loads(GOLDEN_PATH.read_text())
+    assert output == expected, (
+        "Classification output shape changed. If intentional, regenerate the golden "
+        "with `python -m tests.test_output_shape` and review the diff."
+    )
+
+
+def test_output_structural_contract(output):
+    """Explicit keys+types contract per record and per field (legible failures)."""
+    for ftype, type_output in output.items():
+        assert set(type_output) >= {"metadata", "classifications"}, ftype
+        assert isinstance(type_output["classifications"], list)
+
+    for ftype, record in _all_records(output):
+        assert set(record) == RECORD_KEYS, f"{ftype}: {set(record) ^ RECORD_KEYS}"
+        classifications = record["classifications"]
+        # The 5 dimensions must be present; some classifiers (fastq) also emit
+        # extra type-specific scalar keys (instrument_model, is_paired_end, ...)
+        # which the deep-equal golden pins but are outside the dimension contract.
+        assert set(CLASSIFICATION_FIELDS) <= set(classifications), ftype
+        for field in CLASSIFICATION_FIELDS:
+            entry = classifications[field]
+            assert set(entry) == FIELD_KEYS, f"{ftype}.{field}: {set(entry)}"
+            assert entry["value"] is None or isinstance(entry["value"], str)
+            assert isinstance(entry["confidence"], (int, float))
+            assert isinstance(entry["evidence"], list)
+            for ev in entry["evidence"]:
+                assert EVIDENCE_KEYS <= set(ev), f"{ftype}.{field} evidence: {set(ev)}"
+
+
+def test_output_values_in_vocabulary(output):
+    """Every emitted field value must be in the schema vocabulary (or null/sentinel)."""
+    violations = []
+    for ftype, record in _all_records(output):
+        for field in CLASSIFICATION_FIELDS:
+            value = record["classifications"][field]["value"]
+            if value is None:
+                continue
+            if not schema_vocab.value_in_vocabulary(field, value):
+                violations.append(f"{ftype}: {field}={value!r}")
+    assert not violations, (
+        "Pipeline output emits values not in the LinkML schema vocabulary:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def _regenerate_golden():
+    """Write the golden fixture from a fresh pipeline run (manual regen entry point)."""
+    import tempfile
+
+    FIXTURES.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        output = build_output(Path(tmp))
+    GOLDEN_PATH.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n")
+    print(f"Wrote golden fixture to {GOLDEN_PATH}")
+
+
+if __name__ == "__main__":
+    _regenerate_golden()

--- a/tests/test_output_shape.py
+++ b/tests/test_output_shape.py
@@ -16,9 +16,13 @@ Three layers of protection:
    of the schema that applies to today's output; full record-level JSON-Schema
    validation lands in Stage 4a (#122), once the output shape matches the schema.
 
-The golden is produced by the real FileTypeConfig classifiers (so it guards the
-real ``to_output_dict`` shape) with a stub fetcher, so the run is deterministic
-and touches no network. Regenerate with::
+The golden is produced by running the real FileTypeConfig classifiers (so it
+guards the real ``to_output_dict`` record/dimension shape and the pipeline
+envelope) with a per-type stub fetcher — deterministic, no network. The stub
+supplies a placeholder header, so classification runs the filename/extension
+(tier-1/2) path; header-driven (tier-3) evidence variants are not exercised in
+Stage 0. That is acceptable: this guards output *shape*, not classification
+accuracy. Regenerate with::
 
     python -m tests.test_output_shape   # writes tests/fixtures/golden/expected_output.json
 
@@ -72,6 +76,11 @@ GOLDEN_INPUTS = {
 }
 
 STUB_HEADER = "stub-header-no-network"
+# Real fetchers return str (bam/vcf header text) or list[str] (fastq reads /
+# fasta contig names) — see fetchers.py. The stub honors each type's contract so
+# the golden exercises realistic classifier input and stays robust if a classifier
+# later type-guards its argument.
+LIST_RETURNING_TYPES = {"fastq", "fasta"}
 EVIDENCE_KEYS = {"rule_id", "reason", "confidence"}
 FIELD_KEYS = {"value", "confidence", "evidence"}
 RECORD_KEYS = {
@@ -80,9 +89,14 @@ RECORD_KEYS = {
 }
 
 
-def _stub_fetcher(evidence_dir, md5, **kwargs):
-    """Deterministic stand-in for the real header fetcher — no network."""
-    return STUB_HEADER
+def _make_stub_fetcher(file_type: str):
+    """A deterministic, network-free fetcher whose return type matches the real one."""
+    payload = [STUB_HEADER] if file_type in LIST_RETURNING_TYPES else STUB_HEADER
+
+    def _fetch(evidence_dir, md5, **kwargs):
+        return payload
+
+    return _fetch
 
 
 def build_output(tmp_path: Path) -> dict:
@@ -94,7 +108,7 @@ def build_output(tmp_path: Path) -> dict:
     """
     out = {}
     for ftype, records in GOLDEN_INPUTS.items():
-        config = dataclasses.replace(FILE_TYPE_REGISTRY[ftype], fetcher=_stub_fetcher)
+        config = dataclasses.replace(FILE_TYPE_REGISTRY[ftype], fetcher=_make_stub_fetcher(ftype))
         input_path = tmp_path / f"{ftype}_input.json"
         input_path.write_text(json.dumps({"results": records}))
         # workers=1 forces sequential processing so the record order in the output
@@ -105,7 +119,13 @@ def build_output(tmp_path: Path) -> dict:
             config, input_path, tmp_path / f"{ftype}_out.json",
             evidence_base=tmp_path / "evidence", workers=1,
         )
-        pipeline.run()
+        results = pipeline.run()
+        # run() returns [] (and writes no output file) if every record was filtered
+        # out — surface that as a clear failure rather than a later FileNotFoundError.
+        assert results, (
+            f"No records classified for {ftype!r}: a GOLDEN_INPUTS record was filtered "
+            "out (check its file_format/file_name against the config's extensions)."
+        )
         out[ftype] = json.loads((tmp_path / f"{ftype}_out.json").read_text())
     return out
 
@@ -165,7 +185,8 @@ def test_output_structural_contract(output):
             entry = classifications[field]
             assert set(entry) == FIELD_KEYS, f"{ftype}.{field}: {set(entry)}"
             assert entry["value"] is None or isinstance(entry["value"], str)
-            assert isinstance(entry["confidence"], (int, float))
+            conf = entry["confidence"]
+            assert isinstance(conf, (int, float)) and not isinstance(conf, bool)
             assert isinstance(entry["evidence"], list)
             for ev in entry["evidence"]:
                 assert EVIDENCE_KEYS <= set(ev), f"{ftype}.{field} evidence: {set(ev)}"

--- a/tests/test_output_shape.py
+++ b/tests/test_output_shape.py
@@ -13,10 +13,11 @@ Three layers of protection:
    values while ignoring JSON key order / formatting.
 2. ``test_output_structural_contract`` — an explicit keys+types contract per
    record and per field, for legible failures.
-3. ``test_output_values_in_vocabulary`` — every emitted field value is a member
-   of the matching LinkML schema enum (or a sentinel / null). This is the slice
-   of the schema that applies to today's output; full record-level JSON-Schema
-   validation lands in Stage 4a (#122), once the output shape matches the schema.
+3. ``test_output_values_in_vocabulary`` — every classification *dimension* value
+   is a member of the matching LinkML schema enum (or a sentinel / null). This is
+   the slice of the schema that applies to today's output; full record-level
+   JSON-Schema validation lands in Stage 4a (#122), once the output shape matches
+   the schema.
 
 The golden is produced by running the real FileTypeConfig classifiers (so it
 guards the real ``to_output_dict`` record/dimension shape and the pipeline
@@ -198,7 +199,12 @@ def test_output_structural_contract(output):
 
 
 def test_output_values_in_vocabulary(output):
-    """Every emitted field value must be in the schema vocabulary (or null/sentinel)."""
+    """Every classification *dimension* value must be in the schema vocabulary.
+
+    Scoped to the five CLASSIFICATION_FIELDS (or null/sentinel). Type-specific
+    scalar keys some classifiers add (fastq's instrument_model, is_paired_end, ...)
+    are not enum-backed, so they have no vocabulary to check against.
+    """
     violations = []
     for ftype, record in _all_records(output):
         for field in CLASSIFICATION_FIELDS:
@@ -208,7 +214,7 @@ def test_output_values_in_vocabulary(output):
             if not schema_vocab.value_in_vocabulary(field, value):
                 violations.append(f"{ftype}: {field}={value!r}")
     assert not violations, (
-        "Pipeline output emits values not in the LinkML schema vocabulary:\n  "
+        "Pipeline output emits dimension values not in the LinkML schema vocabulary:\n  "
         + "\n  ".join(violations)
     )
 

--- a/tests/test_output_shape.py
+++ b/tests/test_output_shape.py
@@ -1,14 +1,16 @@
 """Golden-fixture + structural guardrail for the classification output shape.
 
 Stage 0 of the sentinel→status migration (epic #116, issue #117). Pins the
-pipeline's output shape so the pure-refactor stages (#118/#119) can prove
-byte-identical output, and the deliberate reshape stages (#120/#121) produce a
-small, reviewable diff against the golden.
+pipeline's output shape so the pure-refactor stages (#118/#119) can prove the
+output is unchanged in structure and values, and the deliberate reshape stages
+(#120/#121) produce a small, reviewable diff against the golden.
 
 Three layers of protection:
 
 1. ``test_output_matches_golden`` — the real pipeline output deep-equals a
-   committed golden JSON. Catches *any* change, byte for byte.
+   committed golden JSON. The comparison is on parsed records (semantic
+   deep-equality, not byte-level), so it catches any change to structure or
+   values while ignoring JSON key order / formatting.
 2. ``test_output_structural_contract`` — an explicit keys+types contract per
    record and per field, for legible failures.
 3. ``test_output_values_in_vocabulary`` — every emitted field value is a member
@@ -28,7 +30,7 @@ accuracy. Regenerate with::
 
 Note: the golden deep-equal is intentionally *value-sensitive* — it pins exact
 values/confidence/reason strings so the migration's pure-refactor stages can prove
-byte-identical output. That couples it to rule content for the duration of epic
+the output is unchanged. That couples it to rule content for the duration of epic
 #116; once the shape stabilizes (after #122) this file should be de-tuned to
 shape-only (drop the deep-equal layer, keep the structural + vocabulary layers).
 """


### PR DESCRIPTION
## Summary

**Stage 0** of the sentinel→status migration (epic #116). A golden-fixture
guardrail that pins the classification output shape, so the pure-refactor stages
(#118/#119) can prove the output is **unchanged in structure and values**
(semantic deep-equality on parsed records) and the deliberate reshape stages
(#120/#121) produce a small, reviewable diff.

Test-only. No production code changes.

## What it does

`tests/test_output_shape.py` runs the **real** FileTypeConfig classifiers (so it
guards the real `to_output_dict` shape) with a per-type stub fetcher —
deterministic, no network — for **all four** registered file types. Three layers:

1. **`test_output_matches_golden`** — real pipeline output deep-equals a committed
   fixture (`tests/fixtures/golden/expected_output.json`). Semantic deep-equality
   on parsed records — catches any change to structure or values. Intentionally
   value-sensitive for the duration of the migration.
2. **`test_output_structural_contract`** — explicit keys+types contract per record
   and per field, for legible failures.
3. **`test_output_values_in_vocabulary`** — every emitted field value is a member
   of the matching LinkML schema enum (or sentinel/null), reusing
   `schema_vocab.value_in_vocabulary`.

Plus `test_golden_inputs_cover_all_file_types` so no registry type goes unpinned.

## Scope decisions

- **Validation scope = values vs vocabulary**, not full JSON-Schema. The generated
  JSON Schema describes the *target* (flat, `status`-required) shape, which current
  output does not match (nested under `classifications`, no `status`). Strict
  record-level JSON-Schema validation is deferred to **Stage 4a (#122)**, once the
  shapes converge.
- The stub exercises the **tier-1/2 (filename/extension)** classification path;
  header-driven (tier-3) evidence variants are not exercised in Stage 0. This
  guards *shape*, not classification accuracy.

## Quality gates

- `pytest` — 380 passing (4 new), deterministic across repeated runs
- `ruff check` clean
- `/simplify` (4-agent) and `/code-review high` (8-angle) both run. Code-review
  caught a real contract mismatch (stub returned `str` for fastq/fasta, which take
  `list[str]`), an opaque-crash path, and a `bool`-accepting type check — all fixed.

Closes #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
