### PR TITLE
Stage 1a: field_value/field_status accessors; migrate src + tests (#118)

### DIFF
--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -48,11 +48,14 @@ def field_value(record: dict, field_name: str):
 
 
 def field_status(record: dict, field_name: str) -> str:
-    """Status of a classification field: CLASSIFIED / NOT_APPLICABLE / NOT_CLASSIFIED.
+    """Status of a classification field.
 
-    Prefers an explicit non-None ``status`` on the field entry when present (the
-    shape the migration is moving toward); otherwise derives it from the current
-    sentinel-in-``value`` convention. A missing/None value reads as NOT_CLASSIFIED.
+    Returns an explicit non-None ``status`` from the field entry verbatim when
+    present (the shape the migration is moving toward — this may be values beyond
+    the three below, e.g. ``conflict`` in later stages). Otherwise derives the
+    status from the current sentinel-in-``value`` convention, yielding one of
+    CLASSIFIED / NOT_APPLICABLE / NOT_CLASSIFIED; a missing/None value reads as
+    NOT_CLASSIFIED.
     """
     entry = _field_entry(record, field_name)
     if isinstance(entry, dict):

--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -2,7 +2,11 @@
 
 from dataclasses import dataclass, field
 
-# Classification value constants
+# Classification status constants. NOT_APPLICABLE / NOT_CLASSIFIED are today
+# smuggled into a field's `value`; the sentinel→status migration (epic #116) is
+# splitting them into a dedicated `status` field. CLASSIFIED is the status when a
+# real value was determined.
+CLASSIFIED = "classified"
 NOT_APPLICABLE = "not_applicable"
 NOT_CLASSIFIED = "not_classified"
 
@@ -12,6 +16,56 @@ NOT_CLASSIFIED = "not_classified"
 CLASSIFICATION_FIELDS = (
     "data_modality", "data_type", "platform", "reference_assembly", "assay_type",
 )
+
+
+def _field_entry(record: dict, field_name: str):
+    """Return the per-field classification entry/value from a record, or None.
+
+    Normalizes the layouts classification records appear in:
+    - per-field:  record["classifications"][field] -> {"value", ...}
+    - nested:     record[field] -> {"value", ...}
+    - flat:       record[field] -> value
+    Returns whatever is found at the field (a dict entry, a scalar, or None).
+    """
+    cls = record.get("classifications", {})
+    if isinstance(cls, dict) and field_name in cls:
+        return cls[field_name]
+    return record.get(field_name)
+
+
+def field_value(record: dict, field_name: str):
+    """Resolved value of a classification field, normalizing record layout.
+
+    Use this for *value* reads. For "is this field applicable / classified?"
+    questions use field_status — so that when the sentinel→status migration moves
+    sentinels out of `value` (epic #116), value-reads and status-checks stay
+    correctly separated and call sites do not need to change again.
+    """
+    entry = _field_entry(record, field_name)
+    if isinstance(entry, dict):
+        return entry.get("value")
+    return entry
+
+
+def field_status(record: dict, field_name: str) -> str:
+    """Status of a classification field: CLASSIFIED / NOT_APPLICABLE / NOT_CLASSIFIED.
+
+    Prefers an explicit non-None ``status`` on the field entry when present (the
+    shape the migration is moving toward); otherwise derives it from the current
+    sentinel-in-``value`` convention. A missing/None value reads as NOT_CLASSIFIED.
+    """
+    entry = _field_entry(record, field_name)
+    if isinstance(entry, dict):
+        if entry.get("status") is not None:
+            return entry["status"]
+        value = entry.get("value")
+    else:
+        value = entry
+    if value == NOT_APPLICABLE:
+        return NOT_APPLICABLE
+    if value is None or value == NOT_CLASSIFIED:
+        return NOT_CLASSIFIED
+    return CLASSIFIED
 
 
 @dataclass

--- a/src/meta_disco/validation_maps.py
+++ b/src/meta_disco/validation_maps.py
@@ -4,6 +4,8 @@ Each external source uses different naming conventions. These maps normalize
 external values to our internal classification values.
 """
 
+from .models import field_value
+
 HPRC_CATALOG_NAMES = ["sequencing-data", "alignments", "annotations", "assemblies"]
 
 HPRC_CATALOG_BASE_URL = (
@@ -52,19 +54,12 @@ _ANNOTATION_REF_PATTERNS: dict[str, str] = {
 def get_classification_value(record: dict, field: str):
     """Extract a classification value from per-field or flat record format.
 
-    Handles three layouts:
-    - Per-field: record["classifications"]["field"]["value"]
-    - Nested dict: record["field"]["value"]
-    - Flat: record["field"]
+    Thin alias for ``models.field_value`` (the canonical accessor), kept so its
+    callers (summaries.py, scripts/, tests/test_hprc_validation.py) keep working
+    until they migrate in Stage 1b (#119). Handles the per-field, nested-dict, and
+    flat layouts.
     """
-    cls = record.get("classifications", {})
-    if isinstance(cls, dict) and field in cls:
-        v = cls[field]
-        return v["value"] if isinstance(v, dict) and "value" in v else v
-    v = record.get(field)
-    if isinstance(v, dict) and "value" in v:
-        return v["value"]
-    return v
+    return field_value(record, field)
 
 
 def extract_ref_from_annotation_type(annotation_type: str) -> str | None:

--- a/tests/test_bed_classification.py
+++ b/tests/test_bed_classification.py
@@ -9,7 +9,13 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from src.meta_disco.header_classifier import classify_from_bed_signals
-from src.meta_disco.models import NOT_APPLICABLE, NOT_CLASSIFIED, FileInfo
+from src.meta_disco.models import (
+    NOT_APPLICABLE,
+    NOT_CLASSIFIED,
+    FileInfo,
+    field_status,
+    field_value,
+)
 from src.meta_disco.rule_engine import RuleEngine
 
 # Create a shared engine instance
@@ -266,9 +272,8 @@ class TestPatternEdgeCases:
 
 
 def _get_val(result: dict, field: str):
-    """Extract classification value from per-field output."""
-    v = result.get(field, {})
-    return v.get("value") if isinstance(v, dict) else v
+    """Extract a classification field's value (delegates to models.field_value)."""
+    return field_value(result, field)
 
 
 class TestBedCoordinateClassification:
@@ -304,7 +309,7 @@ class TestBedCoordinateClassification:
             "max_coordinates": {"HG01106#1#JAHAMC010000001.1": 92310948},
         }
         result = classify_from_bed_signals(signals, file_name="sample.bed")
-        assert _get_val(result, "reference_assembly") == NOT_APPLICABLE
+        assert field_status(result, "reference_assembly") == NOT_APPLICABLE
 
     def test_empty_signals_preserves_filename_classification(self):
         """Empty signals still returns rule engine classification from filename."""
@@ -314,7 +319,7 @@ class TestBedCoordinateClassification:
     def test_empty_signals_no_reference(self):
         """Empty signals should leave reference as not_classified."""
         result = classify_from_bed_signals({}, file_name="sample.bed")
-        assert _get_val(result, "reference_assembly") == NOT_CLASSIFIED
+        assert field_status(result, "reference_assembly") == NOT_CLASSIFIED
 
     def test_coordinates_exceeding_grch38_rule_it_out(self):
         """Coordinates exceeding GRCh38 chr lengths should rule out GRCh38."""
@@ -338,4 +343,4 @@ class TestBedCoordinateClassification:
             "max_coordinates": {},
         }
         result = classify_from_bed_signals(signals, file_name="sample.bed")
-        assert _get_val(result, "reference_assembly") == NOT_CLASSIFIED
+        assert field_status(result, "reference_assembly") == NOT_CLASSIFIED

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -24,19 +24,21 @@ from classify_fasta_files import classify_single_fasta as classify_fasta
 from classify_fastq_files import classify_single_fastq as classify_fastq
 from classify_vcf_files import classify_single_vcf as classify_vcf
 
-from src.meta_disco.models import NOT_APPLICABLE, NOT_CLASSIFIED, FileInfo
+from src.meta_disco.models import (
+    NOT_APPLICABLE,
+    NOT_CLASSIFIED,
+    FileInfo,
+    field_status,
+    field_value,
+)
 from src.meta_disco.rule_engine import RuleEngine
 
 engine = RuleEngine()
 
 
 def get_val(record, field):
-    """Extract classification value from per-field output."""
-    cls = record.get("classifications", record)
-    v = cls.get(field)
-    if isinstance(v, dict) and "value" in v:
-        return v["value"]
-    return v
+    """Extract a classification field's value (delegates to models.field_value)."""
+    return field_value(record, field)
 
 
 def assert_output_format(record):
@@ -83,8 +85,8 @@ class TestBamE2E:
         assert result is not None
         assert_output_format(result)
         assert get_val(result, "platform") == "PACBIO"
-        assert get_val(result, "reference_assembly") == NOT_APPLICABLE
-        assert get_val(result, "assay_type") == NOT_CLASSIFIED
+        assert field_status(result, "reference_assembly") == NOT_APPLICABLE
+        assert field_status(result, "assay_type") == NOT_CLASSIFIED
 
     def test_ont_bam(self):
         """ONT BAM file — 69.8 GB."""
@@ -160,7 +162,7 @@ class TestVcfE2E:
         assert result is not None
         assert_output_format(result)
         assert get_val(result, "data_modality") == "genomic"
-        assert get_val(result, "assay_type") == NOT_CLASSIFIED
+        assert field_status(result, "assay_type") == NOT_CLASSIFIED
 
     def test_single_chrom_reference_detection(self):
         """Single-chromosome VCF should still identify reference assembly."""
@@ -194,7 +196,7 @@ class TestVcfE2E:
                               file_size=443147740)
         cls = result["classifications"]
         ref = cls["reference_assembly"]
-        if ref["value"] not in (NOT_CLASSIFIED, None):
+        if field_status(result, "reference_assembly") != NOT_CLASSIFIED:
             stale = [e for e in ref["evidence"] if e["rule_id"] == "not_classified"]
             assert len(stale) == 0, f"Stale evidence: {stale}"
 
@@ -213,9 +215,9 @@ class TestFastqE2E:
         assert result is not None
         assert_output_format(result)
         assert get_val(result, "platform") == "ILLUMINA"
-        assert get_val(result, "data_modality") == NOT_CLASSIFIED
-        assert get_val(result, "reference_assembly") == NOT_APPLICABLE
-        assert get_val(result, "assay_type") == NOT_CLASSIFIED  # modality unknown, so no WES/WGS inference
+        assert field_status(result, "data_modality") == NOT_CLASSIFIED
+        assert field_status(result, "reference_assembly") == NOT_APPLICABLE
+        assert field_status(result, "assay_type") == NOT_CLASSIFIED  # modality unknown, so no WES/WGS inference
 
     def test_ena_reformatted_fastq(self):
         """ERR3989178_1.fastq.gz — 13.5 GB ENA-reformatted with accession."""
@@ -230,7 +232,7 @@ class TestFastqE2E:
         result = classify_fastq("000644fa14ab21a7106a746664d58aa9", "HG02486x02PE20573_1_sequence.fastq.gz",
                                 file_size=84212465)
         assert result is not None
-        assert get_val(result, "reference_assembly") == NOT_APPLICABLE
+        assert field_status(result, "reference_assembly") == NOT_APPLICABLE
 
     def test_pacbio_ccs_fastq(self):
         """PacBio CCS/HiFi FASTQ — 28.6 GB, should detect PacBio platform."""
@@ -240,8 +242,8 @@ class TestFastqE2E:
         assert result is not None
         assert_output_format(result)
         assert get_val(result, "platform") == "PACBIO"
-        assert get_val(result, "data_modality") == NOT_CLASSIFIED
-        assert get_val(result, "assay_type") == NOT_CLASSIFIED  # modality unknown, so no WGS inference
+        assert field_status(result, "data_modality") == NOT_CLASSIFIED
+        assert field_status(result, "assay_type") == NOT_CLASSIFIED  # modality unknown, so no WGS inference
 
     def test_mgi_fastq(self):
         """MGI/BGI platform FASTQ — 32.3 GB."""
@@ -250,7 +252,8 @@ class TestFastqE2E:
         assert result is not None
         assert_output_format(result)
         platform = get_val(result, "platform")
-        assert platform in ("MGI", "ILLUMINA", NOT_CLASSIFIED), f"Unexpected platform: {platform}"
+        assert platform in ("MGI", "ILLUMINA") or field_status(result, "platform") == NOT_CLASSIFIED, \
+            f"Unexpected platform: {platform}"
 
 
 # =============================================================================
@@ -413,8 +416,8 @@ class TestFastaE2E:
         assert_output_format(result)
         assert get_val(result, "data_modality") == "genomic"
         assert get_val(result, "data_type") == "assembly"
-        assert get_val(result, "reference_assembly") == NOT_APPLICABLE
-        assert get_val(result, "assay_type") == NOT_APPLICABLE
+        assert field_status(result, "reference_assembly") == NOT_APPLICABLE
+        assert field_status(result, "assay_type") == NOT_APPLICABLE
 
     def test_verkko_diploid_assembly(self):
         """HG02300_verkko_gfase_diploid.fasta.gz — verkko assembler output."""
@@ -425,7 +428,7 @@ class TestFastaE2E:
         assert_output_format(result)
         assert get_val(result, "data_modality") == "genomic"
         assert get_val(result, "data_type") == "assembly"
-        assert get_val(result, "reference_assembly") == NOT_APPLICABLE
+        assert field_status(result, "reference_assembly") == NOT_APPLICABLE
 
     def test_hapdup_contigs(self):
         """hapdup_contigs_2.fasta — hapdup output, contig name is just "0".
@@ -438,7 +441,7 @@ class TestFastaE2E:
         assert_output_format(result)
         assert get_val(result, "data_modality") == "genomic"
         assert get_val(result, "data_type") == "assembly"
-        assert get_val(result, "reference_assembly") == NOT_APPLICABLE
+        assert field_status(result, "reference_assembly") == NOT_APPLICABLE
 
     def test_grch38_reference_genome(self):
         """grch38.XX.fasta — 3.2 GB GRCh38 reference genome."""
@@ -450,7 +453,7 @@ class TestFastaE2E:
         assert get_val(result, "data_modality") == "genomic"
         assert get_val(result, "data_type") == "reference_genome"
         assert get_val(result, "reference_assembly") == "GRCh38"
-        assert get_val(result, "assay_type") == NOT_APPLICABLE
+        assert field_status(result, "assay_type") == NOT_APPLICABLE
 
     def test_chm13_reference_genome(self):
         """chm13v2.0.fasta — 3.2 GB CHM13 T2T reference."""
@@ -462,7 +465,7 @@ class TestFastaE2E:
         assert get_val(result, "data_modality") == "genomic"
         assert get_val(result, "data_type") == "reference_genome"
         assert get_val(result, "reference_assembly") == "CHM13"
-        assert get_val(result, "assay_type") == NOT_APPLICABLE
+        assert field_status(result, "assay_type") == NOT_APPLICABLE
 
     def test_hifiasm_mito_contigs(self):
         """HG002.hifiasm_0.19.0_trio.diploid.mito.fa.gz — 26 KB, 7 mitochondrial contigs."""
@@ -473,7 +476,7 @@ class TestFastaE2E:
         assert_output_format(result)
         assert get_val(result, "data_modality") == "genomic"
         assert get_val(result, "data_type") == "assembly"
-        assert get_val(result, "reference_assembly") == NOT_APPLICABLE
+        assert field_status(result, "reference_assembly") == NOT_APPLICABLE
 
     def test_verkko_mito_contigs(self):
         """HG002_verkko_gfase_mito.fasta.gz — 38 KB, 12 verkko contigs."""
@@ -484,7 +487,7 @@ class TestFastaE2E:
         assert_output_format(result)
         assert get_val(result, "data_modality") == "genomic"
         assert get_val(result, "data_type") == "assembly"
-        assert get_val(result, "reference_assembly") == NOT_APPLICABLE
+        assert field_status(result, "reference_assembly") == NOT_APPLICABLE
 
     def test_verkko_mito_single_contig(self):
         """HG02809_verkko_asm_mito_exemplar.fasta.gz — 3.5 KB single contig."""
@@ -495,7 +498,7 @@ class TestFastaE2E:
         assert_output_format(result)
         assert get_val(result, "data_modality") == "genomic"
         assert get_val(result, "data_type") == "assembly"
-        assert get_val(result, "reference_assembly") == NOT_APPLICABLE
+        assert field_status(result, "reference_assembly") == NOT_APPLICABLE
 
     def test_empty_gzip_fasta(self):
         """HG02647.hifiasm_0.19.3_hic.diploid.mito.fa.gz — valid gzip, 20 bytes."""
@@ -506,7 +509,7 @@ class TestFastaE2E:
         assert_output_format(result)
         assert get_val(result, "data_modality") == "genomic"
         assert get_val(result, "data_type") == "assembly"
-        assert get_val(result, "reference_assembly") == NOT_APPLICABLE
+        assert field_status(result, "reference_assembly") == NOT_APPLICABLE
 
     def test_genbank_single_region(self):
         """hg002-f1-assembly-v2-genbank-dip-s2c20h1l-mat.fa — 2.3 MB single GenBank region."""

--- a/tests/test_header_classifier.py
+++ b/tests/test_header_classifier.py
@@ -2,29 +2,24 @@
 
 import pytest
 
-from src.meta_disco.models import NOT_APPLICABLE, NOT_CLASSIFIED
+from src.meta_disco.models import NOT_APPLICABLE, NOT_CLASSIFIED, field_status, field_value
 
 
 def val(result: dict, field: str):
-    """Extract a classification value from the per-field output format.
+    """Extract a classification value (or a derived test aggregate) from output.
 
-    Handles both old flat format (result["field"]) and new per-field format
-    (result["field"]["value"]).
-
-    For "confidence", returns the max confidence across all fields.
+    Field values delegate to models.field_value. Two test-only pseudo-fields are
+    derived from the per-field structure:
+    - "confidence": max confidence across all fields
+    - "matched_rules": flattened, de-duplicated rule_ids from all evidence
     """
-    v = result.get(field)
-    if isinstance(v, dict) and "value" in v:
-        return v["value"]
-    if field == "confidence" and v is None:
-        # Compute overall confidence as max across per-field confidences
+    if field == "confidence" and result.get(field) is None:
         max_conf = 0.0
-        for fld_name, fld_val in result.items():
+        for fld_val in result.values():
             if isinstance(fld_val, dict) and "confidence" in fld_val:
                 max_conf = max(max_conf, fld_val["confidence"])
         return max_conf
-    if field == "matched_rules" and v is None:
-        # Flatten matched rules from per-field evidence
+    if field == "matched_rules" and result.get(field) is None:
         rules = []
         for fld_val in result.values():
             if isinstance(fld_val, dict) and "evidence" in fld_val:
@@ -32,7 +27,7 @@ def val(result: dict, field: str):
                     if e.get("rule_id") not in rules:
                         rules.append(e["rule_id"])
         return rules
-    return v
+    return field_value(result, field)
 from src.meta_disco.header_classifier import (
     # Classification functions
     classify_from_fastq_header,
@@ -321,7 +316,7 @@ class TestFastqClassification:
         ]
         result = classify_from_fastq_header(reads)
         assert val(result, "platform") == "ILLUMINA"
-        assert val(result, "data_modality") == NOT_CLASSIFIED
+        assert field_status(result, "data_modality") == NOT_CLASSIFIED
         assert val(result, "data_type") == "reads"
         assert val(result, "confidence") >= 0.90
 
@@ -369,7 +364,7 @@ class TestFastqClassification:
         ]
         result = classify_from_fastq_header(reads)
         assert val(result, "platform") == "ILLUMINA"
