### PR TITLE
Stage 2: producer dual-writes field `status` (#120)

### DIFF
--- a/scripts/classify_index_files.py
+++ b/scripts/classify_index_files.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from src.meta_disco.models import field_label
+from src.meta_disco.models import field_label, status_for_value
 
 
 def _get_max_confidence(record: dict) -> float:
@@ -297,10 +297,15 @@ def propagate_to_index_files(
             "dataset_title": r["dataset_title"],
             "parent_file": parent,
             "parent_md5sum": r["parent_md5sum"],
+            # Field entries mirror to_output_dict's shape, incl. the Stage 2
+            # `status` key (epic #116), derived from the inherited value.
             "classifications": {
-                fld: (lambda evi: {"value": r.get(fld), "confidence": evi[0]["confidence"], "evidence": evi})(
-                    inherited_evidence(fld, r.get(fld), parent)
-                )
+                fld: (lambda v, evi: {
+                    "value": v,
+                    "status": status_for_value(v),
+                    "confidence": evi[0]["confidence"],
+                    "evidence": evi,
+                })(r.get(fld), inherited_evidence(fld, r.get(fld), parent))
                 for fld in ["data_modality", "data_type", "platform", "reference_assembly", "assay_type"]
             },
         })

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -11,7 +11,7 @@ by the RuleEngine. This module provides:
 import re
 from dataclasses import replace
 
