### PR TITLE
Rules author not_applicable/not_classified via then.status, not values (#133)

### DIFF
--- a/rules/unified_rules.yaml
+++ b/rules/unified_rules.yaml
@@ -250,10 +250,11 @@ rules:
     when:
       extensions: [".bai", ".crai", ".tbi", ".csi", ".fai", ".idx", ".pbi"]
     then:
-      data_modality: not_applicable
-      data_type: not_applicable
-      assay_type: not_applicable
-      platform: not_applicable
+      status:
+        data_modality: not_applicable
+        data_type: not_applicable
+        assay_type: not_applicable
+        platform: not_applicable
     confidence: 1.0
     rationale: "Index file — metadata inherited from parent data file"
 
@@ -266,11 +267,12 @@ rules:
     when:
       extensions: [".md5"]
     then:
-      data_modality: not_applicable
-      data_type: not_applicable
-      reference_assembly: not_applicable
-      assay_type: not_applicable
-      platform: not_applicable
+      status:
+        data_modality: not_applicable
+        data_type: not_applicable
+        reference_assembly: not_applicable
+        assay_type: not_applicable
+        platform: not_applicable
     confidence: 1.0
     rationale: "Checksum file — not data"
 
@@ -283,11 +285,12 @@ rules:
     when:
       extensions: [".log"]
     then:
-      data_modality: not_applicable
-      data_type: not_applicable
-      reference_assembly: not_applicable
-      assay_type: not_applicable
-      platform: not_applicable
+      status:
+        data_modality: not_applicable
+        data_type: not_applicable
+        reference_assembly: not_applicable
+        assay_type: not_applicable
+        platform: not_applicable
     confidence: 1.0
     rationale: "Log file — not data"
 
@@ -300,11 +303,12 @@ rules:
     when:
       filename_pattern: "gs-chunked-io-part\\.\\d+"
     then:
-      data_modality: not_applicable
-      data_type: not_applicable
-      reference_assembly: not_applicable
-      assay_type: not_applicable
-      platform: not_applicable
+      status:
+        data_modality: not_applicable
+        data_type: not_applicable
+        reference_assembly: not_applicable
+        assay_type: not_applicable
+        platform: not_applicable
     confidence: 1.0
     rationale: "Incomplete chunked upload artifact — not usable data"
 
@@ -317,11 +321,12 @@ rules:
     when:
       filename_pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{6}\\.\\d+Z$"
     then:
-      data_modality: not_applicable
-      data_type: not_applicable
-      reference_assembly: not_applicable
-      assay_type: not_applicable
-      platform: not_applicable
+      status:
+        data_modality: not_applicable
+        data_type: not_applicable
+        reference_assembly: not_applicable
+        assay_type: not_applicable
+        platform: not_applicable
     confidence: 1.0
     rationale: "Bare ISO timestamp filename — metadata artifact, not data"
 
@@ -394,8 +399,9 @@ rules:
       data_modality: imaging.histology
       data_type: images
       assay_type: Histology
-      platform: not_applicable
-      reference_assembly: not_applicable
+      status:
+        platform: not_applicable
+        reference_assembly: not_applicable
     confidence: 0.95
     rationale: "SVS files are Aperio whole-slide histology images used for pathology analysis"
 
@@ -408,11 +414,12 @@ rules:
     when:
       extensions: [".png", ".jpg", ".tiff", ".tif"]
     then:
-      data_modality: not_applicable
       data_type: images
-      platform: not_applicable
-      reference_assembly: not_applicable
-      assay_type: not_applicable
+      status:
+        data_modality: not_applicable
+        platform: not_applicable
+        reference_assembly: not_applicable
+        assay_type: not_applicable
     confidence: 0.90
     rationale: "Image files are derived visualizations (QC plots, assembly graphs) — not primary experimental data"
 
@@ -427,7 +434,8 @@ rules:
     then:
       data_type: raw_signal
       platform: ONT
-      reference_assembly: not_applicable
+      status:
+        reference_assembly: not_applicable
     confidence: 0.90
     rationale: "FAST5 files contain raw Oxford Nanopore electrical signal data. Reference not applicable until basecalling/alignment"
 
@@ -439,7 +447,8 @@ rules:
     then:
       data_type: raw_signal
       platform: ONT
-      reference_assembly: not_applicable
+      status:
+        reference_assembly: not_applicable
     confidence: 0.90
     rationale: "POD5 files contain raw Oxford Nanopore electrical signal data (newer format replacing FAST5)"
 
@@ -453,7 +462,8 @@ rules:
       extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
     then:
       data_type: reads
-      reference_assembly: not_applicable
+      status:
+        reference_assembly: not_applicable
     confidence: 0.50
     rationale: "FASTQ files contain raw sequencing reads. Reference not applicable until alignment"
 
@@ -467,8 +477,9 @@ rules:
       extensions: [".fasta", ".fa", ".fasta.gz", ".fa.gz"]
     then:
       data_type: sequence
-      platform: not_applicable
-      assay_type: not_applicable
+      status:
+        platform: not_applicable
+        assay_type: not_applicable
     confidence: 0.30
     rationale: "FASTA file detected; header inspection needed to determine if de novo assembly, reference genome, or transcript sequences"
 
@@ -710,7 +721,8 @@ rules:
     then:
       data_modality: genomic
       data_type: assembly
-      reference_assembly: not_applicable
+      status:
+        reference_assembly: not_applicable
     confidence: 0.80
     rationale: "Filename contains assembly/assembler indicator — de novo assembly"
 
@@ -723,7 +735,8 @@ rules:
     then:
       data_modality: genomic
       data_type: assembly
-      reference_assembly: not_applicable
+      status:
+        reference_assembly: not_applicable
     confidence: 0.80
     rationale: "Filename contains haplotype/phasing indicator — de novo assembly"
 
@@ -901,10 +914,11 @@ rules:
       extensions: [".bed", ".bed.gz"]
       filename_pattern: "(?i)targets?|regions?|capture|exome"
     then:
-      data_modality: not_applicable
-      data_type: not_applicable
-      assay_type: not_applicable
-      platform: not_applicable
+      status:
+        data_modality: not_applicable
+        data_type: not_applicable
+        assay_type: not_applicable
+        platform: not_applicable
     confidence: 0.85
     rationale: "Target/capture region file — reference data, not primary experimental data"
 
@@ -934,10 +948,11 @@ rules:
       extensions: [".txt", ".tsv"]
       filename_pattern: "(?i)\\.stats\\.txt$|samtools\\.stats|mosdepth|flagstat"
     then:
-      data_modality: not_applicable
-      data_type: not_applicable
-      assay_type: not_applicable
-      platform: not_applicable
+      status:
+        data_modality: not_applicable
+        data_type: not_applicable
+        assay_type: not_applicable
+        platform: not_applicable
     confidence: 0.90
     rationale: "QC/stats file — supplementary data, not primary experimental data"
 
@@ -1323,7 +1338,8 @@ rules:
       header_section: "@SQ"
       header_absent: true
     then:
-      reference_assembly: not_applicable
+      status:
+        reference_assembly: not_applicable
     confidence: 0.90
     rationale: "Absence of @SQ lines indicates unaligned reads. Common for PacBio HiFi deliverables before alignment"
 
@@ -1993,7 +2009,8 @@ rules:
       extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
       modality_not_set: true
     then:
-      data_modality: not_classified
+      status:
+        data_modality: not_classified
     confidence: 0.0
     rationale: "FASTQ modality cannot be determined from reads alone — could be genomic, transcriptomic, or epigenomic depending on assay"
 

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -534,11 +534,18 @@ class RuleEngine:
     ) -> None:
         """Collect claims from a rule without setting classification fields.
 
-        Claims are appended to field_evidence. Evaluation happens
-        later in _finalize_result via evaluate_claims().
+        A rule authors each field either as a real value (``then``) or as a
+        non-classified status (``then.status`` → ``rule.then_status``); the loader
+        guarantees never both. Both become a claim appended to field_evidence;
+        evaluation happens later in _finalize_result via evaluate_claims(). A
+        status is still carried internally as a sentinel string in the claim's
+        ``value`` so claim evaluation, the result attributes and the evidence
+        output are unchanged from the pre-#133 sentinel-as-value behavior — the
+        internal sentinel→status cleanup is deferred (see issue #136).
         Also updates result.confidence (running max, not a classification field).
         """
         then = rule.then