-        assert val(result, "data_modality") == NOT_CLASSIFIED
+        assert field_status(result, "data_modality") == NOT_CLASSIFIED
         assert result["archive_accession"] == "ERR1395578"
         assert val(result, "confidence") >= 0.85
 
@@ -380,7 +375,7 @@ class TestFastqClassification:
         ]
         result = classify_from_fastq_header(reads)
         assert val(result, "platform") == "ILLUMINA"
-        assert val(result, "data_modality") == NOT_CLASSIFIED
+        assert field_status(result, "data_modality") == NOT_CLASSIFIED
         assert val(result, "confidence") >= 0.85
 
     def test_pacbio_ccs(self):
@@ -392,7 +387,7 @@ class TestFastqClassification:
         ]
         result = classify_from_fastq_header(reads)
         assert val(result, "platform") == "PACBIO"
-        assert val(result, "data_modality") == NOT_CLASSIFIED
+        assert field_status(result, "data_modality") == NOT_CLASSIFIED
         assert val(result, "data_type") == "reads"
         assert val(result, "confidence") >= 0.95
 
@@ -404,7 +399,7 @@ class TestFastqClassification:
         ]
         result = classify_from_fastq_header(reads)
         assert val(result, "platform") == "PACBIO"
-        assert val(result, "data_modality") == NOT_CLASSIFIED
+        assert field_status(result, "data_modality") == NOT_CLASSIFIED
 
     def test_pacbio_generic(self):
         """Classify generic PacBio FASTQ (movie/zmw without CCS or CLR suffix)."""