-from .models import NOT_APPLICABLE, NOT_CLASSIFIED
+from .models import NOT_APPLICABLE, NOT_CLASSIFIED, status_for_value
 from .validators.read_name_parsers import (  # noqa: F401 — re-exported for backward compat
     detect_paired_end_indicators,
     extract_archive_accession,
@@ -223,8 +223,9 @@ def classify_from_fastq_header(
 
     # Handle empty input — return per-field format with empty evidence
     if not reads or not reads[0]:
+        # Mirror to_output_dict's shape, incl. the Stage 2 `status` key (epic #116).
         def empty_field(v):
-            return {"value": v, "confidence": 0.0, "evidence": []}
+            return {"value": v, "status": status_for_value(v), "confidence": 0.0, "evidence": []}
         return {
             "data_modality": empty_field(None),
             "data_type": empty_field("reads"),

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -56,7 +56,7 @@ def classify_from_header(
 
     Returns:
         Dict with per-field classifications:
-            - {field}: {value, confidence, evidence[]} for each of
+            - {field}: {value, status, confidence, evidence[]} for each of
               data_modality, data_type, assay_type, reference_assembly, platform
     """
     from .rule_engine import ExtendedFileInfo
@@ -136,7 +136,7 @@ def classify_from_vcf_header(
 
     Returns:
         Dict with per-field classifications:
-            - {field}: {value, confidence, evidence[]} for each of
+            - {field}: {value, status, confidence, evidence[]} for each of
               data_modality, data_type, assay_type, reference_assembly, platform
     """
     from .rule_engine import ExtendedFileInfo

--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -43,10 +43,12 @@ def status_for_value(value) -> str:
 
     The one place that maps a sentinel-carrying ``value`` to a status string:
     ``not_applicable`` → NOT_APPLICABLE, ``None``/``not_classified`` →
-    NOT_CLASSIFIED, any real value → CLASSIFIED. Both the read side
-    (``_entry_status``) and the producer (rule_engine's ``to_output_dict``, which
-    dual-writes ``status`` in epic #116 Stage 2) go through this, so the two stay
-    in lockstep as the migration moves sentinels out of ``value``.
+    NOT_CLASSIFIED, any real value → CLASSIFIED. The read side
+    (``_entry_status``) and every producer that dual-writes ``status`` in epic
+    #116 Stage 2 — rule_engine's ``to_output_dict`` plus the header_classifier
+    empty-input fallback and the index-propagation script — go through this, so
+    reader and producers stay in lockstep as the migration moves sentinels out of
+    ``value``.
     """
     if value == NOT_APPLICABLE:
         return NOT_APPLICABLE

--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -38,6 +38,23 @@ def _entry_value(entry):
     return entry.get("value") if isinstance(entry, dict) else entry
 
 
+def status_for_value(value) -> str:
+    """Derive a field's status from its (pre-split) value.
+
+    The one place that maps a sentinel-carrying ``value`` to a status string:
+    ``not_applicable`` → NOT_APPLICABLE, ``None``/``not_classified`` →
+    NOT_CLASSIFIED, any real value → CLASSIFIED. Both the read side
+    (``_entry_status``) and the producer (rule_engine's ``to_output_dict``, which
+    dual-writes ``status`` in epic #116 Stage 2) go through this, so the two stay
+    in lockstep as the migration moves sentinels out of ``value``.
+    """
+    if value == NOT_APPLICABLE:
+        return NOT_APPLICABLE
+    if value is None or value == NOT_CLASSIFIED:
+        return NOT_CLASSIFIED
+    return CLASSIFIED
+
+
 def _entry_status(entry) -> str:
     """Status from a per-field entry: explicit ``status`` if set, else derived."""
     if isinstance(entry, dict):
@@ -46,11 +63,7 @@ def _entry_status(entry) -> str:
         value = entry.get("value")
     else:
         value = entry
-    if value == NOT_APPLICABLE:
-        return NOT_APPLICABLE
-    if value is None or value == NOT_CLASSIFIED:
-        return NOT_CLASSIFIED
-    return CLASSIFIED
+    return status_for_value(value)
 
 
 def field_value(record: dict, field_name: str):

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -11,6 +11,7 @@ from .models import (
     NOT_CLASSIFIED,
     ClassificationResult,
     FileInfo,
+    status_for_value,
 )
 from .rule_loader import UnifiedRule, get_unified_rules
 
@@ -113,7 +114,15 @@ class ExtendedClassificationResult:
         )
 
     def to_output_dict(self) -> dict:
-        """Convert to the per-field output format."""
+        """Convert to the per-field output format.
+
+        Each dimension emits ``{value, status, confidence, evidence}``. Epic #116
+        Stage 2 dual-writes ``status`` (derived from the sentinel-carrying
+        ``value`` via ``status_for_value``) additively — ``value`` still holds the
+        sentinel this stage; Stage 3 nulls it out. Readers already prefer an
+        explicit ``status`` (models.field_status), so this producer change ripples
+        nowhere but the output shape (the Stage 0 golden gains a ``status`` key).
+        """
         classifications = {}
         for fld in self._CLASSIFICATION_FIELDS:
             value = getattr(self, fld)
@@ -121,6 +130,7 @@ class ExtendedClassificationResult:
             fld_conf = max((e.get("confidence", 0) for e in evidence), default=0.0)
             classifications[fld] = {
                 "value": value,
+                "status": status_for_value(value),
                 "confidence": fld_conf,
                 "evidence": evidence,
             }

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -119,9 +119,10 @@ class ExtendedClassificationResult:
         Each dimension emits ``{value, status, confidence, evidence}``. Epic #116
         Stage 2 dual-writes ``status`` (derived from the sentinel-carrying
         ``value`` via ``status_for_value``) additively — ``value`` still holds the
-        sentinel this stage; Stage 3 nulls it out. Readers already prefer an
-        explicit ``status`` (models.field_status), so this producer change ripples
-        nowhere but the output shape (the Stage 0 golden gains a ``status`` key).
+        sentinel this stage; Stage 3 nulls it out. Readers are unaffected (they
+        already prefer an explicit ``status`` via models.field_status); the sibling
+        hand-built entry producers — the fastq empty-input fallback and index
+        propagation — dual-write ``status`` through the same helper to match.
         """
         classifications = {}
         for fld in self._CLASSIFICATION_FIELDS:

--- a/tests/fixtures/golden/expected_output.json
+++ b/tests/fixtures/golden/expected_output.json
@@ -13,6 +13,7 @@
                 "value": "not_classified"
               }
             ],
+            "status": "not_classified",
             "value": "not_classified"
           },
           "data_modality": {
@@ -25,6 +26,7 @@
                 "value": "not_classified"
               }
             ],
+            "status": "not_classified",
             "value": "not_classified"
           },
           "data_type": {
@@ -37,6 +39,7 @@
                 "value": "not_classified"
               }
             ],
+            "status": "not_classified",
             "value": "not_classified"
           },
           "platform": {
@@ -49,6 +52,7 @@
                 "value": "not_classified"
               }
             ],
+            "status": "not_classified",
             "value": "not_classified"
           },
           "reference_assembly": {
@@ -62,6 +66,7 @@
                 "value": "not_applicable"
               }
             ],
+            "status": "not_applicable",
             "value": "not_applicable"
           }
         },
@@ -97,6 +102,7 @@
                 "value": "not_applicable"
               }
             ],
+            "status": "not_applicable",
             "value": "not_applicable"
           },
           "data_modality": {
@@ -117,6 +123,7 @@
                 "value": "genomic"
               }
             ],
+            "status": "classified",
             "value": "genomic"
           },
           "data_type": {
@@ -144,6 +151,7 @@
                 "value": "assembly"
               }
             ],