+        then_status = rule.then_status
         evidence_entry = {
             "rule_id": rule.id,
             "reason": rule.rationale or "",
@@ -546,9 +553,15 @@ class RuleEngine:
             "tier": rule.tier,
         }
         for fld in result._CLASSIFICATION_FIELDS:
-            if fld in then and then[fld] is not None:
+            # A field is authored as a real value (`then`) or a status
+            # (`then.status`), never both; most rules author no status, so only
+            # consult then_status when the rule has one.
+            claim_value = then.get(fld)
+            if claim_value is None and then_status:
+                claim_value = then_status.get(fld)
+            if claim_value is not None:
                 entry = evidence_entry.copy()
-                entry["value"] = then[fld]
+                entry["value"] = claim_value
                 result.field_evidence[fld].append(entry)
 
         # Update overall confidence (take highest confidence from matching rules)

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -1,17 +1,24 @@
 """Loader for unified classification rules from YAML."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import yaml
 
-from .models import CLASSIFICATION_FIELDS
+from .models import CLASSIFICATION_FIELDS, NOT_APPLICABLE, NOT_CLASSIFIED
 
 
 @dataclass
 class UnifiedRule:
-    """A unified classification rule."""
+    """A unified classification rule.
+
+    ``then`` holds only real dimension values ({field: value}). A field a rule
+    declares non-classified is authored in the ``then.status`` sub-map instead and
+    parsed into ``then_status`` ({field: status}); the two never share a field. So
+    a sentinel (``not_applicable`` / ``not_classified``) is never written into a
+    value slot — see epic #116 / issue #133.
+    """
 
     id: str
     tier: int
@@ -20,6 +27,7 @@ class UnifiedRule:
     then: dict[str, Any]
     confidence: float
     rationale: str
+    then_status: dict[str, str] = field(default_factory=dict)
     def matches_extension(self, extension: str) -> bool:
         """Check if this rule applies to a given file extension."""
         if "extensions" not in self.when:
@@ -134,9 +142,17 @@ class RuleLoader:
         "header_section", "header_field", "header_pattern", "header_absent",
         "vcf_header_type", "vcf_pattern", "fastq_pattern",
     }
-    # Effect keys (classification fields) that _apply_rule() reads. A key not
-    # listed here would never be applied, so it is treated as an error.
-    VALID_THEN_KEYS = set(CLASSIFICATION_FIELDS)
+    # Effect keys _apply_rule() reads from a `then` block: the classification
+    # fields (real-value effects) plus the reserved `status` key, whose value is a
+    # sub-map of {field: status} for fields a rule declares non-classified (#133).
+    # A key not listed here would never be applied, so it is treated as an error.
+    THEN_STATUS_KEY = "status"
+    VALID_THEN_KEYS = set(CLASSIFICATION_FIELDS) | {THEN_STATUS_KEY}
+
+    # Statuses a rule may author in a `then.status` sub-map. `classified` is
+    # implied by a real value and `conflict` is engine-derived, so neither may be
+    # written by a rule (mirrors schema_vocab's antecedent/emitted split).
+    AUTHORABLE_STATUSES = {NOT_APPLICABLE, NOT_CLASSIFIED}
 
     # assay_type_rules condition keys that infer_assay_type() treats as iterables
     # (`x not in platform_in`, `any(r in ... for r in matched_rules_any)`). A
@@ -224,8 +240,10 @@ class RuleLoader:
 
         Validates each rule's id (present, unique), tier, scope, and the keys
         used in its ``when``/``then`` blocks (against VALID_WHEN_KEYS /
-        VALID_THEN_KEYS). Raises ValueError on any violation. Does not validate
-        ``then`` *values* against the controlled vocabulary — that check lives in
+        VALID_THEN_KEYS), including the ``then.status`` sub-map (fields, authorable
+        statuses, and value/status non-overlap — see ``_parse_then_status``).
+        Raises ValueError on any violation. Does not validate ``then`` *values*
+        against the controlled vocabulary — that check lives in
         tests/test_rule_vocabulary.py, which reads the LinkML schema.
         """
         rules = []