@@ -414,7 +409,7 @@ class TestFastqClassification:
         ]
         result = classify_from_fastq_header(reads)
         assert val(result, "platform") == "PACBIO"
-        assert val(result, "data_modality") == NOT_CLASSIFIED
+        assert field_status(result, "data_modality") == NOT_CLASSIFIED
         assert val(result, "data_type") == "reads"
 
     def test_ont_uuid(self):
@@ -425,7 +420,7 @@ class TestFastqClassification:
         ]
         result = classify_from_fastq_header(reads)
         assert val(result, "platform") == "ONT"
-        assert val(result, "data_modality") == NOT_CLASSIFIED
+        assert field_status(result, "data_modality") == NOT_CLASSIFIED
 
     def test_ont_runid(self):
         """Classify ONT FASTQ by runid metadata only."""
@@ -435,7 +430,7 @@ class TestFastqClassification:
         ]
         result = classify_from_fastq_header(reads)
         assert val(result, "platform") == "ONT"
-        assert val(result, "data_modality") == NOT_CLASSIFIED
+        assert field_status(result, "data_modality") == NOT_CLASSIFIED
 
     def test_mgi(self):
         """Classify MGI/BGI FASTQ."""
@@ -641,8 +636,8 @@ class TestBamCramClassification:
 @RG\tID:sample1\tPL:PACBIO\tDS:READTYPE=CCS"""
         result = classify_from_header(header)
         assert val(result, "platform") == "PACBIO"
-        assert val(result, "data_modality") == NOT_CLASSIFIED
-        assert val(result, "assay_type") == NOT_CLASSIFIED
+        assert field_status(result, "data_modality") == NOT_CLASSIFIED
+        assert field_status(result, "assay_type") == NOT_CLASSIFIED
 
     def test_ont_basecall_dna_modality(self):
         """ONT basecall_model=dna_* implies genomic modality."""
@@ -684,7 +679,7 @@ class TestBamCramClassification:
         result = classify_from_header(header)
         assert val(result, "platform") == "ONT"
         # basecall_model=rna_ (transcriptomic) vs minimap2 (genomic) = conflict
-        assert val(result, "data_modality") == NOT_CLASSIFIED
+        assert field_status(result, "data_modality") == NOT_CLASSIFIED
 
     def test_assay_type_rnaseq(self):
         """Detect RNA-seq assay_type from STAR aligner."""
@@ -715,12 +710,12 @@ class TestBamCramClassification:
 @RG\tID:sample1\tPL:ILLUMINA
 @PG\tID:ccs\tPN:ccs\tVN:6.4.0"""
         result = classify_from_header(header)