+            "status": "classified",
             "value": "assembly"
           },
           "platform": {
@@ -157,6 +165,7 @@
                 "value": "not_applicable"
               }
             ],
+            "status": "not_applicable",
             "value": "not_applicable"
           },
           "reference_assembly": {
@@ -177,6 +186,7 @@
                 "value": "not_applicable"
               }
             ],
+            "status": "not_applicable",
             "value": "not_applicable"
           }
         },
@@ -213,6 +223,7 @@
                 "value": "not_classified"
               }
             ],
+            "status": "not_classified",
             "value": "not_classified"
           },
           "data_modality": {
@@ -226,6 +237,7 @@
                 "value": "not_classified"
               }
             ],
+            "status": "not_classified",
             "value": "not_classified"
           },
           "data_type": {
@@ -239,6 +251,7 @@
                 "value": "reads"
               }
             ],
+            "status": "classified",
             "value": "reads"
           },
           "instrument_hint": null,
@@ -254,6 +267,7 @@
                 "value": "not_classified"
               }
             ],
+            "status": "not_classified",
             "value": "not_classified"
           },
           "reference_assembly": {
@@ -267,6 +281,7 @@
                 "value": "not_applicable"
               }
             ],
+            "status": "not_applicable",
             "value": "not_applicable"
           }
         },
@@ -301,6 +316,7 @@
                 "value": "not_classified"
               }
             ],
+            "status": "not_classified",
             "value": "not_classified"
           },
           "data_modality": {
@@ -314,6 +330,7 @@
                 "value": "genomic"
               }
             ],
+            "status": "classified",
             "value": "genomic"
           },
           "data_type": {
@@ -327,6 +344,7 @@
                 "value": "variants"
               }
             ],
+            "status": "classified",
             "value": "variants"
           },
           "platform": {
@@ -339,6 +357,7 @@
                 "value": "not_classified"
               }
             ],
+            "status": "not_classified",
             "value": "not_classified"
           },
           "reference_assembly": {
@@ -351,6 +370,7 @@
                 "value": "not_classified"
               }
             ],
+            "status": "not_classified",
             "value": "not_classified"
           }
         },

--- a/tests/test_header_classifier.py
+++ b/tests/test_header_classifier.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.meta_disco.models import NOT_APPLICABLE, NOT_CLASSIFIED, field_status, field_value
+from src.meta_disco.models import CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED, field_status, field_value
 
 
 def val(result: dict, field: str):
@@ -463,6 +463,11 @@ class TestFastqClassification:
         result = classify_from_fastq_header([])
         assert val(result, "platform") is None
         assert val(result, "confidence") == 0.0
+        # The empty-input fallback mirrors to_output_dict's Stage 2 shape (#116):
+        # dimension entries carry a `status` derived from the sentinel value.
+        assert "status" in result["data_modality"]
+        assert field_status(result, "data_modality") == NOT_CLASSIFIED
+        assert field_status(result, "data_type") == CLASSIFIED  # value "reads"
 
     def test_confidence_boost_on_agreement(self):
         """Confidence should increase when all reads agree."""

--- a/tests/test_index_propagation.py
+++ b/tests/test_index_propagation.py
@@ -10,7 +10,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from classify_index_files import INDEX_TO_PARENT, get_parent_candidates, load_classifications, propagate_to_index_files
 
-from src.meta_disco.models import NOT_CLASSIFIED, field_status, field_value
+from src.meta_disco.models import CLASSIFIED, NOT_CLASSIFIED, field_status, field_value
 
 
 class TestParentCandidateGeneration:
@@ -244,6 +244,9 @@ class TestLoadClassifications:
         assert field_value(cls, "data_type") == "annotations"
         assert field_value(cls, "reference_assembly") == "CHM13"
         assert cls["data_modality"]["evidence"][0]["rule_id"] == "inherited_from_parent"
+        # Propagated entries carry the Stage 2 `status` key (epic #116), like to_output_dict.
+        assert "status" in cls["data_modality"]
+        assert field_status(cls, "data_modality") == CLASSIFIED
 
     def test_tbi_inherits_from_vcf_parent(self, tmp_path):
         """End-to-end: a .tbi index inherits from its .vcf.gz parent."""

--- a/tests/test_output_shape.py
+++ b/tests/test_output_shape.py
@@ -88,7 +88,7 @@ STUB_HEADER = "stub-header-no-network"
 # later type-guards its argument.
 LIST_RETURNING_TYPES = {"fastq", "fasta"}
 EVIDENCE_KEYS = {"rule_id", "reason", "confidence"}