@@ -278,18 +296,61 @@ class RuleLoader:
                     f"Rule {rule_id}: unknown 'then' effect key(s) {sorted(unknown_then)}; "
                     f"valid keys are {sorted(self.VALID_THEN_KEYS)}"
                 )
+            then_values = {k: v for k, v in then.items() if k != self.THEN_STATUS_KEY}
+            then_status = self._parse_then_status(
+                rule_id, then.get(self.THEN_STATUS_KEY), then_values
+            )
 
             rules.append(UnifiedRule(
                 id=rule_id,
                 tier=tier,
                 scope=scope,
                 when=when,
-                then=then,
+                then=then_values,
                 confidence=rule_data.get("confidence", 0.0),
                 rationale=rule_data.get("rationale", ""),
+                then_status=then_status,
             ))
 
         return rules
+
+    def _parse_then_status(
+        self, rule_id: str, raw: Any, then_values: dict[str, Any]
+    ) -> dict[str, str]:
+        """Validate and return a rule's ``then.status`` sub-map ({field: status}).
+
+        ``raw`` is the value of the ``then.status`` key (``None`` if the block has
+        no ``status``). Each key must be a classification field, each value an
+        authorable status (``not_applicable`` / ``not_classified`` — not the
+        implied ``classified`` or engine-derived ``conflict``), and no field may
+        also carry a real value in ``then_values`` (a value-vs-status
+        contradiction). Raises ValueError on any violation.
+        """
+        if raw is None:
+            return {}
+        if not isinstance(raw, dict):
+            raise ValueError(
+                f"Rule {rule_id}: 'then.status' must be a mapping, got {type(raw).__name__}"
+            )
+        unknown_fields = set(raw) - set(CLASSIFICATION_FIELDS)
+        if unknown_fields:
+            raise ValueError(
+                f"Rule {rule_id}: unknown 'then.status' field(s) {sorted(unknown_fields)}; "
+                f"valid fields are {sorted(CLASSIFICATION_FIELDS)}"
+            )
+        bad = sorted(f"{k}={v!r}" for k, v in raw.items() if v not in self.AUTHORABLE_STATUSES)
+        if bad:
+            raise ValueError(
+                f"Rule {rule_id}: 'then.status' values must be one of "
+                f"{sorted(self.AUTHORABLE_STATUSES)}; got {bad}"
+            )
+        conflicting = set(raw) & set(then_values)
+        if conflicting:
+            raise ValueError(
+                f"Rule {rule_id}: field(s) {sorted(conflicting)} appear in both 'then' "
+                f"(as a value) and 'then.status' (as a status) — a field is one or the other"
+            )
+        return dict(raw)
 
     def _parse_validators(self, validators_data: dict) -> dict[str, ValidatorConfig]:
         """Parse validator configurations from YAML."""

