### PR TITLE
Stage 3: stop smuggling sentinels into value; value=null when unclassified (#121)

### DIFF
--- a/scripts/classify_index_files.py
+++ b/scripts/classify_index_files.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from src.meta_disco.models import field_label, status_for_value
+from src.meta_disco.models import CLASSIFIED, field_label, status_for_value
 
 
 def _get_max_confidence(record: dict) -> float:
@@ -297,15 +297,15 @@ def propagate_to_index_files(
             "dataset_title": r["dataset_title"],
             "parent_file": parent,
             "parent_md5sum": r["parent_md5sum"],
-            # Field entries mirror to_output_dict's shape, incl. the Stage 2
-            # `status` key (epic #116), derived from the inherited value.
+            # Field entries mirror to_output_dict's shape (epic #116): `status`
+            # carries the sentinel, and `value` is None unless CLASSIFIED (Stage 3).
             "classifications": {
-                fld: (lambda v, evi: {
-                    "value": v,
-                    "status": status_for_value(v),
+                fld: (lambda v, status, evi: {
+                    "value": v if status == CLASSIFIED else None,
+                    "status": status,
                     "confidence": evi[0]["confidence"],
                     "evidence": evi,
-                })(r.get(fld), inherited_evidence(fld, r.get(fld), parent))
+                })(r.get(fld), status_for_value(r.get(fld)), inherited_evidence(fld, r.get(fld), parent))
                 for fld in ["data_modality", "data_type", "platform", "reference_assembly", "assay_type"]
             },
         })

--- a/scripts/classify_index_files.py
+++ b/scripts/classify_index_files.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from src.meta_disco.models import CLASSIFIED, field_label, status_for_value
+from src.meta_disco.models import CLASSIFICATION_FIELDS, build_field_entry, field_label
 
 
 def _get_max_confidence(record: dict) -> float:
