### PR TITLE
Stage 1b: migrate scripts + summaries to accessors; add field_label (#119)

### DIFF
--- a/scripts/classify_auxiliary_genomic.py
+++ b/scripts/classify_auxiliary_genomic.py
@@ -14,7 +14,7 @@ from pathlib import Path
 # Add project root to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.meta_disco.models import NOT_APPLICABLE, NOT_CLASSIFIED, FileInfo, field_value
+from src.meta_disco.models import NOT_APPLICABLE, NOT_CLASSIFIED, FileInfo, field_label
 from src.meta_disco.rule_engine import RuleEngine
 
 _SENTINEL_VALUES = {NOT_CLASSIFIED, NOT_APPLICABLE}
@@ -101,7 +101,7 @@ def classify_auxiliary_genomic(metadata_path: Path, output_path: Path):
     # Count by modality
     modalities = {}
     for r in results:
-        mod = field_value(r, "data_modality") or "N/A"
+        mod = field_label(r, "data_modality")
         modalities[mod] = modalities.get(mod, 0) + 1
 
     print("\nBy modality:")
@@ -111,7 +111,7 @@ def classify_auxiliary_genomic(metadata_path: Path, output_path: Path):
     # Count by reference
     refs = {}
     for r in results:
-        ref = field_value(r, "reference_assembly") or "N/A"
+        ref = field_label(r, "reference_assembly")
         refs[ref] = refs.get(ref, 0) + 1
 
     print("\nBy reference_assembly:")

--- a/scripts/classify_auxiliary_genomic.py
+++ b/scripts/classify_auxiliary_genomic.py
@@ -14,7 +14,7 @@ from pathlib import Path
 # Add project root to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.meta_disco.models import NOT_APPLICABLE, NOT_CLASSIFIED, FileInfo
+from src.meta_disco.models import NOT_APPLICABLE, NOT_CLASSIFIED, FileInfo, field_value
 from src.meta_disco.rule_engine import RuleEngine
 
 _SENTINEL_VALUES = {NOT_CLASSIFIED, NOT_APPLICABLE}
@@ -100,15 +100,8 @@ def classify_auxiliary_genomic(metadata_path: Path, output_path: Path):
 
     # Count by modality
     modalities = {}
-    def _val(rec, field):
-        cls = rec.get("classifications", {})
-        if isinstance(cls, dict) and field in cls:
-            v = cls[field]
-            return v["value"] if isinstance(v, dict) and "value" in v else v
-        return rec.get(field)
-
     for r in results:
-        mod = _val(r, "data_modality") or "N/A"
+        mod = field_value(r, "data_modality") or "N/A"
         modalities[mod] = modalities.get(mod, 0) + 1
 
     print("\nBy modality:")
@@ -118,7 +111,7 @@ def classify_auxiliary_genomic(metadata_path: Path, output_path: Path):
     # Count by reference
     refs = {}
     for r in results:
-        ref = _val(r, "reference_assembly") or "N/A"
+        ref = field_value(r, "reference_assembly") or "N/A"
         refs[ref] = refs.get(ref, 0) + 1
 
     print("\nBy reference_assembly:")

--- a/scripts/classify_bed_files.py
+++ b/scripts/classify_bed_files.py
@@ -136,7 +136,7 @@ def classify_bed_files(metadata_path: Path, output_path: Path):
 
     print("\nBy modality:")
     for mod, count in sorted(stats["by_modality"].items(), key=lambda x: -x[1]):
-        print(f"  {mod or 'N/A'}: {count:,}")
+        print(f"  {mod}: {count:,}")
 
     print("\nBy reference:")
     for ref, count in sorted(stats["by_reference"].items(), key=lambda x: -x[1]):

--- a/scripts/classify_bed_files.py
+++ b/scripts/classify_bed_files.py
@@ -20,9 +20,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from src.meta_disco.header_classifier import classify_from_bed_signals
-from src.meta_disco.models import NOT_APPLICABLE, NOT_CLASSIFIED
-
-_SENTINEL_VALUES = {NOT_CLASSIFIED, NOT_APPLICABLE}
+from src.meta_disco.models import CLASSIFIED, field_label, field_status
 
 EVIDENCE_DIR = Path("data/evidence/anvil/bed")
 
@@ -104,16 +102,16 @@ def classify_bed_files(metadata_path: Path, output_path: Path):
         )
 
         # Update stats
-        data_modality = classifications.get("data_modality", {}).get("value")
-        reference_assembly = classifications.get("reference_assembly", {}).get("value")
+        modality_label = field_label(classifications, "data_modality")
+        reference_label = field_label(classifications, "reference_assembly")
 
-        if data_modality and data_modality not in _SENTINEL_VALUES:
+        if field_status(classifications, "data_modality") == CLASSIFIED:
             stats["with_modality"] += 1
-        stats["by_modality"][data_modality or "N/A"] = stats["by_modality"].get(data_modality or "N/A", 0) + 1
+        stats["by_modality"][modality_label] = stats["by_modality"].get(modality_label, 0) + 1
 
-        if reference_assembly and reference_assembly not in _SENTINEL_VALUES:
+        if field_status(classifications, "reference_assembly") == CLASSIFIED:
             stats["with_reference"] += 1