--- a/src/meta_disco/schema_vocab.py
+++ b/src/meta_disco/schema_vocab.py
@@ -12,13 +12,7 @@ from pathlib import Path
 
 import yaml
 
-from .models import CLASSIFICATION_FIELDS, NOT_APPLICABLE, NOT_CLASSIFIED
-
-# The two statuses a rule may emit *into a value slot* to mean "no value here"
-# (a real value → classified is implied; conflict is engine-derived, never authored).
-# The emitted-value drift check accepts these alongside real dimension values while
-# rules still author them as `then`-values; #133 removes that, and this with it.
-_EMITTABLE_STATUSES = frozenset({NOT_APPLICABLE, NOT_CLASSIFIED})
+from .models import CLASSIFICATION_FIELDS
 
 # Classification field -> the enum that defines its permissible values. By
 # convention each dimension's enum is named ``<field>_enum`` in the schema, so
@@ -119,13 +113,16 @@ def status_values() -> frozenset[str]:
 def value_in_vocabulary(field: str, value: object) -> bool:
     """True if ``value`` is a permissible *value* for the dimension (strict).
 
-    Membership against the dimension's enum only. This is the check for values
-    that must be real dimension values — the *antecedent* side (``when`` /
-    assay ``conditions``, matched against actual values in the rule engine, where
-    a status is a typo — #115) and *output* values (real-or-null since Stage 3,
-    #116). For values a rule *emits* (``then`` values, inferred ``assay_type``),
-    which may legitimately be a status sentinel, use
-    ``emitted_value_in_vocabulary``.
+    Membership against the dimension's enum only — the single value check for
+    every classification value, on all sides:
+    - *antecedent* values (``when`` / assay ``conditions``, matched against actual
+      values in the rule engine, where a status is a typo — #115),
+    - *emitted* values (``then`` values, inferred ``assay_type``), which since
+      #133 are always real dimension values (a field a rule declares
+      non-classified is authored in ``then.status``, not as a sentinel value), and
+    - *output* values (real-or-null since Stage 3, #116).
+    A status (``not_applicable`` / ``not_classified`` / ``classified`` /
+    ``conflict``) never belongs in a value slot, so it is correctly rejected here.
 
     Permissible values are always strings, so a non-string value (e.g. a list from
     a malformed rule like ``platform: [ILLUMINA, PACBIO]``) is reported as
@@ -134,18 +131,3 @@ def value_in_vocabulary(field: str, value: object) -> bool:
     schema missing the expected enum.
     """
     return isinstance(value, str) and value in dimension_values(field)