-FIELD_KEYS = {"value", "confidence", "evidence"}
+FIELD_KEYS = {"value", "status", "confidence", "evidence"}
 RECORD_KEYS = {
     "file_name", "md5sum", "file_size", "file_format",
     "dataset_title", "classifications", "entry_id",

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -2,7 +2,14 @@
 
 import pytest
 
-from src.meta_disco.models import NOT_APPLICABLE, NOT_CLASSIFIED, ClassificationResult, FileInfo
+from src.meta_disco.models import (
+    CLASSIFICATION_FIELDS,
+    CLASSIFIED,
+    NOT_APPLICABLE,
+    NOT_CLASSIFIED,
+    ClassificationResult,
+    FileInfo,
+)
 from src.meta_disco.rule_engine import ExtendedFileInfo, RuleEngine, evaluate_claims
 
 
@@ -590,3 +597,30 @@ class TestSentinelValues:
         assert result.platform == NOT_APPLICABLE
         assert result.reference_assembly == NOT_APPLICABLE
         assert result.assay_type == NOT_APPLICABLE
+
+
+class TestOutputDictStatus:
+    """to_output_dict dual-writes a `status` key alongside `value` (epic #116 Stage 2)."""
+
+    def test_every_dimension_gets_the_status_key(self, engine):
+        # The Stage 2 shape contract: every dimension entry gains `status`
+        # alongside the existing keys, across a spread of file types.
+        for filename in ("sample_WGS_aligned.bam", "sample.fastq.gz", "plot.png"):
+            out = engine.classify_extended(FileInfo(filename=filename)).to_output_dict()
+            for fld in CLASSIFICATION_FIELDS:
+                assert set(out[fld]) == {"value", "status", "confidence", "evidence"}
+
+    def test_status_pins_each_sentinel_state(self, engine):
+        # Concrete value→status outcomes, asserted independently of status_for_value:
+        # a real value classifies, and each sentinel keeps its own status this stage.
+        classified = engine.classify_extended(
+            FileInfo(filename="sample_WGS_aligned.bam")).to_output_dict()["data_modality"]
+        assert (classified["value"], classified["status"]) == ("genomic", CLASSIFIED)
+
+        n_a = engine.classify_extended(
+            FileInfo(filename="plot.png")).to_output_dict()["reference_assembly"]
+        assert (n_a["value"], n_a["status"]) == (NOT_APPLICABLE, NOT_APPLICABLE)
+
+        n_c = engine.classify_extended(
+            ExtendedFileInfo(filename="sample.bam", file_size_gb=60.0)).to_output_dict()["data_modality"]
+        assert (n_c["value"], n_c["status"]) == (NOT_CLASSIFIED, NOT_CLASSIFIED)


### PR DESCRIPTION
## Stage 2 of the sentinel→status migration (epic #116)

Closes #120.

The producer now **dual-writes** a `status` key alongside `value` for each classification dimension. This is the additive "expand" step of the expand/contract migration: `value` is unchanged this stage (still carries the sentinel); Stage 3 (#121) will null it out.

### What changed

- **`models.status_for_value(value)`** — a single value→status derivation (`not_applicable`→`NOT_APPLICABLE`, `None`/`not_classified`→`NOT_CLASSIFIED`, real value→`CLASSIFIED`), extracted from `_entry_status`. Both the read side and every producer go through it, so reader and producers stay in lockstep as the migration proceeds.
- **`rule_engine.to_output_dict`** — emits `{value, status, confidence, evidence}` per dimension. Readers are unaffected: `models.field_status` already prefers an explicit `status` key (proven by the future-shape tests added in Stage 1b).
- **Two other hand-built producers** dual-write `status` through the same helper so the output shape is consistent everywhere:
  - `header_classifier.classify_from_fastq_header` empty-input fallback
  - `scripts/classify_index_files.py` index propagation
  - A codebase sweep confirms these are the only hand-built field-entry producers; all other `{value,...}` dicts are internal evidence (correctly no status).

### Tests / fixtures

- Regenerated the Stage 0 golden (`expected_output.json`) — only 20 `status` keys added (4 file types × 5 dimensions), no other lines changed; verified each `status` is coherent with its sibling `value`.
- `FIELD_KEYS` in the structural contract gains `status`.
- New producer tests (`TestOutputDictStatus`) + empty-input and index-propagation `status` assertions.

All 413 tests pass; ruff clean.

### Follow-up

- Noted separately: the fastq empty-input fallback emits `value=None` where the rule engine emits sentinel strings (e.g. `reference_assembly` → `not_classified` vs `not_applicable`). Pre-existing, out of scope for this additive stage — filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