@@ -287,6 +287,14 @@ def propagate_to_index_files(
     standard_results = []
     for r in results:
         parent = r["parent_file"]
+        # Field entries share to_output_dict's builder (epic #116): `status`
+        # carries the sentinel, `value` is None unless CLASSIFIED (Stage 3).
+        classifications = {}
+        for fld in CLASSIFICATION_FIELDS:
+            value = r.get(fld)
+            evidence = inherited_evidence(fld, value, parent)
+            classifications[fld] = build_field_entry(
+                value, confidence=evidence[0]["confidence"], evidence=evidence)
         standard_results.append({
             "file_name": r["file_name"],
             "file_format": r["file_format"],
@@ -297,17 +305,7 @@ def propagate_to_index_files(
             "dataset_title": r["dataset_title"],
             "parent_file": parent,
             "parent_md5sum": r["parent_md5sum"],
-            # Field entries mirror to_output_dict's shape (epic #116): `status`
-            # carries the sentinel, and `value` is None unless CLASSIFIED (Stage 3).
-            "classifications": {
-                fld: (lambda v, status, evi: {
-                    "value": v if status == CLASSIFIED else None,
-                    "status": status,
-                    "confidence": evi[0]["confidence"],
-                    "evidence": evi,
-                })(r.get(fld), status_for_value(r.get(fld)), inherited_evidence(fld, r.get(fld), parent))
-                for fld in ["data_modality", "data_type", "platform", "reference_assembly", "assay_type"]
-            },
+            "classifications": classifications,
         })
 
     with open(output_path, "w") as f:

--- a/scripts/generate_classification_report.py
+++ b/scripts/generate_classification_report.py
@@ -371,11 +371,11 @@ def generate_report(source_path: Path, output_dir: Path, report_path: Path):
 
     print("\n--- Coverage by Axis ---")
 
-    # These "is classified" counts stay on field_value (via _val) to keep Stage 1b a
-    # pure refactor: today a sentinel value is truthy (counted, as before); once
-    # Stage 3 moves sentinels out of `value`, field_value returns None and the count
-    # self-corrects with no code change. (The old truthy-count over-reports coverage
-    # for not_applicable/not_classified fields — tracked as a follow-up, not fixed here.)
+    # "is classified" coverage counts: field_value (via _val) returns None for
+    # not_applicable/not_classified fields now that Stage 3 nulls sentinels out of
+    # `value` (epic #116), so a falsy value is not counted and these reflect true
+    # coverage. This self-corrected the Stage 1b over-count of sentinels-as-
+    # classified with no logic change here (closes #127).
     with_modality = sum(1 for item in all_classified if _val(item, "data_modality"))
     with_ref = sum(1 for item in all_classified if _val(item, "reference_assembly"))
     with_platform = sum(1 for item in all_classified if _val(item, "platform"))

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -223,8 +223,9 @@ def classify_from_fastq_header(
 
     # Handle empty input — no reads to classify. Statuses are known directly, so
     # pass them explicitly to build_field_entry (epic #116 Stage 3 shape).
-    # reference_assembly is not_applicable (reads are unaligned), matching the
-    # non-empty path (#131); the other dimensions are not_classified.
+    # data_type is the classified "reads"; reference_assembly is not_applicable
+    # (reads are unaligned), matching the non-empty path (#131); the remaining
+    # dimensions are not_classified.
     if not reads or not reads[0]:
         return {
             "data_modality": build_field_entry(None, status=NOT_CLASSIFIED),

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -11,7 +11,7 @@ by the RuleEngine. This module provides:
 import re
 from dataclasses import replace
 
-from .models import NOT_APPLICABLE, NOT_CLASSIFIED, status_for_value
+from .models import CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED
 from .validators.read_name_parsers import (  # noqa: F401 — re-exported for backward compat
     detect_paired_end_indicators,
     extract_archive_accession,
@@ -221,17 +221,19 @@ def classify_from_fastq_header(
     # Use provided filename or generate one
     filename = file_name or "sample.fastq.gz"
 
-    # Handle empty input — return per-field format with empty evidence
+    # Handle empty input — no reads to classify. Mirror to_output_dict's Stage 3
+    # shape (epic #116): `value` is None unless CLASSIFIED, sentinels live in
+    # `status`. reference_assembly is not_applicable (reads are unaligned),
+    # matching the non-empty path (#131); the other dimensions are not_classified.
     if not reads or not reads[0]:
-        # Mirror to_output_dict's shape, incl. the Stage 2 `status` key (epic #116).
-        def empty_field(v):
-            return {"value": v, "status": status_for_value(v), "confidence": 0.0, "evidence": []}
+        def field_entry(status, value=None):
+            return {"value": value, "status": status, "confidence": 0.0, "evidence": []}
         return {
-            "data_modality": empty_field(None),
-            "data_type": empty_field("reads"),
-            "platform": empty_field(None),
-            "reference_assembly": empty_field(None),
-            "assay_type": empty_field(None),
+            "data_modality": field_entry(NOT_CLASSIFIED),
+            "data_type": field_entry(CLASSIFIED, "reads"),
+            "platform": field_entry(NOT_CLASSIFIED),
+            "reference_assembly": field_entry(NOT_APPLICABLE),
+            "assay_type": field_entry(NOT_CLASSIFIED),
             "is_paired_end": None,
             "instrument_model": None,
             "instrument_hint": None,

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -11,7 +11,7 @@ by the RuleEngine. This module provides:
 import re
 from dataclasses import replace
 
-from .models import CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED
+from .models import CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED, build_field_entry
 from .validators.read_name_parsers import (  # noqa: F401 — re-exported for backward compat
     detect_paired_end_indicators,
     extract_archive_accession,
@@ -221,19 +221,17 @@ def classify_from_fastq_header(
     # Use provided filename or generate one
     filename = file_name or "sample.fastq.gz"
 
-    # Handle empty input — no reads to classify. Mirror to_output_dict's Stage 3
-    # shape (epic #116): `value` is None unless CLASSIFIED, sentinels live in
-    # `status`. reference_assembly is not_applicable (reads are unaligned),
-    # matching the non-empty path (#131); the other dimensions are not_classified.
+    # Handle empty input — no reads to classify. Statuses are known directly, so
+    # pass them explicitly to build_field_entry (epic #116 Stage 3 shape).
+    # reference_assembly is not_applicable (reads are unaligned), matching the
+    # non-empty path (#131); the other dimensions are not_classified.
     if not reads or not reads[0]:
-        def field_entry(status, value=None):
-            return {"value": value, "status": status, "confidence": 0.0, "evidence": []}
         return {
-            "data_modality": field_entry(NOT_CLASSIFIED),
-            "data_type": field_entry(CLASSIFIED, "reads"),
-            "platform": field_entry(NOT_CLASSIFIED),
-            "reference_assembly": field_entry(NOT_APPLICABLE),
-            "assay_type": field_entry(NOT_CLASSIFIED),
+            "data_modality": build_field_entry(None, status=NOT_CLASSIFIED),
+            "data_type": build_field_entry("reads", status=CLASSIFIED),
+            "platform": build_field_entry(None, status=NOT_CLASSIFIED),
+            "reference_assembly": build_field_entry(None, status=NOT_APPLICABLE),
+            "assay_type": build_field_entry(None, status=NOT_CLASSIFIED),
             "is_paired_end": None,
             "instrument_model": None,
             "instrument_hint": None,

--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -43,18 +43,41 @@ def status_for_value(value) -> str:
 
     The one place that maps a sentinel-carrying ``value`` to a status string:
     ``not_applicable`` → NOT_APPLICABLE, ``None``/``not_classified`` →
-    NOT_CLASSIFIED, any real value → CLASSIFIED. The read side (``_entry_status``)
-    and the producers that derive status from a sentinel-carrying value —
-    rule_engine's ``to_output_dict`` and the index-propagation script — go through
-    this, so reader and producers stay in lockstep as epic #116 moves sentinels
-    out of ``value``. (The header_classifier empty-input fallback knows each
-    field's status directly, so it sets ``status`` explicitly rather than deriving.)
+    NOT_CLASSIFIED, any real value → CLASSIFIED. Used by the read side
+    (``_entry_status``) and by ``build_field_entry`` when a producer carries the
+    sentinel in ``value`` and no explicit status is given, so reader and producers
+    stay in lockstep as epic #116 moves sentinels out of ``value``.
     """
     if value == NOT_APPLICABLE:
         return NOT_APPLICABLE
     if value is None or value == NOT_CLASSIFIED:
         return NOT_CLASSIFIED
     return CLASSIFIED
+
+
+def build_field_entry(value, status=None, confidence=0.0, evidence=None) -> dict:
+    """Build a serialized per-field classification entry.
+
+    The single place that assembles the ``{value, status, confidence, evidence}``
+    output shape and enforces epic #116's Stage 3 invariant: sentinels live only
+    in ``status`` and ``value`` is ``None`` unless the field is CLASSIFIED. Every
+    producer (rule_engine's ``to_output_dict``, the index-propagation script, the
+    header_classifier empty-input fallback) goes through here, so the invariant is
+    defined once and the read-side guard (``_entry_status``) never sees an
+    incoherent entry.
+
+    ``status`` defaults to ``status_for_value(value)`` for producers that still
+    carry the sentinel in ``value``; pass it explicitly when the status is known
+    directly.
+    """
+    if status is None:
+        status = status_for_value(value)
+    return {
+        "value": value if status == CLASSIFIED else None,
+        "status": status,
+        "confidence": confidence,
+        "evidence": evidence if evidence is not None else [],
+    }
 
 
 def _entry_status(entry) -> str:

--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -63,8 +63,9 @@ def build_field_entry(value, status=None, confidence=0.0, evidence=None) -> dict
     in ``status`` and ``value`` is ``None`` unless the field is CLASSIFIED. Every
     producer (rule_engine's ``to_output_dict``, the index-propagation script, the
     header_classifier empty-input fallback) goes through here, so the invariant is
-    defined once and the read-side guard (``_entry_status``) never sees an
-    incoherent entry.
+    defined once. A non-CLASSIFIED status nulls ``value``; a CLASSIFIED status
+    with no value raises ValueError — either way the entry is coherent, so the
+    read-side guard (``_entry_status``) is never handed a contradictory shape.
 
     ``status`` defaults to ``status_for_value(value)`` for producers that still
     carry the sentinel in ``value``; pass it explicitly when the status is known
@@ -72,6 +73,8 @@ def build_field_entry(value, status=None, confidence=0.0, evidence=None) -> dict
     """
     if status is None:
         status = status_for_value(value)
+    if status == CLASSIFIED and value is None:
+        raise ValueError("cannot build a CLASSIFIED field entry with value=None")
     return {
         "value": value if status == CLASSIFIED else None,
         "status": status,

--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -63,18 +63,25 @@ def build_field_entry(value, status=None, confidence=0.0, evidence=None) -> dict
     in ``status`` and ``value`` is ``None`` unless the field is CLASSIFIED. Every
     producer (rule_engine's ``to_output_dict``, the index-propagation script, the
     header_classifier empty-input fallback) goes through here, so the invariant is
-    defined once. A non-CLASSIFIED status nulls ``value``; a CLASSIFIED status
-    with no value raises ValueError — either way the entry is coherent, so the
-    read-side guard (``_entry_status``) is never handed a contradictory shape.
+    defined once. When an explicit ``status`` is passed it must be coherent with
+    ``value``: a CLASSIFIED status requires a real value, and a non-CLASSIFIED
+    status must not carry one (a sentinel or ``None`` is fine) — either mismatch
+    raises ValueError rather than smuggling a sentinel into ``value`` or silently
+    dropping a real value. So the entry is always coherent and the read-side guard
+    (``_entry_status``) is never handed a contradictory shape.
 
     ``status`` defaults to ``status_for_value(value)`` for producers that still
     carry the sentinel in ``value``; pass it explicitly when the status is known
-    directly.
+    directly. The derived path is coherent by construction and never raises.
     """
     if status is None:
         status = status_for_value(value)
-    if status == CLASSIFIED and value is None:
-        raise ValueError("cannot build a CLASSIFIED field entry with value=None")
+    # "real value" = a value that classifies (not None, not a sentinel string).
+    value_is_real = status_for_value(value) == CLASSIFIED
+    if status == CLASSIFIED and not value_is_real:
+        raise ValueError(f"CLASSIFIED field entry needs a real value, got {value!r}")
+    if status != CLASSIFIED and value_is_real:
+        raise ValueError(f"{status!r} field entry must not carry a real value, got {value!r}")
     return {
         "value": value if status == CLASSIFIED else None,
         "status": status,

--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -55,6 +55,25 @@ def status_for_value(value) -> str:
     return CLASSIFIED
 
 
+def _assert_coherent(value, status) -> None:
+    """Raise ValueError if (value, status) contradict epic #116's Stage 3 contract.
+
+    The single definition of entry coherence: a CLASSIFIED field must carry a real
+    value (not None, not a sentinel string), and a non-CLASSIFIED status must not
+    carry one. Enforced on both sides — when building output (``build_field_entry``)
+    and when reading an explicit status (``_entry_status``) — so a sentinel can
+    never be smuggled into ``value`` under a classified status, or a real value be
+    dropped under a non-classified status, from either direction.
+    """
+    value_is_real = status_for_value(value) == CLASSIFIED
+    if status == CLASSIFIED and not value_is_real:
+        raise ValueError(
+            f"incoherent entry: CLASSIFIED status requires a real value, got {value!r}")
+    if status != CLASSIFIED and value_is_real:
+        raise ValueError(
+            f"incoherent entry: {status!r} status must not carry a real value, got {value!r}")
+
+
 def build_field_entry(value, status=None, confidence=0.0, evidence=None) -> dict:
     """Build a serialized per-field classification entry.
 
@@ -76,12 +95,7 @@ def build_field_entry(value, status=None, confidence=0.0, evidence=None) -> dict
     """
     if status is None:
         status = status_for_value(value)
-    # "real value" = a value that classifies (not None, not a sentinel string).
-    value_is_real = status_for_value(value) == CLASSIFIED
-    if status == CLASSIFIED and not value_is_real:
-        raise ValueError(f"CLASSIFIED field entry needs a real value, got {value!r}")
-    if status != CLASSIFIED and value_is_real:
-        raise ValueError(f"{status!r} field entry must not carry a real value, got {value!r}")
+    _assert_coherent(value, status)
     return {
         "value": value if status == CLASSIFIED else None,
         "status": status,
@@ -93,20 +107,19 @@ def build_field_entry(value, status=None, confidence=0.0, evidence=None) -> dict
 def _entry_status(entry) -> str:
     """Status from a per-field entry: explicit ``status`` if set, else derived.
 
-    Raises ValueError on an incoherent entry — an explicit ``status == classified``
-    with a null ``value``. Epic #116's Stage 3 invariant is that a classified field
-    carries a real value; this is the loud-failure counterpart to the declined
-    field_label None-guard (#129): reject the self-contradictory shape rather than
-    fabricating a ``None`` bucket label from it. Both field_status and field_label
-    route through here, so both fail loudly instead of silently mis-reading.
+    When the entry carries an explicit ``status``, it is validated against ``value``
+    via ``_assert_coherent`` — an incoherent pairing (CLASSIFIED without a real
+    value, or a non-CLASSIFIED status carrying a real value) raises ValueError.
+    Epic #116's Stage 3 invariant is that sentinels live only in ``status``; this
+    is the loud-failure counterpart to the declined field_label None-guard (#129):
+    reject the self-contradictory shape rather than fabricating a bucket label from
+    it. Both field_status and field_label route through here, so both fail loudly
+    instead of silently mis-reading a smuggled sentinel as a classified value.
     """
     if isinstance(entry, dict):
         status = entry.get("status")
         if status is not None:
-            if status == CLASSIFIED and entry.get("value") is None:
-                raise ValueError(
-                    f"incoherent classification entry: status=classified but value is None ({entry!r})"
-                )
+            _assert_coherent(entry.get("value"), status)
             return status
         value = entry.get("value")
     else:

--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -43,12 +43,12 @@ def status_for_value(value) -> str:
 
     The one place that maps a sentinel-carrying ``value`` to a status string:
     ``not_applicable`` → NOT_APPLICABLE, ``None``/``not_classified`` →
-    NOT_CLASSIFIED, any real value → CLASSIFIED. The read side
-    (``_entry_status``) and every producer that dual-writes ``status`` in epic
-    #116 Stage 2 — rule_engine's ``to_output_dict`` plus the header_classifier
-    empty-input fallback and the index-propagation script — go through this, so
-    reader and producers stay in lockstep as the migration moves sentinels out of
-    ``value``.
+    NOT_CLASSIFIED, any real value → CLASSIFIED. The read side (``_entry_status``)
+    and the producers that derive status from a sentinel-carrying value —
+    rule_engine's ``to_output_dict`` and the index-propagation script — go through
+    this, so reader and producers stay in lockstep as epic #116 moves sentinels
+    out of ``value``. (The header_classifier empty-input fallback knows each
+    field's status directly, so it sets ``status`` explicitly rather than deriving.)
     """
     if value == NOT_APPLICABLE:
         return NOT_APPLICABLE

--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -58,10 +58,23 @@ def status_for_value(value) -> str:
 
 
 def _entry_status(entry) -> str:
-    """Status from a per-field entry: explicit ``status`` if set, else derived."""
+    """Status from a per-field entry: explicit ``status`` if set, else derived.
+
+    Raises ValueError on an incoherent entry — an explicit ``status == classified``
+    with a null ``value``. Epic #116's Stage 3 invariant is that a classified field
+    carries a real value; this is the loud-failure counterpart to the declined
+    field_label None-guard (#129): reject the self-contradictory shape rather than
+    fabricating a ``None`` bucket label from it. Both field_status and field_label
+    route through here, so both fail loudly instead of silently mis-reading.
+    """
     if isinstance(entry, dict):
-        if entry.get("status") is not None:
-            return entry["status"]
+        status = entry.get("status")
+        if status is not None:
+            if status == CLASSIFIED and entry.get("value") is None:
+                raise ValueError(
+                    f"incoherent classification entry: status=classified but value is None ({entry!r})"
+                )
+            return status
         value = entry.get("value")
     else:
         value = entry

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -7,12 +7,11 @@ from typing import Any
 
 from .models import (
     CLASSIFICATION_FIELDS,
-    CLASSIFIED,
     NOT_APPLICABLE,
     NOT_CLASSIFIED,
     ClassificationResult,
     FileInfo,
-    status_for_value,
+    build_field_entry,
 )
 from .rule_loader import UnifiedRule, get_unified_rules
 
@@ -117,29 +116,20 @@ class ExtendedClassificationResult:
     def to_output_dict(self) -> dict:
         """Convert to the per-field output format.
 
-        Each dimension emits ``{value, status, confidence, evidence}``. Epic #116
-        Stage 3 completes the sentinel→status split: ``status`` carries
-        ``not_applicable`` / ``not_classified`` (derived from the internal
-        sentinel-carrying attribute via ``status_for_value``), and ``value`` is
-        ``None`` unless the field is CLASSIFIED — sentinels no longer live in
-        ``value``. The internal attribute (``getattr(self, fld)``) still holds the
-        sentinel; only the serialized output is nulled. Readers are unaffected
-        (they read ``status`` via models.field_status); the sibling hand-built
-        producers — the fastq empty-input fallback and index propagation — mirror
-        this shape.
+        Each dimension emits ``{value, status, confidence, evidence}`` via
+        ``models.build_field_entry``, which applies epic #116's Stage 3 invariant:
+        ``status`` carries ``not_applicable`` / ``not_classified`` and ``value`` is
+        ``None`` unless the field is CLASSIFIED. The internal attribute
+        (``getattr(self, fld)``) still holds the sentinel; only the serialized
+        output is nulled. Readers are unaffected (they read ``status`` via
+        models.field_status).
         """
         classifications = {}
         for fld in self._CLASSIFICATION_FIELDS:
             value = getattr(self, fld)
-            status = status_for_value(value)
             evidence = self.field_evidence.get(fld, [])
             fld_conf = max((e.get("confidence", 0) for e in evidence), default=0.0)
-            classifications[fld] = {
-                "value": value if status == CLASSIFIED else None,
-                "status": status,
-                "confidence": fld_conf,
-                "evidence": evidence,
-            }
+            classifications[fld] = build_field_entry(value, confidence=fld_conf, evidence=evidence)
         return classifications
 
     # Classification field names (single source of truth: models.CLASSIFICATION_FIELDS)

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from .models import (
     CLASSIFICATION_FIELDS,
+    CLASSIFIED,
     NOT_APPLICABLE,
     NOT_CLASSIFIED,
     ClassificationResult,
@@ -117,21 +118,25 @@ class ExtendedClassificationResult:
         """Convert to the per-field output format.
 
         Each dimension emits ``{value, status, confidence, evidence}``. Epic #116
-        Stage 2 dual-writes ``status`` (derived from the sentinel-carrying
-        ``value`` via ``status_for_value``) additively — ``value`` still holds the
-        sentinel this stage; Stage 3 nulls it out. Readers are unaffected (they
-        already prefer an explicit ``status`` via models.field_status); the sibling
-        hand-built entry producers — the fastq empty-input fallback and index
-        propagation — dual-write ``status`` through the same helper to match.
+        Stage 3 completes the sentinel→status split: ``status`` carries
+        ``not_applicable`` / ``not_classified`` (derived from the internal
+        sentinel-carrying attribute via ``status_for_value``), and ``value`` is
+        ``None`` unless the field is CLASSIFIED — sentinels no longer live in
+        ``value``. The internal attribute (``getattr(self, fld)``) still holds the
+        sentinel; only the serialized output is nulled. Readers are unaffected
+        (they read ``status`` via models.field_status); the sibling hand-built
+        producers — the fastq empty-input fallback and index propagation — mirror
+        this shape.
         """
         classifications = {}
         for fld in self._CLASSIFICATION_FIELDS:
             value = getattr(self, fld)
+            status = status_for_value(value)
             evidence = self.field_evidence.get(fld, [])
             fld_conf = max((e.get("confidence", 0) for e in evidence), default=0.0)
             classifications[fld] = {
-                "value": value,
-                "status": status_for_value(value),
+                "value": value if status == CLASSIFIED else None,
+                "status": status,
                 "confidence": fld_conf,
                 "evidence": evidence,
             }

--- a/src/meta_disco/schema_vocab.py
+++ b/src/meta_disco/schema_vocab.py
@@ -25,6 +25,10 @@ SENTINEL_VALUES = frozenset({NOT_APPLICABLE, NOT_CLASSIFIED})
 # this derives from the single source of truth rather than re-listing the fields.
 DIMENSION_ENUMS = {field: f"{field}_enum" for field in CLASSIFICATION_FIELDS}
 
+# The enum defining the permissible per-field ``status`` values (epic #116's
+# sentinel→status split): classified / not_applicable / not_classified / conflict.
+STATUS_ENUM = "classification_status_enum"
+
 # ``when`` condition keys whose value must be a member of a dimension enum,
 # mapped to that dimension. The rule engine compares these against enum values at
 # match time, so a typo'd value silently never matches rather than erroring — the
@@ -94,6 +98,22 @@ def dimension_values(field: str) -> frozenset[str]:
             f"for dimension {field!r}"
         )
     return enums[enum_name]
+
+
+def status_values() -> frozenset[str]:
+    """Return the permissible per-field ``status`` values from the schema.
+
+    The single source of truth for the status vocabulary (classified /
+    not_applicable / not_classified / conflict), mirroring dimension_values for
+    the ``status`` field the sentinel→status migration adds (epic #116). Raises
+    KeyError (with the schema path) if the schema is missing the status enum.
+    """
+    enums = _load_enums()
+    if STATUS_ENUM not in enums:
+        raise KeyError(
+            f"Schema at {default_schema_path()} is missing enum {STATUS_ENUM!r}"
+        )
+    return enums[STATUS_ENUM]
 
 
 def value_in_vocabulary(field: str, value: object) -> bool:

--- a/tests/fixtures/golden/expected_output.json
+++ b/tests/fixtures/golden/expected_output.json
@@ -14,7 +14,7 @@
               }
             ],
             "status": "not_classified",
-            "value": "not_classified"
+            "value": null
           },
           "data_modality": {
             "confidence": 0.0,
@@ -27,7 +27,7 @@
               }
             ],
             "status": "not_classified",
-            "value": "not_classified"
+            "value": null
           },
           "data_type": {
             "confidence": 0.0,
@@ -40,7 +40,7 @@
               }
             ],
             "status": "not_classified",
-            "value": "not_classified"
+            "value": null
           },
           "platform": {
             "confidence": 0.0,
@@ -53,7 +53,7 @@
               }
             ],
             "status": "not_classified",
-            "value": "not_classified"
+            "value": null
           },
           "reference_assembly": {
             "confidence": 0.9,
@@ -67,7 +67,7 @@
               }
             ],
             "status": "not_applicable",
-            "value": "not_applicable"
+            "value": null
           }
         },
         "dataset_title": "GOLDEN_FIXTURE",
@@ -103,7 +103,7 @@
               }
             ],
             "status": "not_applicable",