-
-
-def emitted_value_in_vocabulary(field: str, value: object) -> bool:
-    """True if ``value`` is valid for a field a rule *emits*: a dimension value or a sentinel.
-
-    Emitted values — ``then`` values and inferred ``assay_type`` — may be a real
-    dimension enum value OR one of the two value-slot sentinels
-    (``not_applicable`` / ``not_classified``) that rules still write to mean "no
-    value here" (see #133 for removing that). ``classified`` / ``conflict`` are
-    *not* accepted — a rule never emits those, so ``then: {platform: classified}``
-    is a typo the drift check should catch. Antecedent and output values are
-    stricter still (dimension only) — see ``value_in_vocabulary``. Non-string
-    values report as not-in-vocabulary.
-    """
-    return isinstance(value, str) and value in (dimension_values(field) | _EMITTABLE_STATUSES)

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -114,6 +114,43 @@ class TestVariantFiles:
         assert result.reference_assembly == "GRCh38"
 
 
+class TestThenStatus:
+    """A rule authoring a non-classified status via `then.status` (#133)."""
+
+    def _engine_with_rule(self, tmp_path, then):
+        import yaml
+        path = tmp_path / "rules.yaml"
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.safe_dump_all([
+                {"extension_map": {".foo": "foo"}},
+                {"rules": [{
+                    "id": "foo_rule", "tier": 1, "scope": "extension",
+                    "when": {"extensions": [".foo"]}, "then": then, "confidence": 1.0,
+                }]},
+            ], f)
+        return RuleEngine(path)
+
+    def test_status_only_field_is_not_applicable(self, tmp_path):
+        engine = self._engine_with_rule(
+            tmp_path, {"status": {"reference_assembly": "not_applicable"}})
+        out = engine.classify_extended(FileInfo(filename="x.foo")).to_output_dict()
+        assert out["reference_assembly"]["status"] == NOT_APPLICABLE
+        assert out["reference_assembly"]["value"] is None
+
+    def test_real_value_and_status_coexist_in_one_rule(self, tmp_path):
+        # The mixed case (e.g. nanopore_fast5): a real value and a status in the
+        # same then-clause resolve independently and correctly.
+        engine = self._engine_with_rule(tmp_path, {
+            "data_type": "raw_signal",
+            "status": {"reference_assembly": "not_applicable"},
+        })
+        out = engine.classify_extended(FileInfo(filename="x.foo")).to_output_dict()
+        assert out["data_type"]["status"] == CLASSIFIED
+        assert out["data_type"]["value"] == "raw_signal"
+        assert out["reference_assembly"]["status"] == NOT_APPLICABLE
+        assert out["reference_assembly"]["value"] is None
+
+
 class TestDerivativeFiles:
     """Test that derivative files (indices, checksums, logs) get not_applicable."""
 

--- a/tests/test_rule_vocabulary.py
+++ b/tests/test_rule_vocabulary.py
@@ -36,19 +36,46 @@ def _when_value_violations(rules):
 
 
 def test_rule_then_values_in_vocabulary():
-    """Every value a rule emits must be in the schema vocabulary (or a sentinel)."""
+    """Every value a rule emits must be a real value in the schema vocabulary.
+
+    Since #133, a field a rule declares non-classified is authored in
+    ``then.status`` (see test_rule_then_status_values_are_schema_statuses), so a
+    ``then``-value is always a real dimension value and the check is strict
+    (``value_in_vocabulary``) — a sentinel in a value slot is now a violation.
+    """
     rules = get_unified_rules()
     violations = []
     for rule in rules.rules:
         for field, value in (rule.then or {}).items():
             if field not in schema_vocab.DIMENSION_ENUMS or value is None:
                 continue