-        assert val(result, "platform") == NOT_CLASSIFIED
+        assert field_status(result, "platform") == NOT_CLASSIFIED
 
     def test_empty_header(self):
         """Handle empty header — treated as unaligned."""
         result = classify_from_header("")
-        assert val(result, "reference_assembly") == NOT_APPLICABLE
+        assert field_status(result, "reference_assembly") == NOT_APPLICABLE
 
 
 # =============================================================================
@@ -809,7 +804,8 @@ class TestContigLengthDetection:
         result = classify_from_vcf_header(header)
         # Currently assembly= in contig is matched by vcf_contig_assembly rules
         # The ##reference line is the primary detection path
-        assert val(result, "reference_assembly") in ("GRCh38", NOT_CLASSIFIED)
+        assert (val(result, "reference_assembly") == "GRCh38"
+                or field_status(result, "reference_assembly") == NOT_CLASSIFIED)
 
     def test_vcf_reference_field(self):
         """VCF reference detection from ##reference= line."""
@@ -827,7 +823,7 @@ class TestEdgeCases:
         """Handle malformed FASTQ read names."""
         reads = ["not_a_valid_read", "another_invalid", ""]
         result = classify_from_fastq_header(reads)
-        assert val(result, "platform") == NOT_CLASSIFIED
+        assert field_status(result, "platform") == NOT_CLASSIFIED
 
     def test_vcf_minimal(self):
         """Handle minimal VCF with just column header."""