-            "value": "not_applicable"
+            "value": null
           },
           "data_modality": {
             "confidence": 0.8,
@@ -166,7 +166,7 @@
               }
             ],
             "status": "not_applicable",
-            "value": "not_applicable"
+            "value": null
           },
           "reference_assembly": {
             "confidence": 0.8,
@@ -187,7 +187,7 @@
               }
             ],
             "status": "not_applicable",
-            "value": "not_applicable"
+            "value": null
           }
         },
         "dataset_title": "GOLDEN_FIXTURE",
@@ -224,7 +224,7 @@
               }
             ],
             "status": "not_classified",
-            "value": "not_classified"
+            "value": null
           },
           "data_modality": {
             "confidence": 0.0,
@@ -238,7 +238,7 @@
               }
             ],
             "status": "not_classified",
-            "value": "not_classified"
+            "value": null
           },
           "data_type": {
             "confidence": 0.5,
@@ -268,7 +268,7 @@
               }
             ],
             "status": "not_classified",
-            "value": "not_classified"
+            "value": null
           },
           "reference_assembly": {
             "confidence": 0.5,
@@ -282,7 +282,7 @@
               }
             ],
             "status": "not_applicable",
-            "value": "not_applicable"
+            "value": null
           }
         },
         "dataset_title": "GOLDEN_FIXTURE",