-            if not schema_vocab.emitted_value_in_vocabulary(field, value):
+            if not schema_vocab.value_in_vocabulary(field, value):
                 violations.append(f"{rule.id}: {field}={value!r}")
 
     assert not violations, (
         "Rules emit classification values not in the LinkML schema vocabulary.\n"
         "Add them to classification.yaml or fix the rule:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_rule_then_status_values_are_schema_statuses():
+    """Every ``then.status`` value a rule authors must be a schema status value.
+
+    The status counterpart to test_rule_then_values_in_vocabulary: rules author
+    ``not_applicable`` / ``not_classified`` in ``then.status`` (#133), and those
+    must be members of the schema's classification_status_enum — so the loader's
+    authorable set and the schema stay in lockstep.
+    """
+    statuses = schema_vocab.status_values()
+    violations = [
+        f"{rule.id}: status.{field}={status!r}"
+        for rule in get_unified_rules().rules
+        for field, status in rule.then_status.items()
+        if status not in statuses
+    ]
+    assert not violations, (
+        "Rules author then.status values not in the schema status enum:\n  "
         + "\n  ".join(violations)
     )
 
@@ -90,7 +117,7 @@ def test_assay_type_inference_values_in_vocabulary():
     violations = [
         f"{r.id}: assay_type={r.assay_type!r}"
         for r in rules.assay_type_rules
-        if r.assay_type and not schema_vocab.emitted_value_in_vocabulary("assay_type", r.assay_type)
+        if r.assay_type and not schema_vocab.value_in_vocabulary("assay_type", r.assay_type)
     ]
     assert not violations, (
         "assay_type inference rules emit values not in the schema vocabulary:\n  "
@@ -234,23 +261,11 @@ def test_value_in_vocabulary_rejects_bogus_and_non_string():
     assert not schema_vocab.value_in_vocabulary("platform", ["ILLUMINA", "PACBIO"])
 
 
-def test_emitted_value_in_vocabulary_accepts_dimension_value_or_sentinel():
-    # Emitted (then / assay_type) values may be a real value or a value-slot
-    # sentinel — rules still write `not_applicable` as a then-value (#133).
-    assert schema_vocab.emitted_value_in_vocabulary("reference_assembly", "GRCh38")
-    assert schema_vocab.emitted_value_in_vocabulary("reference_assembly", "not_applicable")
-    assert schema_vocab.emitted_value_in_vocabulary("data_modality", "not_classified")
-
-
-def test_emitted_value_in_vocabulary_rejects_non_value_statuses():
-    # `classified` / `conflict` are never emitted into a value slot — catch the typo.
-    assert not schema_vocab.emitted_value_in_vocabulary("platform", "classified")
-    assert not schema_vocab.emitted_value_in_vocabulary("platform", "conflict")
-
-
-def test_emitted_value_in_vocabulary_rejects_bogus_and_non_string():
-    assert not schema_vocab.emitted_value_in_vocabulary("reference_assembly", "GRCh99")
-    assert not schema_vocab.emitted_value_in_vocabulary("platform", ["ILLUMINA", "PACBIO"])
+def test_value_in_vocabulary_rejects_all_statuses():
+    # A status never belongs in a value slot — the emitted-value check is now
+    # strict too (#133), so then/assay/output values reject every status.
+    for status in ("not_applicable", "not_classified", "classified", "conflict"):
+        assert not schema_vocab.value_in_vocabulary("platform", status)
 
 
 def _write_rules_file(tmp_path, rule):
@@ -278,6 +293,70 @@ def test_loader_rejects_unknown_then_key(tmp_path):
         "then": {"data_modalty": "genomic"},  # typo: should be data_modality
     })
     with pytest.raises(ValueError, match="unknown 'then' effect key"):