--- a/tests/test_header_classifier.py
+++ b/tests/test_header_classifier.py
@@ -28,6 +28,8 @@ def val(result: dict, field: str):
                         rules.append(e["rule_id"])
         return rules
     return field_value(result, field)
+
+
 from src.meta_disco.header_classifier import (
     # Classification functions
     classify_from_fastq_header,

--- a/tests/test_index_propagation.py
+++ b/tests/test_index_propagation.py
@@ -10,6 +10,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from classify_index_files import INDEX_TO_PARENT, get_parent_candidates, load_classifications, propagate_to_index_files
 
+from src.meta_disco.models import NOT_CLASSIFIED, field_status, field_value
+
 
 class TestParentCandidateGeneration:
     """Test parent filename candidate generation."""
@@ -238,9 +240,9 @@ class TestLoadClassifications:
         assert csi["file_name"] == "HG03652.regions.bed.gz.csi"
         assert csi["parent_file"] == "HG03652.regions.bed.gz"
         cls = csi["classifications"]
-        assert cls["data_modality"]["value"] == "genomic"
-        assert cls["data_type"]["value"] == "annotations"
-        assert cls["reference_assembly"]["value"] == "CHM13"
+        assert field_value(cls, "data_modality") == "genomic"
+        assert field_value(cls, "data_type") == "annotations"
+        assert field_value(cls, "reference_assembly") == "CHM13"
         assert cls["data_modality"]["evidence"][0]["rule_id"] == "inherited_from_parent"
 
     def test_tbi_inherits_from_vcf_parent(self, tmp_path):
@@ -271,9 +273,9 @@ class TestLoadClassifications:
             output = json.load(f)
         assert len(output["classifications"]) == 1
         cls = output["classifications"][0]["classifications"]
-        assert cls["data_modality"]["value"] == "genomic"
-        assert cls["data_type"]["value"] == "variants.germline"
-        assert cls["reference_assembly"]["value"] == "GRCh38"
+        assert field_value(cls, "data_modality") == "genomic"
+        assert field_value(cls, "data_type") == "variants.germline"
+        assert field_value(cls, "reference_assembly") == "GRCh38"
 
     def test_bai_inherits_from_bam_parent(self, tmp_path):
         """End-to-end: a .bai index inherits from its .bam parent."""
@@ -303,9 +305,9 @@ class TestLoadClassifications:
             output = json.load(f)
         assert len(output["classifications"]) == 1
         cls = output["classifications"][0]["classifications"]
-        assert cls["data_modality"]["value"] == "transcriptomic.bulk"
-        assert cls["platform"]["value"] == "ILLUMINA"
-        assert cls["assay_type"]["value"] == "RNA-seq"
+        assert field_value(cls, "data_modality") == "transcriptomic.bulk"
+        assert field_value(cls, "platform") == "ILLUMINA"
+        assert field_value(cls, "assay_type") == "RNA-seq"
 
     def test_no_matching_parent_goes_to_unmatched(self, tmp_path):
         """Index file with no parent in metadata goes to unmatched_files, not classifications."""
@@ -349,5 +351,5 @@ class TestLoadClassifications:
         assert len(output["classifications"]) == 1
         cls = output["classifications"][0]["classifications"]
         for fld in ["data_modality", "data_type", "platform", "reference_assembly", "assay_type"]:
-            assert cls[fld]["value"] == "not_classified", f"{fld} should be not_classified"
+            assert field_status(cls, fld) == NOT_CLASSIFIED, f"{fld} should be not_classified"
         assert cls["data_modality"]["evidence"][0]["reason"].startswith("Parent file")


### PR DESCRIPTION
## Summary

**Stage 1a** of the sentinel→status migration (epic #116). Centralizes every
output-dict field-value read and sentinel comparison behind two accessors, so the
later format change (sentinels move from `value` into a dedicated `status` field,
Stages 2–3) does **not** ripple through consumers.

**Pure refactor — output unchanged.** The #117 golden (`test_output_matches_golden`)
proves it byte-for-byte; 380 tests pass.

## What changed

- **`src/meta_disco/models.py`** — new `field_value(record, field)`,
  `field_status(record, field)`, `_field_entry` normalizer, and `CLASSIFIED`
  constant. `field_status` prefers an explicit `status` key when present
  (forward-compat for Stage 2 — inert today since no producer writes it) and
  otherwise derives status from the current sentinel-in-`value` convention.
- **`src/meta_disco/validation_maps.py`** — `get_classification_value` now
  delegates to `field_value`, kept as an alias so `summaries.py`, `scripts/`, and
  `tests/test_hprc_validation.py` keep working until they migrate in **Stage 1b
  (#119)**.
- **tests** (`test_evals`, `test_header_classifier`, `test_bed_classification`,
  `test_index_propagation`) — value-read helpers delegate to `field_value`;
  sentinel comparisons (`== NOT_APPLICABLE/NOT_CLASSIFIED`, membership,
  `not in (NC, None)`) converted to `field_status` so they stay correct once
  sentinels leave `value` in Stage 3.

## Out of scope (later stages)

- `rule_engine.py` in-memory claim reads — a different shape (claim lists), not
  output records.
- `scripts/` value-read copies — **Stage 1b (#119)** (precise inventory recorded
  on that issue).
- Producers (`header_classifier.py` sentinel writes, `to_output_dict`).

## Review notes (`/simplify` + `/code-review high`, both run)

The conversions are exactly equivalent on today's data (sentinels still live in
`value`). Two deliberate, currently-unreachable semantic choices, recorded for
transparency:

- **`field_value` returns `None` for a dict entry lacking a `"value"` key**
  (the old `get_classification_value` returned the dict). Unreachable — every
  dimension entry carries `value`; aux fields are scalars. Intentional cleanup of
  a quirk, not a regression.
- **`field_status == NOT_CLASSIFIED` also matches `None`**, slightly widening the
  converted asserts. This is the correct target-state semantics (post-Stage-3 a
  not_classified field has `value=None`). Field-*drop* regressions remain covered
  by the #117 golden + structural-contract tests.

Closes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