-        stats["by_reference"][reference_assembly or "N/A"] = stats["by_reference"].get(reference_assembly or "N/A", 0) + 1
+        stats["by_reference"][reference_label] = stats["by_reference"].get(reference_label, 0) + 1
 
         results.append({
             "file_name": name,

--- a/scripts/classify_images.py
+++ b/scripts/classify_images.py
@@ -14,7 +14,7 @@ from pathlib import Path
 # Add project root to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.meta_disco.models import FileInfo, field_value
+from src.meta_disco.models import FileInfo, field_label
 from src.meta_disco.rule_engine import RuleEngine
 
 
@@ -84,7 +84,7 @@ def classify_images(metadata_path: Path, output_path: Path):
     # Count by modality
     modalities = {}
     for r in results:
-        mod = field_value(r, "data_modality") or "N/A"
+        mod = field_label(r, "data_modality")
         modalities[mod] = modalities.get(mod, 0) + 1
 
     print("\nBy modality:")

--- a/scripts/classify_images.py
+++ b/scripts/classify_images.py
@@ -14,7 +14,7 @@ from pathlib import Path
 # Add project root to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.meta_disco.models import FileInfo
+from src.meta_disco.models import FileInfo, field_value
 from src.meta_disco.rule_engine import RuleEngine
 
 
@@ -81,17 +81,10 @@ def classify_images(metadata_path: Path, output_path: Path):
     print(f"Total images: {total_all:,}")
     print("=" * 70)
 
-    def _val(rec, field):
-        cls = rec.get("classifications", {})
-        if isinstance(cls, dict) and field in cls:
-            v = cls[field]
-            return v["value"] if isinstance(v, dict) and "value" in v else v
-        return rec.get(field)
-
     # Count by modality
     modalities = {}
     for r in results:
-        mod = _val(r, "data_modality") or "N/A"
+        mod = field_value(r, "data_modality") or "N/A"
         modalities[mod] = modalities.get(mod, 0) + 1
 
     print("\nBy modality:")

--- a/scripts/classify_index_files.py
+++ b/scripts/classify_index_files.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from src.meta_disco.models import field_value
+from src.meta_disco.models import field_label
 
 
 def _get_max_confidence(record: dict) -> float:
@@ -84,11 +84,11 @@ def load_classifications(*paths: Path) -> dict[str, dict]:
             md5 = c.get("md5sum")
             if md5:
                 classifications[md5] = {
-                    "data_modality": field_value(c, "data_modality"),
-                    "data_type": field_value(c, "data_type"),
-                    "assay_type": field_value(c, "assay_type"),
-                    "platform": field_value(c, "platform"),
-                    "reference_assembly": field_value(c, "reference_assembly"),
+                    "data_modality": field_label(c, "data_modality"),
+                    "data_type": field_label(c, "data_type"),
+                    "assay_type": field_label(c, "assay_type"),
+                    "platform": field_label(c, "platform"),
+                    "reference_assembly": field_label(c, "reference_assembly"),
                     "confidence": _get_max_confidence(c),
                     "source_file": c.get("file_name"),
                 }

--- a/scripts/classify_index_files.py
+++ b/scripts/classify_index_files.py
@@ -7,23 +7,12 @@ reference_assembly from their parent files (.bam, .vcf.gz, .cram).
 
 import argparse
 import json
+import sys
 from collections import defaultdict
 from pathlib import Path
 
-
-def _get_field(record: dict, field: str):
-    """Extract a classification field from either per-field or flat format."""
-    # Per-field format: {"classifications": {"field": {"value": ...}}}
-    cls = record.get("classifications", {})
-    if isinstance(cls, dict) and field in cls:
-        entry = cls[field]
-        if isinstance(entry, dict) and "value" in entry:
-            return entry["value"]
-    # Flat format: {"field": value}
-    v = record.get(field)
-    if isinstance(v, dict) and "value" in v:
-        return v["value"]
-    return v
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from src.meta_disco.models import field_value
 
 
 def _get_max_confidence(record: dict) -> float:
@@ -95,11 +84,11 @@ def load_classifications(*paths: Path) -> dict[str, dict]:
             md5 = c.get("md5sum")
             if md5:
                 classifications[md5] = {
-                    "data_modality": _get_field(c, "data_modality"),
-                    "data_type": _get_field(c, "data_type"),
-                    "assay_type": _get_field(c, "assay_type"),
-                    "platform": _get_field(c, "platform"),
-                    "reference_assembly": _get_field(c, "reference_assembly"),
+                    "data_modality": field_value(c, "data_modality"),
+                    "data_type": field_value(c, "data_type"),
+                    "assay_type": field_value(c, "assay_type"),
+                    "platform": field_value(c, "platform"),
+                    "reference_assembly": field_value(c, "reference_assembly"),
                     "confidence": _get_max_confidence(c),
                     "source_file": c.get("file_name"),
                 }

--- a/scripts/fetch_bed_headers.py
+++ b/scripts/fetch_bed_headers.py
@@ -26,6 +26,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 import requests
 
 from src.meta_disco.header_classifier import classify_from_bed_signals
+from src.meta_disco.models import field_label
 
 S3_MIRROR_URL = "https://anvilproject.s3.amazonaws.com/file"
 EVIDENCE_DIR = Path("data/evidence/anvil/bed")
@@ -363,10 +364,7 @@ def print_summary(classifications: list[dict]):
 
     refs = defaultdict(int)
     for c in classifications:
-        cls = c.get("classifications", {})
-        ref_entry = cls.get("reference_assembly", {})
-        ref = ref_entry.get("value") if isinstance(ref_entry, dict) else "not_classified"
-        refs[ref or "not_classified"] += 1
+        refs[field_label(c, "reference_assembly")] += 1
 
     print(f"\nTotal: {len(classifications)}")
     print("\nReference assemblies:")

--- a/scripts/generate_classification_report.py
+++ b/scripts/generate_classification_report.py
@@ -2,24 +2,15 @@
 """Generate classification coverage report with charts."""
 
 import json
+import sys
 from collections import Counter
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
 
-
-def _val(rec, field):
-    """Extract value from per-field or flat format."""
-    cls = rec.get("classifications", {})
-    if isinstance(cls, dict) and field in cls:
-        v = cls[field]
-        return v["value"] if isinstance(v, dict) and "value" in v else v
-    v = rec.get(field)
-    if isinstance(v, dict) and "value" in v:
-        return v["value"]
-    return v
-
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from src.meta_disco.models import field_label as _val
 
 # =============================================================================
 # FILE FORMAT CATEGORY RULES

--- a/scripts/generate_classification_report.py
+++ b/scripts/generate_classification_report.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from src.meta_disco.models import CLASSIFIED, field_label, field_status
+from src.meta_disco.models import field_label
 from src.meta_disco.models import field_value as _val
 
 # =============================================================================
@@ -371,11 +371,16 @@ def generate_report(source_path: Path, output_dir: Path, report_path: Path):
 
     print("\n--- Coverage by Axis ---")
 
-    with_modality = sum(1 for item in all_classified if field_status(item, "data_modality") == CLASSIFIED)
-    with_ref = sum(1 for item in all_classified if field_status(item, "reference_assembly") == CLASSIFIED)
-    with_platform = sum(1 for item in all_classified if field_status(item, "platform") == CLASSIFIED)
-    with_dtype = sum(1 for item in all_classified if field_status(item, "data_type") == CLASSIFIED or item.get("_source") in ["BAM/CRAM", "VCF", "FASTQ"])
-    with_assay = sum(1 for item in all_classified if field_status(item, "assay_type") == CLASSIFIED)
+    # These "is classified" counts stay on field_value (via _val) to keep Stage 1b a
+    # pure refactor: today a sentinel value is truthy (counted, as before); once
+    # Stage 3 moves sentinels out of `value`, field_value returns None and the count
+    # self-corrects with no code change. (The old truthy-count over-reports coverage
+    # for not_applicable/not_classified fields — tracked as a follow-up, not fixed here.)
+    with_modality = sum(1 for item in all_classified if _val(item, "data_modality"))
+    with_ref = sum(1 for item in all_classified if _val(item, "reference_assembly"))
+    with_platform = sum(1 for item in all_classified if _val(item, "platform"))
+    with_dtype = sum(1 for item in all_classified if _val(item, "data_type") or item.get("_source") in ["BAM/CRAM", "VCF", "FASTQ"])
+    with_assay = sum(1 for item in all_classified if _val(item, "assay_type"))
 
     print(f"data_modality:      {with_modality:,} / {total_classified:,} ({with_modality/total_classified*100:.1f}%)")
     print(f"reference_assembly: {with_ref:,} / {total_classified:,} ({with_ref/total_classified*100:.1f}%)")

--- a/scripts/generate_classification_report.py
+++ b/scripts/generate_classification_report.py
@@ -10,7 +10,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from src.meta_disco.models import field_label as _val
+from src.meta_disco.models import CLASSIFIED, field_label, field_status
+from src.meta_disco.models import field_value as _val
 
 # =============================================================================
 # FILE FORMAT CATEGORY RULES
@@ -202,7 +203,7 @@ def generate_report(source_path: Path, output_dir: Path, report_path: Path):
 
     modality_counts = Counter()
     for item in all_classified:
-        mod = _val(item, "data_modality") or "N/A"
+        mod = field_label(item, "data_modality")
         modality_counts[mod] += 1
 
     # Sort by count
@@ -227,7 +228,7 @@ def generate_report(source_path: Path, output_dir: Path, report_path: Path):
 
     ref_counts = Counter()
     for item in all_classified:
-        ref = _val(item, "reference_assembly") or "N/A"
+        ref = field_label(item, "reference_assembly")
         ref_counts[ref] += 1
 
     ref_sorted = sorted(ref_counts.items(), key=lambda x: x[1], reverse=True)
@@ -250,7 +251,7 @@ def generate_report(source_path: Path, output_dir: Path, report_path: Path):
 
     platform_counts = Counter()
     for item in all_classified:
-        plat = _val(item, "platform") or "N/A"
+        plat = field_label(item, "platform")
         platform_counts[plat] += 1
 
     plat_sorted = sorted(platform_counts.items(), key=lambda x: x[1], reverse=True)
@@ -370,11 +371,11 @@ def generate_report(source_path: Path, output_dir: Path, report_path: Path):
 
     print("\n--- Coverage by Axis ---")
 
-    with_modality = sum(1 for item in all_classified if _val(item, "data_modality"))
-    with_ref = sum(1 for item in all_classified if _val(item, "reference_assembly"))
-    with_platform = sum(1 for item in all_classified if _val(item, "platform"))
-    with_dtype = sum(1 for item in all_classified if _val(item, "data_type") or item.get("_source") in ["BAM/CRAM", "VCF", "FASTQ"])
-    with_assay = sum(1 for item in all_classified if _val(item, "assay_type"))
+    with_modality = sum(1 for item in all_classified if field_status(item, "data_modality") == CLASSIFIED)
+    with_ref = sum(1 for item in all_classified if field_status(item, "reference_assembly") == CLASSIFIED)
+    with_platform = sum(1 for item in all_classified if field_status(item, "platform") == CLASSIFIED)
+    with_dtype = sum(1 for item in all_classified if field_status(item, "data_type") == CLASSIFIED or item.get("_source") in ["BAM/CRAM", "VCF", "FASTQ"])
+    with_assay = sum(1 for item in all_classified if field_status(item, "assay_type") == CLASSIFIED)
 
     print(f"data_modality:      {with_modality:,} / {total_classified:,} ({with_modality/total_classified*100:.1f}%)")
     print(f"reference_assembly: {with_ref:,} / {total_classified:,} ({with_ref/total_classified*100:.1f}%)")

--- a/scripts/generate_coverage_report.py
+++ b/scripts/generate_coverage_report.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from src.meta_disco.models import field_label
 from src.meta_disco.output_utils import CLASSIFICATION_FILES, find_latest_run
 from src.meta_disco.rule_loader import UnifiedRules
 
@@ -67,15 +68,13 @@ def load_records(run_dir: Path) -> list[dict]:
             cls = r.get("classifications", r)
             rec = {"file_name": r.get("file_name", "")}
             for field in ["data_modality", "data_type", "platform", "reference_assembly", "assay_type"]:
+                rec[field] = field_label(r, field)
+                # Store the first evidence reason (used for not_classified aggregation)
                 v = cls.get(field)
-                if isinstance(v, dict) and "value" in v:
-                    rec[field] = v["value"]
-                    # Store the first evidence reason (used for not_classified aggregation)
+                if isinstance(v, dict):
                     evidence = v.get("evidence", [])
                     if evidence:
                         rec[f"{field}_reason"] = evidence[0].get("reason", "")
-                else:
-                    rec[field] = v
             rec["ext"] = get_extension(rec["file_name"])
             records.append(rec)
     return records

--- a/scripts/generate_validation_report.py
+++ b/scripts/generate_validation_report.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from src.meta_disco.models import field_label
 from src.meta_disco.output_utils import CLASSIFICATION_FILES, find_latest_run
 
 DIMENSIONS = ["data_modality", "data_type", "platform", "reference_assembly", "assay_type"]
@@ -69,14 +70,9 @@ def load_our_classifications(run_dir: Path) -> tuple[dict, dict]:
         with open(path) as f:
             data = json.load(f)
         for r in data.get("classifications", data.get("results", [])):
-            cls = r.get("classifications", r)
             rec = {}
             for field in DIMENSIONS:
-                v = cls.get(field)
-                if isinstance(v, dict) and "value" in v:
-                    rec[field] = v["value"]
-                else:
-                    rec[field] = v
+                rec[field] = field_label(r, field)
             md5 = r.get("md5sum") or r.get("file_md5sum")
             file_name = r.get("file_name", "")
             if md5:

--- a/scripts/validate_against_hprc.py
+++ b/scripts/validate_against_hprc.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import requests
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
+from src.meta_disco.models import field_label, field_value
 from src.meta_disco.output_utils import find_latest_run
 from src.meta_disco.validation_maps import (
     HPRC_CATALOG_BASE_URL,
@@ -33,7 +34,6 @@ from src.meta_disco.validation_maps import (
     HPRC_PLATFORM_MAP,
     HPRC_REF_COORDINATES_MAP,
     extract_ref_from_annotation_type,
-    get_classification_value,
 )
 
 
@@ -214,21 +214,21 @@ def validate_against_hprc(
             catalog_stats["sequencing-data"]["matched"] += 1
             meta = seq_lookup[filename]
 
-            our_platform = get_classification_value(c, "platform") or ""
+            our_platform = field_label(c, "platform") or ""
             m = validate_dimension(our_platform, meta["platform"], counters, "platform")
             if m:
                 m["hprc_instrument"] = meta.get("instrument_model")
-                m["our_instrument"] = get_classification_value(c, "instrument_model")
+                m["our_instrument"] = field_value(c, "instrument_model")
                 file_mismatches["platform"] = m
 
-            our_modality = get_classification_value(c, "data_modality") or ""
+            our_modality = field_label(c, "data_modality") or ""
             m = validate_dimension(
                 our_modality, meta["data_modality"], counters, "data_modality"
             )
             if m:
                 file_mismatches["data_modality"] = m
 
-            our_assay = get_classification_value(c, "assay_type") or ""
+            our_assay = field_label(c, "assay_type") or ""
             m = validate_dimension(
                 our_assay, meta["assay_type"], counters, "assay_type"
             )
@@ -240,7 +240,7 @@ def validate_against_hprc(
             catalog_stats["alignments"]["matched"] += 1
             meta = align_lookup[filename]
 
-            our_ref = get_classification_value(c, "reference_assembly") or ""
+            our_ref = field_label(c, "reference_assembly") or ""
             m = validate_dimension(our_ref, meta["reference_assembly"], counters, "reference_assembly")
             if m:
                 m["source"] = "alignments"
@@ -251,7 +251,7 @@ def validate_against_hprc(
             catalog_stats["annotations"]["matched"] += 1
             meta = annot_lookup[filename]
 
-            our_ref = get_classification_value(c, "reference_assembly") or ""
+            our_ref = field_label(c, "reference_assembly") or ""
             m = validate_dimension(our_ref, meta["reference_assembly"], counters, "reference_assembly")
             if m:
                 m["source"] = "annotations"

--- a/scripts/validate_against_hprc.py
+++ b/scripts/validate_against_hprc.py
@@ -214,21 +214,21 @@ def validate_against_hprc(
             catalog_stats["sequencing-data"]["matched"] += 1
             meta = seq_lookup[filename]
 
-            our_platform = field_label(c, "platform") or ""
+            our_platform = field_label(c, "platform")
             m = validate_dimension(our_platform, meta["platform"], counters, "platform")
             if m:
                 m["hprc_instrument"] = meta.get("instrument_model")
                 m["our_instrument"] = field_value(c, "instrument_model")
                 file_mismatches["platform"] = m
 
-            our_modality = field_label(c, "data_modality") or ""
+            our_modality = field_label(c, "data_modality")
             m = validate_dimension(
                 our_modality, meta["data_modality"], counters, "data_modality"
             )
             if m:
                 file_mismatches["data_modality"] = m
 
-            our_assay = field_label(c, "assay_type") or ""
+            our_assay = field_label(c, "assay_type")
             m = validate_dimension(
                 our_assay, meta["assay_type"], counters, "assay_type"
             )
@@ -240,7 +240,7 @@ def validate_against_hprc(
             catalog_stats["alignments"]["matched"] += 1
             meta = align_lookup[filename]
 
-            our_ref = field_label(c, "reference_assembly") or ""
+            our_ref = field_label(c, "reference_assembly")
             m = validate_dimension(our_ref, meta["reference_assembly"], counters, "reference_assembly")
             if m:
                 m["source"] = "alignments"
@@ -251,7 +251,7 @@ def validate_against_hprc(
             catalog_stats["annotations"]["matched"] += 1
             meta = annot_lookup[filename]
 
-            our_ref = field_label(c, "reference_assembly") or ""
+            our_ref = field_label(c, "reference_assembly")
             m = validate_dimension(our_ref, meta["reference_assembly"], counters, "reference_assembly")
             if m:
                 m["source"] = "annotations"

--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -71,6 +71,18 @@ def field_status(record: dict, field_name: str) -> str:
     return CLASSIFIED
 
 
+def field_label(record: dict, field_name: str) -> str | None:
+    """Display label for a field: its value when classified, else its status.
+
+    Reproduces the pre-split convention where ``value`` held either a real value or
+    a sentinel — for histograms / aggregations that bucket by that combined label.
+    Survives the sentinel→status split (epic #116): once sentinels move out of
+    ``value``, this still yields the sentinel via the status.
+    """
+    status = field_status(record, field_name)
+    return field_value(record, field_name) if status == CLASSIFIED else status
+
+
 @dataclass
 class FileInfo:
     """Input file information for classification."""

--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -27,37 +27,19 @@ def _field_entry(record: dict, field_name: str):
     - flat:       record[field] -> value
     Returns whatever is found at the field (a dict entry, a scalar, or None).
     """
-    cls = record.get("classifications", {})
+    cls = record.get("classifications")
     if isinstance(cls, dict) and field_name in cls:
         return cls[field_name]
     return record.get(field_name)
 
 
-def field_value(record: dict, field_name: str):
-    """Resolved value of a classification field, normalizing record layout.
-
-    Use this for *value* reads. For "is this field applicable / classified?"
-    questions use field_status — so that when the sentinel→status migration moves
-    sentinels out of `value` (epic #116), value-reads and status-checks stay
-    correctly separated and call sites do not need to change again.
-    """
-    entry = _field_entry(record, field_name)
-    if isinstance(entry, dict):
-        return entry.get("value")
-    return entry
+def _entry_value(entry):
+    """Resolved value from a per-field entry (a dict ``{"value": ...}`` or scalar)."""
+    return entry.get("value") if isinstance(entry, dict) else entry
 
 
-def field_status(record: dict, field_name: str) -> str:
-    """Status of a classification field.
-
-    Returns an explicit non-None ``status`` from the field entry verbatim when
-    present (the shape the migration is moving toward — this may be values beyond
-    the three below, e.g. ``conflict`` in later stages). Otherwise derives the
-    status from the current sentinel-in-``value`` convention, yielding one of
-    CLASSIFIED / NOT_APPLICABLE / NOT_CLASSIFIED; a missing/None value reads as
-    NOT_CLASSIFIED.
-    """
-    entry = _field_entry(record, field_name)
+def _entry_status(entry) -> str:
+    """Status from a per-field entry: explicit ``status`` if set, else derived."""
     if isinstance(entry, dict):
         if entry.get("status") is not None:
             return entry["status"]
@@ -71,16 +53,46 @@ def field_status(record: dict, field_name: str) -> str:
     return CLASSIFIED
 
 
+def field_value(record: dict, field_name: str):
+    """Resolved value of a classification field, normalizing record layout.
+
+    Use this for *value* reads. For "is this field applicable / classified?"
+    questions use field_status, and for histogram / aggregation bucket keys that
+    should fold unclassified into a sentinel bucket use field_label — so that when
+    the sentinel→status migration moves sentinels out of `value` (epic #116),
+    value-reads, status-checks, and bucket labels stay correctly separated and
+    call sites do not need to change again.
+    """
+    return _entry_value(_field_entry(record, field_name))
+
+
+def field_status(record: dict, field_name: str) -> str:
+    """Status of a classification field.
+
+    Returns an explicit non-None ``status`` from the field entry verbatim when
+    present (the shape the migration is moving toward — this may be values beyond
+    the three below, e.g. ``conflict`` in later stages). Otherwise derives the
+    status from the current sentinel-in-``value`` convention, yielding one of
+    CLASSIFIED / NOT_APPLICABLE / NOT_CLASSIFIED; a missing/None value reads as
+    NOT_CLASSIFIED.
+    """
+    return _entry_status(_field_entry(record, field_name))
+
+
 def field_label(record: dict, field_name: str) -> str | None:
     """Display label for a field: its value when classified, else its status.
 
     Reproduces the pre-split convention where ``value`` held either a real value or
     a sentinel — for histograms / aggregations that bucket by that combined label.
-    Survives the sentinel→status split (epic #116): once sentinels move out of
-    ``value``, this still yields the sentinel via the status.
+    Returns the field_value when status is CLASSIFIED (which may be None only in the
+    future explicit-status shape), otherwise the status string. Survives the
+    sentinel→status split (epic #116): the not_applicable / not_classified buckets
+    persist via the status once sentinels move out of ``value`` (a non-sentinel
+    status such as ``conflict`` would likewise surface here).
     """
-    status = field_status(record, field_name)
-    return field_value(record, field_name) if status == CLASSIFIED else status
+    entry = _field_entry(record, field_name)
+    status = _entry_status(entry)
+    return _entry_value(entry) if status == CLASSIFIED else status
 
 
 @dataclass

--- a/src/meta_disco/summaries.py
+++ b/src/meta_disco/summaries.py
@@ -1,6 +1,6 @@
 """Summary printers for classification results."""
 
-from .validation_maps import get_classification_value as _val
+from .models import field_label, field_value
 
 
 def _print_field_table(title: str, counts: dict, width: int = 35):
@@ -18,7 +18,7 @@ def _print_sample_evidence(classifications: list[dict], fields: list[tuple[str, 
     for c in classifications[:3]:
         print(f"\nFile: {c.get('file_name', 'unknown')}")
         for label, field in fields:
-            val = _val(c, field)
+            val = field_value(c, field)
             if val is not None:
                 print(f"  {label}: {val}")
 
@@ -40,13 +40,13 @@ def print_bam_summary(classifications: list[dict]):
     platforms = {}
 
     for c in classifications:
-        mod = _val(c, "data_modality") or "unknown"
+        mod = field_label(c, "data_modality") or "unknown"
         modalities[mod] = modalities.get(mod, 0) + 1
 
-        ref = _val(c, "reference_assembly") or "unknown"
+        ref = field_label(c, "reference_assembly") or "unknown"
         references[ref] = references.get(ref, 0) + 1
 
-        plat = _val(c, "platform") or "unknown"
+        plat = field_label(c, "platform") or "unknown"
         platforms[plat] = platforms.get(plat, 0) + 1
 
     print(f"\nTotal files classified: {len(classifications)}")
@@ -77,13 +77,13 @@ def print_vcf_summary(classifications: list[dict]):
     references = {}
 
     for c in classifications:
-        mod = _val(c, "data_modality") or "unknown"
+        mod = field_label(c, "data_modality") or "unknown"
         modalities[mod] = modalities.get(mod, 0) + 1
 
-        dtype = _val(c, "data_type") or "unknown"
+        dtype = field_label(c, "data_type") or "unknown"
         data_types[dtype] = data_types.get(dtype, 0) + 1
 
-        ref = _val(c, "reference_assembly") or "unknown"
+        ref = field_label(c, "reference_assembly") or "unknown"
         references[ref] = references.get(ref, 0) + 1
 
     print(f"\nTotal files classified: {len(classifications)}")
@@ -116,20 +116,20 @@ def print_fastq_summary(classifications: list[dict]):
     archive_sources = {}
 
     for c in classifications:
-        plat = _val(c, "platform") or "unknown"
+        plat = field_label(c, "platform") or "unknown"
         platforms[plat] = platforms.get(plat, 0) + 1
 
-        mod = _val(c, "data_modality") or "unknown"
+        mod = field_label(c, "data_modality") or "unknown"
         modalities[mod] = modalities.get(mod, 0) + 1
 
-        if _val(c, "is_paired_end"):
+        if field_value(c, "is_paired_end"):
             paired_count += 1
 
-        model = _val(c, "instrument_model")
+        model = field_value(c, "instrument_model")
         if model:
             instrument_models[model] = instrument_models.get(model, 0) + 1
 
-        source = _val(c, "archive_source")
+        source = field_value(c, "archive_source")
         if source:
             archive_sources[source] = archive_sources.get(source, 0) + 1
 

--- a/src/meta_disco/summaries.py
+++ b/src/meta_disco/summaries.py
@@ -40,13 +40,13 @@ def print_bam_summary(classifications: list[dict]):
     platforms = {}
 
     for c in classifications:
-        mod = field_label(c, "data_modality") or "unknown"
+        mod = field_label(c, "data_modality")
         modalities[mod] = modalities.get(mod, 0) + 1
 
-        ref = field_label(c, "reference_assembly") or "unknown"
+        ref = field_label(c, "reference_assembly")
         references[ref] = references.get(ref, 0) + 1
 
-        plat = field_label(c, "platform") or "unknown"
+        plat = field_label(c, "platform")
         platforms[plat] = platforms.get(plat, 0) + 1
 
     print(f"\nTotal files classified: {len(classifications)}")
@@ -77,13 +77,13 @@ def print_vcf_summary(classifications: list[dict]):
     references = {}
 
     for c in classifications:
-        mod = field_label(c, "data_modality") or "unknown"
+        mod = field_label(c, "data_modality")
         modalities[mod] = modalities.get(mod, 0) + 1
 
-        dtype = field_label(c, "data_type") or "unknown"
+        dtype = field_label(c, "data_type")
         data_types[dtype] = data_types.get(dtype, 0) + 1
 
-        ref = field_label(c, "reference_assembly") or "unknown"
+        ref = field_label(c, "reference_assembly")
         references[ref] = references.get(ref, 0) + 1
 
     print(f"\nTotal files classified: {len(classifications)}")
@@ -116,12 +116,15 @@ def print_fastq_summary(classifications: list[dict]):
     archive_sources = {}
 
     for c in classifications:
-        plat = field_label(c, "platform") or "unknown"
+        plat = field_label(c, "platform")
         platforms[plat] = platforms.get(plat, 0) + 1
 
-        mod = field_label(c, "data_modality") or "unknown"
+        mod = field_label(c, "data_modality")
         modalities[mod] = modalities.get(mod, 0) + 1
 
+        # Dimensions above use field_label so unclassified files bucket as a
+        # sentinel; these scalar metadata fields have no sentinel convention, so
+        # they use field_value and are simply skipped when absent.
         if field_value(c, "is_paired_end"):
             paired_count += 1
 

--- a/src/meta_disco/validation_maps.py
+++ b/src/meta_disco/validation_maps.py
@@ -4,8 +4,6 @@ Each external source uses different naming conventions. These maps normalize
 external values to our internal classification values.
 """
 
-from .models import field_value
-
 HPRC_CATALOG_NAMES = ["sequencing-data", "alignments", "annotations", "assemblies"]
 
 HPRC_CATALOG_BASE_URL = (
@@ -49,19 +47,6 @@ _ANNOTATION_REF_PATTERNS: dict[str, str] = {
     "Reference Mappings GRCh38": "GRCh38",
     "ChromAlias T2T": "CHM13",
 }
-
-
-def get_classification_value(record: dict, field: str):
-    """Extract a classification value from per-field or flat record format.
-
-    Thin alias for ``models.field_value`` (the canonical accessor), kept so its
-    callers (summaries.py, scripts/, tests/test_hprc_validation.py) keep working
-    until they migrate in Stage 1b (#119). Handles the per-field, nested-dict, and
-    flat layouts.
-    """
-    return field_value(record, field)
-
-
 def extract_ref_from_annotation_type(annotation_type: str) -> str | None:
     """Extract reference assembly from an HPRC annotation type string.
 

--- a/tests/test_field_accessors.py
+++ b/tests/test_field_accessors.py
@@ -1,0 +1,151 @@
+"""Unit tests for the classification field accessors (models.field_*).
+
+These accessors are the seam the sentinel→status migration (epic #116) relies on:
+value reads go through field_value, status checks through field_status, and
+histogram/aggregation bucket keys through field_label. The suite pins their
+semantics across every record layout, every sentinel state, and — critically —
+the *future* explicit-``status`` shape that Stage 2/#120 will introduce (no
+producer writes ``status`` yet, so only these tests exercise that path).
+"""
+
+import pytest
+
+from src.meta_disco.models import (
+    CLASSIFIED,
+    NOT_APPLICABLE,
+    NOT_CLASSIFIED,
+    field_label,
+    field_status,
+    field_value,
+)
+
+
+def _wrapped(field, entry):
+    """A per-field record: {"classifications": {field: entry}}."""
+    return {"classifications": {field: entry}}
+
+
+# --- field_value -----------------------------------------------------------
+
+class TestFieldValue:
+    def test_classified_wrapped(self):
+        assert field_value(_wrapped("data_modality", {"value": "genomic"}), "data_modality") == "genomic"
+
+    def test_sentinel_value_returned_verbatim_today(self):
+        # Pre-split, the sentinel lives in `value`; field_value returns it raw.
+        rec = _wrapped("reference_assembly", {"value": NOT_APPLICABLE})
+        assert field_value(rec, "reference_assembly") == NOT_APPLICABLE
+
+    def test_none_value(self):
+        assert field_value(_wrapped("platform", {"value": None}), "platform") is None
+
+    def test_nested_layout(self):
+        assert field_value({"platform": {"value": "ONT"}}, "platform") == "ONT"
+
+    def test_flat_layout(self):
+        assert field_value({"platform": "ILLUMINA"}, "platform") == "ILLUMINA"
+
+    def test_missing_field(self):
+        assert field_value(_wrapped("platform", {"value": "ONT"}), "data_modality") is None
+
+    def test_empty_record(self):
+        assert field_value({}, "platform") is None
+
+    def test_scalar_field(self):
+        # Non-dimension scalar metadata: returned as-is (no sentinel semantics).
+        assert field_value({"classifications": {"is_paired_end": False}}, "is_paired_end") is False
+
+    def test_future_status_shape_returns_value(self):
+        # Once sentinels move to `status`, an unclassified field has value=None.
+        rec = _wrapped("platform", {"value": None, "status": NOT_CLASSIFIED})
+        assert field_value(rec, "platform") is None
+
+
+# --- field_status ----------------------------------------------------------
+
+class TestFieldStatus:
+    def test_classified(self):
+        assert field_status(_wrapped("data_modality", {"value": "genomic"}), "data_modality") == CLASSIFIED
+
+    def test_not_applicable_from_value(self):
+        assert field_status(_wrapped("platform", {"value": NOT_APPLICABLE}), "platform") == NOT_APPLICABLE
+
+    def test_not_classified_from_value(self):
+        assert field_status(_wrapped("platform", {"value": NOT_CLASSIFIED}), "platform") == NOT_CLASSIFIED
+
+    def test_none_value_is_not_classified(self):
+        assert field_status(_wrapped("platform", {"value": None}), "platform") == NOT_CLASSIFIED
+
+    def test_missing_field_is_not_classified(self):
+        assert field_status({}, "platform") == NOT_CLASSIFIED
+
+    def test_flat_scalar_classified(self):
+        assert field_status({"platform": "ILLUMINA"}, "platform") == CLASSIFIED
+
+    def test_explicit_status_preferred(self):
+        # An explicit non-None status is returned verbatim — even values beyond
+        # the three derived ones (e.g. conflict in a later stage).
+        rec = _wrapped("data_modality", {"value": None, "status": "conflict"})
+        assert field_status(rec, "data_modality") == "conflict"
+
+    def test_explicit_none_status_falls_through_to_value(self):
+        rec = _wrapped("platform", {"value": "ONT", "status": None})
+        assert field_status(rec, "platform") == CLASSIFIED
+
+    def test_future_split_shape(self):
+        # Stage 3: value=None, status carries the sentinel.
+        rec = _wrapped("reference_assembly", {"value": None, "status": NOT_APPLICABLE})
+        assert field_status(rec, "reference_assembly") == NOT_APPLICABLE
+
+
+# --- field_label -----------------------------------------------------------
+
+class TestFieldLabel:
+    def test_classified_returns_value(self):
+        assert field_label(_wrapped("data_modality", {"value": "genomic"}), "data_modality") == "genomic"
+
+    def test_not_applicable_returns_sentinel(self):
+        assert field_label(_wrapped("platform", {"value": NOT_APPLICABLE}), "platform") == NOT_APPLICABLE
+
+    def test_not_classified_returns_sentinel(self):
+        assert field_label(_wrapped("platform", {"value": NOT_CLASSIFIED}), "platform") == NOT_CLASSIFIED
+
+    def test_none_value_returns_not_classified(self):
+        assert field_label(_wrapped("platform", {"value": None}), "platform") == NOT_CLASSIFIED
+
+    def test_missing_field_returns_not_classified(self):
+        assert field_label({}, "platform") == NOT_CLASSIFIED
+
+    def test_never_none_for_sentinels(self):
+        # The property histograms rely on: field_label is a usable bucket key,
+        # never None, for the unclassified cases.
+        assert field_label(_wrapped("platform", {"value": None}), "platform") is not None
+
+    def test_future_split_preserves_sentinel_bucket(self):
+        # Stage 3: sentinel moved to status; the bucket label still resolves to it.
+        rec = _wrapped("reference_assembly", {"value": None, "status": NOT_APPLICABLE})
+        assert field_label(rec, "reference_assembly") == NOT_APPLICABLE
+
+    def test_future_split_classified_returns_value(self):
+        rec = _wrapped("data_modality", {"value": "genomic", "status": CLASSIFIED})
+        assert field_label(rec, "data_modality") == "genomic"
+
+    def test_non_sentinel_status_surfaces(self):
+        # A non-sentinel status (conflict) surfaces as the bucket label.
+        rec = _wrapped("data_modality", {"value": None, "status": "conflict"})
+        assert field_label(rec, "data_modality") == "conflict"
+
+
+# --- consistency across the three accessors --------------------------------
+
+@pytest.mark.parametrize("value,exp_status,exp_label", [
+    ("genomic", CLASSIFIED, "genomic"),
+    (NOT_APPLICABLE, NOT_APPLICABLE, NOT_APPLICABLE),
+    (NOT_CLASSIFIED, NOT_CLASSIFIED, NOT_CLASSIFIED),
+    (None, NOT_CLASSIFIED, NOT_CLASSIFIED),
+])
+def test_accessor_consistency_today(value, exp_status, exp_label):
+    rec = _wrapped("data_modality", {"value": value})
+    assert field_value(rec, "data_modality") == value
+    assert field_status(rec, "data_modality") == exp_status
+    assert field_label(rec, "data_modality") == exp_label

--- a/tests/test_hprc_validation.py
+++ b/tests/test_hprc_validation.py
@@ -113,7 +113,7 @@ class TestExtractRefFromAnnotationType:
         assert extract_ref_from_annotation_type("") is None
 
 
-class TestGetClassificationValue:
+class TestFieldValue:
     def test_per_field_format(self):
         record = {"classifications": {"platform": {"value": "PACBIO", "confidence": 0.9}}}
         assert field_value(record, "platform") == "PACBIO"

--- a/tests/test_hprc_validation.py
+++ b/tests/test_hprc_validation.py
@@ -7,6 +7,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from src.meta_disco.models import field_value
 from src.meta_disco.validation_maps import (
     HPRC_CATALOG_BASE_URL,
     HPRC_CATALOG_NAMES,
@@ -15,7 +16,6 @@ from src.meta_disco.validation_maps import (
     HPRC_PLATFORM_MAP,
     HPRC_REF_COORDINATES_MAP,
     extract_ref_from_annotation_type,
-    get_classification_value,
 )
 
 
@@ -116,22 +116,22 @@ class TestExtractRefFromAnnotationType:
 class TestGetClassificationValue:
     def test_per_field_format(self):
         record = {"classifications": {"platform": {"value": "PACBIO", "confidence": 0.9}}}
-        assert get_classification_value(record, "platform") == "PACBIO"
+        assert field_value(record, "platform") == "PACBIO"
 
     def test_flat_format(self):
         record = {"platform": "ILLUMINA"}
-        assert get_classification_value(record, "platform") == "ILLUMINA"
+        assert field_value(record, "platform") == "ILLUMINA"
 
     def test_nested_dict_value(self):
         record = {"platform": {"value": "ONT"}}
-        assert get_classification_value(record, "platform") == "ONT"
+        assert field_value(record, "platform") == "ONT"
 
     def test_missing_field(self):
         record = {"classifications": {"platform": {"value": "PACBIO"}}}
-        assert get_classification_value(record, "data_modality") is None
+        assert field_value(record, "data_modality") is None
 
     def test_empty_record(self):
-        assert get_classification_value({}, "platform") is None
+        assert field_value({}, "platform") is None
 
 
 class TestSharedConstants:


### PR DESCRIPTION
## Summary

**Stage 1b** of the sentinel→status migration (epic #116). Removes the four
duplicate value-read helpers (`_get_field` + three `_val` copies) and all inline
output-dict reads from `scripts/` and `summaries.py`, routing them through the
`models` accessors so the Stage 3 format change does not ripple here. Also removes
the `validation_maps.get_classification_value` alias (all callers migrated).

**Pure refactor — output unchanged.** The #117 golden + 380 tests pass; verified
end-to-end on cached evidence.

## New accessor: `field_label`

`models.field_label(record, field)` = the value when classified, else the status —
i.e. the pre-split "value-with-sentinel" string. This is the faithful, Stage-3-safe
replacement for the old helpers (which returned the sentinel via `value`), used for
histograms/distributions and inheritance propagation.

## Per-site accessor choice

| Use | Accessor |
|---|---|
| dimension reads — histograms, parent inheritance | `field_label` |
| scalar metadata — instrument_model, is_paired_end, archive_* | `field_value` |
| "is classified / applicable" checks | `field_status` |

`field_label` navigates the record once (via shared `_entry_value`/`_entry_status`);
`_field_entry` no longer allocates a throwaway `{}` per call (hot path over large
catalogs).

## Out of scope

- `rule_engine` in-memory claim reads (a different shape).
- Producer sentinel *writes* (Stage 3).
- **#127** — the report's "Coverage by Axis" counts over-report coverage today
  (they count truthy sentinel strings); kept as-is to preserve the pure refactor,
  self-corrects at Stage 3. Tracked separately.

## Review

- `/simplify` (4-agent): caught a silent `\b`-sed failure (3 files stuck on
  `field_value`) and a coverage-count bug from an over-broad alias; both fixed.
- `/code-review high` (A/B/C + conventions): confirmed the migration faithful for
  the consumed data shapes; the one non-equivalent site (coverage counts) was
  reverted to `field_value` to keep this a true pure refactor.

Closes #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