@@ -317,7 +317,7 @@
               }
             ],
             "status": "not_classified",
-            "value": "not_classified"
+            "value": null
           },
           "data_modality": {
             "confidence": 0.85,
@@ -358,7 +358,7 @@
               }
             ],
             "status": "not_classified",
-            "value": "not_classified"
+            "value": null
           },
           "reference_assembly": {
             "confidence": 0.0,
@@ -371,7 +371,7 @@
               }
             ],
             "status": "not_classified",
-            "value": "not_classified"
+            "value": null
           }
         },
         "dataset_title": "GOLDEN_FIXTURE",

--- a/tests/test_field_accessors.py
+++ b/tests/test_field_accessors.py
@@ -14,6 +14,7 @@ from src.meta_disco.models import (
     CLASSIFIED,
     NOT_APPLICABLE,
     NOT_CLASSIFIED,
+    build_field_entry,
     field_label,
     field_status,
     field_value,
@@ -182,3 +183,37 @@ class TestCoherenceGuard:
         # No explicit status (old on-disk shape) → derive; never triggers the guard.
         rec = _wrapped("reference_assembly", {"value": NOT_APPLICABLE})
         assert field_status(rec, "reference_assembly") == NOT_APPLICABLE
+
+
+# --- build_field_entry: the single producer shape/invariant --------------------
+
+class TestBuildFieldEntry:
+    def test_classified_keeps_value(self):
+        e = build_field_entry("genomic", confidence=0.9, evidence=[{"x": 1}])
+        assert e == {"value": "genomic", "status": CLASSIFIED,
+                     "confidence": 0.9, "evidence": [{"x": 1}]}
+
+    def test_derived_sentinel_nulls_value(self):
+        # Sentinel-carrying value with no explicit status → status derived, value nulled.
+        assert build_field_entry(NOT_APPLICABLE)["value"] is None
+        assert build_field_entry(NOT_APPLICABLE)["status"] == NOT_APPLICABLE
+        assert build_field_entry(None)["status"] == NOT_CLASSIFIED
+
+    def test_explicit_status_nulls_value_when_unclassified(self):
+        e = build_field_entry(None, status=NOT_APPLICABLE)
+        assert (e["value"], e["status"]) == (None, NOT_APPLICABLE)
+
+    def test_explicit_classified_with_value(self):
+        e = build_field_entry("reads", status=CLASSIFIED)
+        assert (e["value"], e["status"]) == ("reads", CLASSIFIED)
+
+    def test_evidence_defaults_to_fresh_list(self):
+        a = build_field_entry(None)
+        b = build_field_entry(None)
+        assert a["evidence"] == [] and a["evidence"] is not b["evidence"]
+
+    def test_classified_without_value_raises(self):
+        # Self-guard: build_field_entry never emits the incoherent shape the
+        # read-side guard would reject (#129).
+        with pytest.raises(ValueError, match="CLASSIFIED"):
+            build_field_entry(None, status=CLASSIFIED)

--- a/tests/test_field_accessors.py
+++ b/tests/test_field_accessors.py
@@ -217,3 +217,15 @@ class TestBuildFieldEntry:
         # read-side guard would reject (#129).
         with pytest.raises(ValueError, match="CLASSIFIED"):
             build_field_entry(None, status=CLASSIFIED)
+
+    def test_classified_with_sentinel_value_raises(self):
+        # Explicit CLASSIFIED + a sentinel value would smuggle the sentinel back
+        # into `value`; reject it.
+        with pytest.raises(ValueError, match="real value"):
+            build_field_entry(NOT_APPLICABLE, status=CLASSIFIED)
+
+    def test_unclassified_status_with_real_value_raises(self):
+        # A real value under a non-CLASSIFIED status would be silently dropped;
+        # reject the contradiction instead.
+        with pytest.raises(ValueError, match="must not carry a real value"):
+            build_field_entry("genomic", status=NOT_CLASSIFIED)

--- a/tests/test_field_accessors.py
+++ b/tests/test_field_accessors.py
@@ -149,3 +149,36 @@ def test_accessor_consistency_today(value, exp_status, exp_label):
     assert field_value(rec, "data_modality") == value
     assert field_status(rec, "data_modality") == exp_status
     assert field_label(rec, "data_modality") == exp_label
+
+
+# --- coherence guard (#129): reject status=classified with a null value --------
+
+class TestCoherenceGuard:
+    def test_field_status_raises_on_classified_none(self):
+        rec = _wrapped("data_modality", {"value": None, "status": CLASSIFIED})
+        with pytest.raises(ValueError, match="incoherent"):
+            field_status(rec, "data_modality")
+
+    def test_field_label_raises_on_classified_none(self):
+        # The declined None-guard, inverted: fail loudly instead of returning a
+        # None bucket label from a self-contradictory entry.
+        rec = _wrapped("data_modality", {"value": None, "status": CLASSIFIED})
+        with pytest.raises(ValueError, match="incoherent"):
+            field_label(rec, "data_modality")
+
+    def test_coherent_classified_does_not_raise(self):
+        rec = _wrapped("data_modality", {"value": "genomic", "status": CLASSIFIED})
+        assert field_status(rec, "data_modality") == CLASSIFIED
+        assert field_label(rec, "data_modality") == "genomic"
+
+    def test_non_classified_status_with_none_value_is_fine(self):
+        # not_applicable / not_classified / conflict with value=None are the
+        # normal Stage 3 shape — only status==classified requires a value.
+        for status in (NOT_APPLICABLE, NOT_CLASSIFIED, "conflict"):
+            rec = _wrapped("reference_assembly", {"value": None, "status": status})
+            assert field_status(rec, "reference_assembly") == status
+
+    def test_legacy_sentinel_in_value_still_reads(self):
+        # No explicit status (old on-disk shape) → derive; never triggers the guard.
+        rec = _wrapped("reference_assembly", {"value": NOT_APPLICABLE})
+        assert field_status(rec, "reference_assembly") == NOT_APPLICABLE

--- a/tests/test_field_accessors.py
+++ b/tests/test_field_accessors.py
@@ -184,6 +184,24 @@ class TestCoherenceGuard:
         rec = _wrapped("reference_assembly", {"value": NOT_APPLICABLE})
         assert field_status(rec, "reference_assembly") == NOT_APPLICABLE
 
+    def test_field_status_raises_on_classified_sentinel_value(self):
+        # A sentinel value under CLASSIFIED would be read as a classified value —
+        # sentinel smuggling on the read side. Reject it (same rule as the producer).
+        rec = _wrapped("reference_assembly", {"value": NOT_APPLICABLE, "status": CLASSIFIED})
+        with pytest.raises(ValueError, match="incoherent"):
+            field_status(rec, "reference_assembly")
+
+    def test_field_status_raises_on_real_value_under_unclassified(self):
+        rec = _wrapped("data_modality", {"value": "genomic", "status": NOT_CLASSIFIED})
+        with pytest.raises(ValueError, match="must not carry a real value"):
+            field_status(rec, "data_modality")
+
+    def test_stage2_transitional_record_still_reads(self):
+        # Stage 2 shape (sentinel in value AND matching non-classified status) is
+        # coherent — value isn't a *real* value, so the guard leaves it alone.
+        rec = _wrapped("reference_assembly", {"value": NOT_APPLICABLE, "status": NOT_APPLICABLE})
+        assert field_status(rec, "reference_assembly") == NOT_APPLICABLE
+
 
 # --- build_field_entry: the single producer shape/invariant --------------------
 

--- a/tests/test_header_classifier.py
+++ b/tests/test_header_classifier.py
@@ -463,11 +463,16 @@ class TestFastqClassification:
         result = classify_from_fastq_header([])
         assert val(result, "platform") is None
         assert val(result, "confidence") == 0.0
-        # The empty-input fallback mirrors to_output_dict's Stage 2 shape (#116):
-        # dimension entries carry a `status` derived from the sentinel value.
+        # The empty-input fallback mirrors to_output_dict's Stage 3 shape (#116):
+        # sentinels live in `status`, `value` is None unless CLASSIFIED.
         assert "status" in result["data_modality"]
         assert field_status(result, "data_modality") == NOT_CLASSIFIED
         assert field_status(result, "data_type") == CLASSIFIED  # value "reads"
+        assert val(result, "data_type") == "reads"
+        # #131: empty reads are still unaligned → reference_assembly not_applicable,
+        # matching the non-empty fastq path (not not_classified).
+        assert field_status(result, "reference_assembly") == NOT_APPLICABLE
+        assert val(result, "reference_assembly") is None
 
     def test_confidence_boost_on_agreement(self):
         """Confidence should increase when all reads agree."""

--- a/tests/test_output_shape.py
+++ b/tests/test_output_shape.py
@@ -47,12 +47,7 @@ import pytest
 
 from src.meta_disco import schema_vocab
 from src.meta_disco.file_types import FILE_TYPE_REGISTRY
-from src.meta_disco.models import (
-    CLASSIFICATION_FIELDS,
-    CLASSIFIED,
-    NOT_APPLICABLE,
-    NOT_CLASSIFIED,
-)
+from src.meta_disco.models import CLASSIFICATION_FIELDS, CLASSIFIED
 from src.meta_disco.pipeline import ClassifyPipeline
 
 FIXTURES = Path(__file__).parent / "fixtures" / "golden"
@@ -196,9 +191,10 @@ def test_output_structural_contract(output):
             entry = classifications[field]
             assert set(entry) == FIELD_KEYS, f"{ftype}.{field}: {set(entry)}"
             assert entry["value"] is None or isinstance(entry["value"], str)
-            # Stage 3 (#116) coherence: sentinels live only in `status`; `value`
-            # is non-null iff the field is CLASSIFIED.
-            assert entry["status"] in (CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED), \
+            # Stage 3 (#116) coherence: status is a schema-defined value (incl.
+            # conflict, #88); sentinels live only in `status`; `value` is non-null
+            # iff the field is CLASSIFIED.
+            assert entry["status"] in schema_vocab.status_values(), \
                 f"{ftype}.{field}: status={entry['status']!r}"
             assert (entry["status"] == CLASSIFIED) == (entry["value"] is not None), \
                 f"{ftype}.{field}: incoherent value={entry['value']!r} status={entry['status']!r}"

--- a/tests/test_output_shape.py
+++ b/tests/test_output_shape.py
@@ -47,7 +47,12 @@ import pytest
 
 from src.meta_disco import schema_vocab
 from src.meta_disco.file_types import FILE_TYPE_REGISTRY
-from src.meta_disco.models import CLASSIFICATION_FIELDS
+from src.meta_disco.models import (
+    CLASSIFICATION_FIELDS,
+    CLASSIFIED,
+    NOT_APPLICABLE,
+    NOT_CLASSIFIED,
+)
 from src.meta_disco.pipeline import ClassifyPipeline
 
 FIXTURES = Path(__file__).parent / "fixtures" / "golden"
@@ -191,6 +196,12 @@ def test_output_structural_contract(output):
             entry = classifications[field]
             assert set(entry) == FIELD_KEYS, f"{ftype}.{field}: {set(entry)}"
             assert entry["value"] is None or isinstance(entry["value"], str)
+            # Stage 3 (#116) coherence: sentinels live only in `status`; `value`
+            # is non-null iff the field is CLASSIFIED.
+            assert entry["status"] in (CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED), \
+                f"{ftype}.{field}: status={entry['status']!r}"
+            assert (entry["status"] == CLASSIFIED) == (entry["value"] is not None), \
+                f"{ftype}.{field}: incoherent value={entry['value']!r} status={entry['status']!r}"
             conf = entry["confidence"]
             assert isinstance(conf, (int, float)) and not isinstance(conf, bool)
             assert isinstance(entry["evidence"], list)

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -600,27 +600,28 @@ class TestSentinelValues:
 
 
 class TestOutputDictStatus:
-    """to_output_dict dual-writes a `status` key alongside `value` (epic #116 Stage 2)."""
+    """to_output_dict splits `status` from `value` (epic #116). Stage 3: sentinels
+    live only in `status`; `value` is None unless the field is CLASSIFIED."""
 
     def test_every_dimension_gets_the_status_key(self, engine):
-        # The Stage 2 shape contract: every dimension entry gains `status`
-        # alongside the existing keys, across a spread of file types.
+        # Every dimension entry carries `status` alongside the existing keys,
+        # across a spread of file types.
         for filename in ("sample_WGS_aligned.bam", "sample.fastq.gz", "plot.png"):
             out = engine.classify_extended(FileInfo(filename=filename)).to_output_dict()
             for fld in CLASSIFICATION_FIELDS:
                 assert set(out[fld]) == {"value", "status", "confidence", "evidence"}
 
     def test_status_pins_each_sentinel_state(self, engine):
-        # Concrete value→status outcomes, asserted independently of status_for_value:
-        # a real value classifies, and each sentinel keeps its own status this stage.
+        # Stage 3 shape: a real value classifies (value kept); each sentinel lives
+        # in `status` with `value` nulled out — no sentinels in `value`.
         classified = engine.classify_extended(
             FileInfo(filename="sample_WGS_aligned.bam")).to_output_dict()["data_modality"]
         assert (classified["value"], classified["status"]) == ("genomic", CLASSIFIED)
 
         n_a = engine.classify_extended(
             FileInfo(filename="plot.png")).to_output_dict()["reference_assembly"]
-        assert (n_a["value"], n_a["status"]) == (NOT_APPLICABLE, NOT_APPLICABLE)
+        assert (n_a["value"], n_a["status"]) == (None, NOT_APPLICABLE)
 
         n_c = engine.classify_extended(
             ExtendedFileInfo(filename="sample.bam", file_size_gb=60.0)).to_output_dict()["data_modality"]
-        assert (n_c["value"], n_c["status"]) == (NOT_CLASSIFIED, NOT_CLASSIFIED)
+        assert (n_c["value"], n_c["status"]) == (None, NOT_CLASSIFIED)

--- a/tests/test_rule_vocabulary.py
+++ b/tests/test_rule_vocabulary.py
@@ -213,6 +213,14 @@ def test_dimension_values_unknown_field_raises_clear_error():
         schema_vocab.dimension_values("not_a_field")
 
 
+def test_status_values_from_schema():
+    # The permissible per-field `status` values, loaded from the schema enum —
+    # incl. `conflict` (#88), which is not yet produced but is a valid status.
+    assert schema_vocab.status_values() == frozenset(
+        {"classified", "not_applicable", "not_classified", "conflict"}
+    )
+
+
 def _write_rules_file(tmp_path, rule):
     """Write a minimal two-document rules file containing a single rule."""
     path = tmp_path / "rules.yaml"


### PR DESCRIPTION
## Stage 3 of the sentinel→status migration (epic #116)

Closes #121. Also closes #127, #129, #131.

The **contract** step: `value` now carries only real classifications; the `not_applicable` / `not_classified` sentinels live solely in `status`. `value` is `None` unless `status == classified`.

### What changed

- **Producers null the value** unless classified — centralized in a new `models.build_field_entry(value, status=None, confidence, evidence)`, the single place that assembles the `{value, status, confidence, evidence}` shape and enforces the invariant. `to_output_dict`, the index-propagation script, and the fastq empty-input fallback all route through it. Internal `ClassificationResult` attributes still hold sentinels; only the serialized output is nulled.
- **No consumer changes.** Verified every direct `["value"]` read in `src/` is on internal claim/evidence/result structures (which keep sentinels); output `value` is read only via the accessors, which read `status` since Stage 2. A cross-file trace over all report/aggregation/serialization sites found zero breakage.
- **Golden**: exactly 15 unclassified fields flip `value` sentinel → `null` (5 not_applicable + 10 not_classified); `status` unchanged, nothing else. The structural-contract test now enforces coherence (`value` non-null iff `status == classified`).

### Folded-in follow-ups

- **#129 (coherence)** — `_entry_status` (behind `field_status` + `field_label`) raises on the self-contradictory `status=classified, value=None` shape rather than fabricating a `None` bucket label. `build_field_entry` self-guards symmetrically, so producers can't emit that shape either.
- **#131** — the empty-input fastq fallback now classifies `reference_assembly` as `not_applicable` (unaligned reads), matching the non-empty path (was `not_classified`).
- **#127** — the report coverage counts over-counted sentinels as classified in Stage 1b; now that unclassified `value` is `None` (falsy), the `field_value`-based counts self-correct — no logic change, comment updated.

### Tests

424 pass; ruff clean. New `TestBuildFieldEntry` (builder shape + self-guard) and `TestCoherenceGuard` (read-side raise/non-raise); producer + empty-input + index-propagation tests updated to the Stage 3 shape.

### Acceptance (#121)
- [x] `value` is null unless `status == classified`
- [x] No `scripts/`/`src/` consumer changes needed
- [x] Golden reflects intended change; value-vocabulary check passes (null skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
