### PR TITLE
Add docstring & comment accuracy as a review gate (#124)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,18 @@ The LinkML schema (`anvil_file.yaml`) defines:
 - **After changing function behavior**: verify the docstring still matches — especially guard conditions, side effects, return values, and mutation behavior.
 - **After changing output format**: check all consumers — summary printers, tests, downstream scripts.
 
+## Docstring & Comment Accuracy
+
+Docstrings and comments are claims about behavior and MUST be literally true and
+precisely scoped — verify each against the code before committing. This is a
+review gate: `/simplify` and `/code-review` must check docstrings/comments for
+these, and flag any that overclaim.
+
+- **No overclaiming scope/coverage**: do not say "every"/"all"/"any" when the code covers a subset (e.g. a check that only iterates `CLASSIFICATION_FIELDS` is not "every emitted field"). State the actual scope.
+- **No false absolutes**: do not say "byte-identical" for a semantic dict compare, or "deterministic / no network" unless the code guarantees it. Describe the real mechanism.
+- **No speculation as fact** (see Design Principles): if a comment asserts what a code path does, confirm it actually does that on the inputs in question.
+- **Prefer precise over tidy**: a longer accurate sentence beats a clean wrong one. Re-read every docstring/comment you touched against the final code.
+
 ## Environment
 
 - LLM component: Conda (`environment.yaml`) with Python 3.8, pandas, requests


### PR DESCRIPTION
## Summary

Docstrings and comments are claims about behavior and must be literally true and precisely scoped. Adds a **Docstring & Comment Accuracy** section to CLAUDE.md under Code Change Discipline.

## Why

PR #123 (#117) spent **three** Copilot round-trips purely on docstring accuracy:
- "byte-identical" for a semantic dict compare
- "tier-3 not exercised" when the golden contained tier-3 evidence
- "every emitted field value" when only the 5 dimension fields are checked

Each round is slow (push → wait for CP → reply → resolve). This makes it a local gate.

## How it works

- `/code-review`'s **Conventions** angle already reads the repo CLAUDE.md and flags violations of its rules — so the new section is checked automatically on every review.
- `/simplify` includes a docstring-accuracy angle in its agent prompts.

The rule covers: no overclaiming scope ("every"/"all" vs a subset), no false absolutes ("byte-identical" for a deep-equal, "no network" unless guaranteed), no speculation as fact, and prefer precise over tidy.

Closes #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)