+        RuleLoader(path).load()
+
+
+def test_loader_parses_then_status(tmp_path):
+    # A `then.status` sub-map is parsed into `then_status`; `then` keeps only the
+    # real-value effects, with the `status` key stripped out (#133).
+    path = _write_rules_file(tmp_path, {
+        "id": "mixed", "tier": 2, "scope": "extension",
+        "when": {"extensions": [".fast5"]},
+        "then": {
+            "data_type": "raw_signal", "platform": "ONT",
+            "status": {"reference_assembly": "not_applicable"},
+        },
+    })
+    rule = RuleLoader(path).load().rules[0]
+    assert rule.then == {"data_type": "raw_signal", "platform": "ONT"}
+    assert rule.then_status == {"reference_assembly": "not_applicable"}
+
+
+def test_loader_rejects_unknown_then_status_field(tmp_path):
+    path = _write_rules_file(tmp_path, {
+        "id": "bad_status_field", "tier": 1, "scope": "extension",
+        "when": {"extensions": [".md5"]},
+        "then": {"status": {"data_modalty": "not_applicable"}},  # typo
+    })
+    with pytest.raises(ValueError, match="unknown 'then.status' field"):
+        RuleLoader(path).load()
+
+
+@pytest.mark.parametrize("bad_status", ["classified", "conflict", "genomic", "typo"])
+def test_loader_rejects_non_authorable_then_status_value(tmp_path, bad_status):
+    # Only not_applicable / not_classified may be authored; classified is implied
+    # by a real value and conflict is engine-derived.
+    path = _write_rules_file(tmp_path, {
+        "id": "bad_status_value", "tier": 1, "scope": "extension",
+        "when": {"extensions": [".md5"]},
+        "then": {"status": {"data_modality": bad_status}},
+    })
+    with pytest.raises(ValueError, match="'then.status' values must be one of"):
+        RuleLoader(path).load()
+
+
+def test_loader_rejects_field_in_both_then_and_status(tmp_path):
+    # A field is either a real value or a status, never both.
+    path = _write_rules_file(tmp_path, {
+        "id": "field_conflict", "tier": 2, "scope": "extension",
+        "when": {"extensions": [".bam"]},
+        "then": {
+            "data_modality": "genomic",
+            "status": {"data_modality": "not_applicable"},
+        },
+    })
+    with pytest.raises(ValueError, match="appear in both 'then'"):
+        RuleLoader(path).load()
+
+
+@pytest.mark.parametrize("bad_status_block", ["not_applicable", [], 0])
+def test_loader_rejects_non_mapping_then_status(tmp_path, bad_status_block):
+    path = _write_rules_file(tmp_path, {
+        "id": "bad_status_block", "tier": 1, "scope": "extension",
+        "when": {"extensions": [".md5"]},
+        "then": {"status": bad_status_block},
+    })
+    with pytest.raises(ValueError, match="'then.status' must be a mapping"):
         RuleLoader(path).load()
 
 


### PR DESCRIPTION
## Summary

Closes the **last place a sentinel acted as a value** in epic #116's sentinel→status migration. Rules used to smuggle `not_applicable` / `not_classified` into a `then`-*value* slot; they now declare a non-classified field in a `then.status:` sub-map, so a then-value is **always a real dimension value**.

```yaml
# before
then:
  data_type: raw_signal
  reference_assembly: not_applicable   # sentinel in a value slot

# after
then:
  data_type: raw_signal
  status:
    reference_assembly: not_applicable  # a status, not a value
```

## What changed

- **rule_loader** — `then.status` is parsed into `UnifiedRule.then_status`; `_parse_then_status` validates fields (⊆ dimensions), authorable statuses (`not_applicable`/`not_classified` only — `classified` is implied, `conflict` is engine-derived), and that a field is never both a value and a status.
- **rule_engine** `_apply_rule` — applies `then_status` claims alongside `then` values.
- **schema_vocab** — removed `emitted_value_in_vocabulary` / `_EMITTABLE_STATUSES`; the then-value and assay-inference drift checks are now strict `value_in_vocabulary`, since no emit path carries a sentinel anymore (the drift-check payoff the issue calls for).
- **rules/unified_rules.yaml** — 47 sentinel then-values (46 `not_applicable` + 1 `not_classified`) across 17 rules moved into `then.status` sub-maps.
- **tests** — `then.status` loader parsing/validation, the `then.status`→output contract (including a mixed real-value + status rule), a `then.status`↔schema-status drift check, and a strict value-check that rejects all statuses. **446 passed** (was 430).

## Deliberate scope / deferral

This PR stops at the **rule-authoring boundary**. Inside the engine, an authored status is still carried as a sentinel string in the claim's `value`, so `evaluate_claims`, the `ExtendedClassificationResult` attributes, and the emitted `evidence[].value` are unchanged — the **golden fixture is byte-identical**, a strong behavior-preservation signal. Pushing `status` through the engine internals (and reworking the entangled `header_classifier`) is deferred to **#136**.

Follow-up to #122 (Stage 4a). Part of epic #116.

Closes #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)