### PR TITLE
Push status through engine internals: retire the internal sentinel-as-value (#136)

### DIFF
--- a/scripts/classify_auxiliary_genomic.py
+++ b/scripts/classify_auxiliary_genomic.py
@@ -14,10 +14,8 @@ from pathlib import Path
 # Add project root to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.meta_disco.models import NOT_APPLICABLE, NOT_CLASSIFIED, FileInfo, field_label
+from src.meta_disco.models import FileInfo, field_label
 from src.meta_disco.rule_engine import RuleEngine
-
-_SENTINEL_VALUES = {NOT_CLASSIFIED, NOT_APPLICABLE}
 
 # Extensions handled by this script
 AUXILIARY_EXTENSIONS = {".fast5", ".pod5", ".fast5.tar", ".fast5.tar.gz", ".pvar", ".psam", ".pgen"}
@@ -61,7 +59,9 @@ def classify_auxiliary_genomic(metadata_path: Path, output_path: Path):
         )
         result = engine.classify_extended(file_info)
 
-        if result.reference_assembly and result.reference_assembly not in _SENTINEL_VALUES:
+        # reference_assembly holds a real value or None (the sentinel lives in
+        # status now — epic #116 / #136), so truthiness = a real reference.
+        if result.reference_assembly:
             stats[matched_ext]["with_ref"] += 1
 
         results.append({

--- a/scripts/classify_index_files.py
+++ b/scripts/classify_index_files.py
@@ -14,6 +14,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from src.meta_disco.models import (
     CLASSIFICATION_FIELDS,
+    NOT_APPLICABLE,
     build_field_entry,
     field_label,
     status_for_value,
@@ -284,10 +285,18 @@ def propagate_to_index_files(
                      "reason": f"Inherited from parent file: {parent}",
                      "confidence": 0.95,
                      "value": field_val}]
+        status = status_for_value(field_val)
+        # An explicit not_applicable parent isn't "no value" — the field is
+        # determined (not applicable). Keep "had no value" for the not_classified /
+        # missing case. (generate_coverage_report normalizes both reason forms.)
+        if status == NOT_APPLICABLE:
+            reason = f"Parent file {parent} marks {field_name} not applicable"
+        else:
+            reason = f"Parent file {parent} had no value for {field_name}"
         return [{"rule_id": "inherited_from_parent",
-                 "reason": f"Parent file {parent} had no value for {field_name}",
+                 "reason": reason,
                  "confidence": 0.0,
-                 "status": status_for_value(field_val)}]
+                 "status": status}]
 
     standard_results = []
     for r in results:

--- a/scripts/classify_index_files.py
+++ b/scripts/classify_index_files.py
@@ -12,7 +12,12 @@ from collections import defaultdict
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from src.meta_disco.models import CLASSIFICATION_FIELDS, build_field_entry, field_label
+from src.meta_disco.models import (
+    CLASSIFICATION_FIELDS,
+    build_field_entry,
+    field_label,
+    status_for_value,
+)
 
 
 def _get_max_confidence(record: dict) -> float:
@@ -282,7 +287,7 @@ def propagate_to_index_files(
         return [{"rule_id": "inherited_from_parent",
                  "reason": f"Parent file {parent} had no value for {field_name}",
                  "confidence": 0.0,
-                 "value": field_val or nc}]
+                 "status": status_for_value(field_val)}]
 
     standard_results = []
     for r in results:

--- a/scripts/generate_coverage_report.py
+++ b/scripts/generate_coverage_report.py
@@ -93,6 +93,11 @@ def _normalize_reason(reason: str) -> str:
         reason,
     )
     reason = re.sub(
+        r"Parent file .+ marks (\w+) not applicable",
+        r"Parent file marks \1 not applicable",
+        reason,
+    )
+    reason = re.sub(
         r"Inherited from parent file: .+",
         "Inherited from parent file",
         reason,

--- a/scripts/run_batch_classification.py
+++ b/scripts/run_batch_classification.py
@@ -47,7 +47,7 @@ def run_classification(files: list[dict], engine: RuleEngine) -> list[dict]:
             dataset_title=file_data.get("dataset_title"),
         )
 
-        result = engine.classify(file_info)
+        result = engine.classify_extended(file_info)
 
         results.append({
             # Original metadata
@@ -62,9 +62,9 @@ def run_classification(files: list[dict], engine: RuleEngine) -> list[dict]:
             # Original API values
             "api_data_modality": file_data.get("data_modality"),
             "api_reference_assembly": file_data.get("reference_assembly"),
-            # Classification results
-            "predicted_modality": result.data_modality,
-            "predicted_reference": result.reference_assembly,
+            # Classification results (label = value when classified, else the status)
+            "predicted_modality": result.label("data_modality"),
+            "predicted_reference": result.label("reference_assembly"),
             "confidence": result.confidence,
             "rules_matched": "|".join(result.rules_matched),
             "reasons": "|".join(result.reasons),

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -266,10 +266,14 @@ def classify_from_fastq_header(
         file_info_stripped = replace(file_info, fastq_first_read=stripped_read)
         result_stripped = engine.classify_extended(file_info_stripped, include_tier3=True)
         if result_stripped.platform:
-            # Merge results - keep the platform and modality from stripped version
+            # Merge results - keep the platform and modality from stripped version.
+            # Adopt the stripped modality whenever it made a definitive statement
+            # (a real value or not_applicable), carrying its status — a status-only
+            # declaration has data_modality=None, so a truthiness check would drop it.
             result.set_field("platform", result_stripped.platform)
-            if result_stripped.data_modality:
-                result.set_field("data_modality", result_stripped.data_modality)
+            if result_stripped.is_declared("data_modality"):
+                result.set_field("data_modality", result_stripped.data_modality,
+                                 result_stripped.status_of("data_modality"))
             result.confidence = max(result.confidence, result_stripped.confidence)
             # Merge per-field evidence
             for fld, entries in result_stripped.field_evidence.items():

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -91,7 +91,7 @@ def classify_from_header(
 
     # Apply contig-based reference (overrides everything — definitive signal)
     if contig_ref:
-        result.reference_assembly = contig_ref
+        result.set_field("reference_assembly", contig_ref)
         result.confidence = max(result.confidence, contig_conf)
         reason = f"Reference {contig_ref} detected from {contig_matches} matching contig lengths (definitive)"
         result.field_evidence["reference_assembly"] = [{
@@ -101,8 +101,8 @@ def classify_from_header(
             "value": contig_ref,
         }]
         # Aligned to a known reference genome = genomic data
-        if result.data_modality in (None, NOT_CLASSIFIED):
-            result.data_modality = "genomic"
+        if not result.is_declared("data_modality"):
+            result.set_field("data_modality", "genomic")
             result.field_evidence["data_modality"] = [{
                 "rule_id": "aligned_to_reference",
                 "reason": f"Aligned to {contig_ref} — file contains genomic alignments",
@@ -171,7 +171,7 @@ def classify_from_vcf_header(
 
     # Apply contig-based reference (overrides everything — definitive signal)
     if contig_ref:
-        result.reference_assembly = contig_ref
+        result.set_field("reference_assembly", contig_ref)
         result.confidence = max(result.confidence, contig_conf)
         reason = f"Reference {contig_ref} detected from {contig_matches} matching contig lengths (definitive)"
         result.field_evidence["reference_assembly"] = [{
@@ -261,14 +261,15 @@ def classify_from_fastq_header(
 
     # If no platform detected and this is archive-reformatted, try the stripped version
     # This handles cases like @ERR... A00297:... where the Illumina pattern is after the space
-    if (not result.platform or result.platform == NOT_CLASSIFIED) and accession and remainder.strip():
+    if not result.is_declared("platform") and accession and remainder.strip():
         stripped_read = "@" + remainder.strip()
         file_info_stripped = replace(file_info, fastq_first_read=stripped_read)
         result_stripped = engine.classify_extended(file_info_stripped, include_tier3=True)
         if result_stripped.platform:
             # Merge results - keep the platform and modality from stripped version
-            result.platform = result_stripped.platform
-            result.data_modality = result_stripped.data_modality or result.data_modality
+            result.set_field("platform", result_stripped.platform)
+            if result_stripped.data_modality:
+                result.set_field("data_modality", result_stripped.data_modality)
             result.confidence = max(result.confidence, result_stripped.confidence)
             # Merge per-field evidence
             for fld, entries in result_stripped.field_evidence.items():
@@ -397,10 +398,10 @@ def classify_from_fasta_header(
 
     # 1. Transcript IDs → transcriptomic
     if transcript_contigs and len(transcript_contigs) > len(ref_matches):
-        result.data_modality = "transcriptomic.bulk"
-        result.data_type = "sequence"
-        if result.reference_assembly in (None, NOT_CLASSIFIED):
-            result.reference_assembly = NOT_CLASSIFIED
+        result.set_field("data_modality", "transcriptomic.bulk")
+        result.set_field("data_type", "sequence")
+        if not result.is_declared("reference_assembly"):
+            result.set_field("reference_assembly", status=NOT_CLASSIFIED)
         result.field_evidence["data_modality"] = [{
             "rule_id": "fasta_transcript_contigs",
             "reason": f"Found {len(transcript_contigs)} transcript IDs (e.g., {transcript_contigs[0]})",
@@ -433,27 +434,30 @@ def classify_from_fasta_header(
             tied = [a for a, c in assembly_counts.items() if c == best_count]
             if len(tied) == 1:
                 best_ref = tied[0]
-            elif result.reference_assembly and result.reference_assembly not in (NOT_CLASSIFIED, NOT_APPLICABLE):
+            elif result.reference_assembly:
                 # Rule engine already detected reference from filename (e.g., "chm13" in name)
                 best_ref = result.reference_assembly
             else:
                 # Can't distinguish — contigs match multiple references equally
                 best_ref = None
 
-            result.data_modality = "genomic"
-            result.data_type = "reference_genome"
-            if best_ref:
-                result.reference_assembly = best_ref
-                result.confidence = 0.95
-            else:
-                result.confidence = 0.80
-            result.field_evidence["reference_assembly"] = [{
+            result.set_field("data_modality", "genomic")
+            result.set_field("data_type", "reference_genome")
+            ref_entry = {
                 "rule_id": "fasta_reference_contigs",
                 "reason": f"Matched {best_count} contigs to reference chromosomes"
                           + (f" ({best_ref})" if best_ref else " (ambiguous — multiple references share these names)"),
                 "confidence": 0.95 if best_ref else 0.50,
-                "value": best_ref or NOT_CLASSIFIED,
-            }]
+            }
+            if best_ref:
+                result.set_field("reference_assembly", best_ref)
+                result.confidence = 0.95
+                ref_entry["value"] = best_ref
+            else:
+                result.set_field("reference_assembly", status=NOT_CLASSIFIED)
+                result.confidence = 0.80
+                ref_entry["status"] = NOT_CLASSIFIED
+            result.field_evidence["reference_assembly"] = [ref_entry]
             result.field_evidence["data_modality"] = [{
                 "rule_id": "fasta_reference_contigs",
                 "reason": "Contig names match known reference genome",
@@ -470,9 +474,9 @@ def classify_from_fasta_header(
 
     # 3. Assembler output contigs → de novo assembly
     if assembler_contigs:
-        result.data_modality = "genomic"
-        result.data_type = "assembly"
-        result.reference_assembly = NOT_APPLICABLE
+        result.set_field("data_modality", "genomic")
+        result.set_field("data_type", "assembly")
+        result.set_field("reference_assembly", status=NOT_APPLICABLE)
         result.confidence = 0.90
         sample = assembler_contigs[0]
         result.field_evidence["data_modality"] = [{
@@ -491,15 +495,15 @@ def classify_from_fasta_header(
             "rule_id": "fasta_assembler_contigs",
             "reason": "De novo assembly — no reference genome applicable",
             "confidence": 0.90,
-            "value": NOT_APPLICABLE,
+            "status": NOT_APPLICABLE,
         }]
         return result.to_output_dict()
 
     # 4. Many non-standard contigs → likely de novo assembly
     if num_contigs > 50 and not ref_matches:
-        result.data_modality = "genomic"
-        result.data_type = "assembly"
-        result.reference_assembly = NOT_APPLICABLE
+        result.set_field("data_modality", "genomic")
+        result.set_field("data_type", "assembly")
+        result.set_field("reference_assembly", status=NOT_APPLICABLE)
         result.confidence = 0.75
         result.field_evidence["data_modality"] = [{
             "rule_id": "fasta_many_contigs",
@@ -517,22 +521,22 @@ def classify_from_fasta_header(
             "rule_id": "fasta_many_contigs",
             "reason": "De novo assembly — no reference genome applicable",
             "confidence": 0.75,
-            "value": NOT_APPLICABLE,
+            "status": NOT_APPLICABLE,
         }]
         return result.to_output_dict()
 
     # 5. Default: preserve rule engine results if they set modality/type,
     #    otherwise fall back to genomic/sequence
-    if result.data_modality in (None, NOT_CLASSIFIED):
-        result.data_modality = "genomic"
+    if not result.is_declared("data_modality"):
+        result.set_field("data_modality", "genomic")
         result.field_evidence["data_modality"] = [{
             "rule_id": "fasta_default_genomic",
             "reason": f"FASTA with {num_contigs} contigs — defaulting to genomic",
             "confidence": 0.50,
             "value": "genomic",
         }]
-    if result.data_type in (None, NOT_CLASSIFIED):
-        result.data_type = "sequence"
+    if not result.is_declared("data_type"):
+        result.set_field("data_type", "sequence")
         result.field_evidence["data_type"] = [{
             "rule_id": "fasta_default_genomic",
             "reason": "Unable to determine specific FASTA type from headers",
@@ -700,8 +704,8 @@ def classify_from_bed_signals(
                 (ev.get("confidence", 0.0) for ev in existing_ref_evidence),
                 default=0.0,
             )
-            if result.reference_assembly in (None, NOT_CLASSIFIED) or coord_conf > existing_ref_conf:
-                result.reference_assembly = coord_ref
+            if not result.is_declared("reference_assembly") or coord_conf > existing_ref_conf:
+                result.set_field("reference_assembly", coord_ref)
                 result.confidence = max(result.confidence, coord_conf)
                 result.field_evidence["reference_assembly"] = [{
                     "rule_id": "bed_coordinate_reference",
@@ -711,12 +715,12 @@ def classify_from_bed_signals(
                 }]
         elif coord_ref is None and coord_conf == 0.0:
             if "Non-standard chromosome" in coord_rationale:
-                result.reference_assembly = NOT_APPLICABLE
+                result.set_field("reference_assembly", status=NOT_APPLICABLE)
                 result.field_evidence["reference_assembly"] = [{
                     "rule_id": "bed_nonstandard_contigs",
                     "reason": coord_rationale,
                     "confidence": 0.0,
-                    "value": NOT_APPLICABLE,
+                    "status": NOT_APPLICABLE,
                 }]
 
     return result.to_output_dict()

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -96,8 +96,7 @@ class ExtendedClassificationResult:
         without a real value, or a non-classified status carrying one, raises
         rather than silently mis-storing.
         """
-        if fld not in self.field_status:
-            raise ValueError(f"unknown classification field {fld!r}")
+        self._require_field(fld)
         if status is None:
             status = status_for_value(value)
         if status not in (CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED):
@@ -106,19 +105,29 @@ class ExtendedClassificationResult:
         setattr(self, fld, value if status == CLASSIFIED else None)
         self.field_status[fld] = status
 
+    def _require_field(self, fld: str) -> None:
+        """Raise ValueError for an unknown classification field, so every accessor
+        that takes a ``fld`` fails with one clear message rather than a bare
+        KeyError leaking from the ``field_status`` lookup."""
+        if fld not in self.field_status:
+            raise ValueError(f"unknown classification field {fld!r}")
+
     def status_of(self, fld: str) -> str:
         """Resolved status of a dimension (classified / not_applicable / not_classified)."""
+        self._require_field(fld)
         return self.field_status[fld]
 
     def is_declared(self, fld: str) -> bool:
         """True if a definitive statement was made for the field — a real value
         (CLASSIFIED) or an explicit not_applicable — vs not_classified/unset."""
+        self._require_field(fld)
         return self.field_status[fld] in (CLASSIFIED, NOT_APPLICABLE)
 
     def label(self, fld: str) -> str | None:
         """Combined value-or-status label for the field (mirrors models.field_label):
         the real value when CLASSIFIED, else the status string. For flat/legacy
         views (basic ClassificationResult, CSV reports) that want one column."""
+        self._require_field(fld)
         return getattr(self, fld) if self.field_status[fld] == CLASSIFIED else self.field_status[fld]
 
     @property

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -7,11 +7,14 @@ from typing import Any
 
 from .models import (
     CLASSIFICATION_FIELDS,
+    CLASSIFIED,
     NOT_APPLICABLE,
     NOT_CLASSIFIED,
     ClassificationResult,
     FileInfo,
+    _assert_coherent,
     build_field_entry,
+    status_for_value,
 )
 from .rule_loader import UnifiedRule, get_unified_rules
 
@@ -72,6 +75,44 @@ class ExtendedClassificationResult:
         "assay_type": [],
         "platform": [],
     })
+    # Resolved status per dimension (epic #116 / #136): the dimension attributes
+    # above hold a real value or None only — the sentinel (not_applicable /
+    # not_classified) lives here, never in a value slot. Defaults to
+    # not_classified (no statement made) until a value or status is set.
+    field_status: dict[str, str] = field(
+        default_factory=lambda: {fld: NOT_CLASSIFIED for fld in CLASSIFICATION_FIELDS})
+
+    def set_field(self, fld: str, value: str | None = None, status: str | None = None) -> None:
+        """Set a dimension's value and status coherently.
+
+        ``value`` is a real value or None; ``status`` defaults to
+        ``status_for_value(value)``. A CLASSIFIED status stores the value; any
+        non-classified status stores None (the sentinel lives only in
+        ``field_status``). The (value, status) pairing is checked against the
+        single coherence definition (``models._assert_coherent``): a CLASSIFIED
+        status without a real value, or a non-classified status carrying one,
+        raises rather than silently mis-storing.
+        """
+        if status is None:
+            status = status_for_value(value)
+        _assert_coherent(value, status)  # single coherence definition (models)
+        setattr(self, fld, value if status == CLASSIFIED else None)
+        self.field_status[fld] = status
+
+    def status_of(self, fld: str) -> str:
+        """Resolved status of a dimension (classified / not_applicable / not_classified)."""
+        return self.field_status[fld]
+
+    def is_declared(self, fld: str) -> bool:
+        """True if a definitive statement was made for the field — a real value
+        (CLASSIFIED) or an explicit not_applicable — vs not_classified/unset."""
+        return self.field_status[fld] in (CLASSIFIED, NOT_APPLICABLE)
+
+    def label(self, fld: str) -> str | None:
+        """Combined value-or-status label for the field (mirrors models.field_label):
+        the real value when CLASSIFIED, else the status string. For flat/legacy
+        views (basic ClassificationResult, CSV reports) that want one column."""
+        return getattr(self, fld) if self.field_status[fld] == CLASSIFIED else self.field_status[fld]
 
     @property
     def rules_matched(self) -> list[str]:
@@ -117,128 +158,130 @@ class ExtendedClassificationResult:
         """Convert to the per-field output format.
 
         Each dimension emits ``{value, status, confidence, evidence}`` via
-        ``models.build_field_entry``, which applies epic #116's Stage 3 invariant:
-        ``status`` carries ``not_applicable`` / ``not_classified`` and ``value`` is
-        ``None`` unless the field is CLASSIFIED. The internal attribute
-        (``getattr(self, fld)``) still holds the sentinel; only the serialized
-        output is nulled. Readers are unaffected (they read ``status`` via
-        models.field_status).
+        ``models.build_field_entry``. The dimension attribute holds a real value or
+        None and ``field_status`` holds the resolved status (epic #116 / #136), so
+        both are passed straight through — the sentinel is never in ``value``,
+        internally or in the output.
         """
         classifications = {}
         for fld in self._CLASSIFICATION_FIELDS:
-            value = getattr(self, fld)
             evidence = self.field_evidence.get(fld, [])
             fld_conf = max((e.get("confidence", 0) for e in evidence), default=0.0)
-            classifications[fld] = build_field_entry(value, confidence=fld_conf, evidence=evidence)
+            classifications[fld] = build_field_entry(
+                getattr(self, fld), status=self.field_status[fld],
+                confidence=fld_conf, evidence=evidence)
         return classifications
 
     # Classification field names (single source of truth: models.CLASSIFICATION_FIELDS)
     _CLASSIFICATION_FIELDS = CLASSIFICATION_FIELDS
 
 
+def _claim_declaration(claim: dict) -> str | None:
+    """A claim's *declaration*: its real ``value``, else its ``status`` (a rule
+    authors not_applicable / not_classified as a ``status``, never in the value
+    slot — epic #116 / #136). Resolution runs over declarations; the winner is
+    split back into (value, status) by ``_resolved``."""
+    value = claim.get("value")
+    return value if value is not None else claim.get("status")
+
+
+def _resolved(declaration: str | None, confidence: float, reason: str,
+              is_conflict: bool = False, competing: list | None = None) -> dict:
+    """Package a winning declaration as ``{value, status, ...}``: a real declaration
+    becomes value with status CLASSIFIED; a status declaration becomes that status
+    with value None — so a sentinel never lands in ``value``."""
+    status = status_for_value(declaration)
+    out = {
+        "value": declaration if status == CLASSIFIED else None,
+        "status": status,
+        "confidence": confidence,
+        "reason": reason,
+        "is_conflict": is_conflict,
+    }
+    if competing is not None:
+        out["competing_values"] = competing
+    return out
+
+
 def evaluate_claims(claims: list[dict]) -> dict:
     """Evaluate competing claims for a single classification field.
 
-    Takes a list of evidence entries (each with rule_id, value, confidence,
-    and optionally tier) and resolves them to a single value.
+    Each claim *declares* either a real value or a status (not_applicable /
+    not_classified — see ``_claim_declaration``). Resolution runs in declaration
+    space and the winner is split back into a real value + status.
 
     Resolution rules:
     - No claims → not_classified
     - Single claim → use it
-    - All claims agree → use value, max confidence
+    - All claims agree → use declaration, max confidence
     - Claims disagree, highest tier is unique → highest tier wins (override)
     - Claims disagree, NOT_APPLICABLE at top tier → not_applicable wins (terminal)
     - Claims disagree, same max tier → conflict (not_classified)
 
     Args:
-        claims: List of evidence dicts with at least {value, confidence}.
-                Optional: tier (int), rule_id (str), reason (str).
+        claims: List of evidence dicts, each with a ``value`` or a ``status``, plus
+                ``confidence`` and optionally ``tier`` / ``rule_id`` / ``reason``.
 
     Returns:
-        Dict with: value, confidence, reason, is_conflict, competing_values (if conflict)
+        Dict with: value (real or None), status, confidence, reason, is_conflict,
+        competing_values (if conflict).
     """
-    # Filter out synthetic placeholders and None values, but keep
-    # rule-authored NOT_CLASSIFIED claims (e.g., fastq_modality_unknown)
+    # Drop the synthetic not_classified placeholder and empty claims, but keep
+    # rule-authored not_classified declarations (e.g., fastq_modality_unknown).
     real_claims = [c for c in claims
-                   if c.get("value") is not None
+                   if _claim_declaration(c) is not None
                    and c.get("rule_id") != "not_classified"]
 
-    # For conflict resolution, separate claims with real values from
-    # NOT_CLASSIFIED claims (which mean "I looked but can't determine")
-    assertive_claims = [c for c in real_claims if c["value"] != NOT_CLASSIFIED]
+    # Assertive = real-value declarations; a not_classified status means
+    # "I looked but can't determine" and doesn't assert a value.
+    assertive_claims = [c for c in real_claims if _claim_declaration(c) != NOT_CLASSIFIED]
 
     if not real_claims:
-        return {
-            "value": NOT_CLASSIFIED,
-            "confidence": 0.0,
-            "reason": "no_claims",
-            "is_conflict": False,
-        }
+        return _resolved(NOT_CLASSIFIED, 0.0, "no_claims")
 
-    # If no assertive claims (only rule-authored NOT_CLASSIFIED), resolve as not_classified
+    # Only not_classified declarations present → resolve as not_classified
     # (the rule's rationale is preserved in field_evidence, not in this return value)
     if not assertive_claims:
         best = max(real_claims, key=lambda c: c.get("confidence", 0))
-        return {
-            "value": NOT_CLASSIFIED,
-            "confidence": best.get("confidence", 0),
-            "reason": "single_claim" if len(real_claims) == 1 else "unanimous",
-            "is_conflict": False,
-        }
+        return _resolved(NOT_CLASSIFIED, best.get("confidence", 0),
+                         "single_claim" if len(real_claims) == 1 else "unanimous")
 
-    # Check if all assertive claims agree
-    values = {c["value"] for c in assertive_claims}
+    # Check if all assertive declarations agree
+    declarations = {_claim_declaration(c) for c in assertive_claims}
 
-    if len(values) == 1:
-        # Unanimous — use the value with highest confidence
+    if len(declarations) == 1:
+        # Unanimous — use the highest-confidence claim
         best = max(assertive_claims, key=lambda c: c.get("confidence", 0))
-        return {
-            "value": best["value"],
-            "confidence": max(c.get("confidence", 0) for c in assertive_claims),
-            "reason": "unanimous" if len(assertive_claims) > 1 else "single_claim",
-            "is_conflict": False,
-        }
+        return _resolved(_claim_declaration(best),
+                         max(c.get("confidence", 0) for c in assertive_claims),
+                         "unanimous" if len(assertive_claims) > 1 else "single_claim")
 
-    # Assertive claims disagree — check tiers
+    # Assertive declarations disagree — check tiers
     max_tier = max(c.get("tier", 0) for c in assertive_claims)
     top_tier_claims = [c for c in assertive_claims if c.get("tier", 0) == max_tier]
-    top_tier_values = {c["value"] for c in top_tier_claims}
+    top_tier_decls = {_claim_declaration(c) for c in top_tier_claims}
 
     # NOT_APPLICABLE is a terminal declaration — it wins over real values
     # at the same tier without triggering a conflict (e.g., text_stats
     # setting not_applicable shouldn't conflict with filename_ref patterns)
-    if NOT_APPLICABLE in top_tier_values:
-        na_claims = [c for c in top_tier_claims if c["value"] == NOT_APPLICABLE]
+    if NOT_APPLICABLE in top_tier_decls:
+        na_claims = [c for c in top_tier_claims if _claim_declaration(c) == NOT_APPLICABLE]
         best = max(na_claims, key=lambda c: c.get("confidence", 0))
-        return {
-            "value": NOT_APPLICABLE,
-            "confidence": best.get("confidence", 0),
-            "reason": "not_applicable_terminal",
-            "is_conflict": False,
-        }
+        return _resolved(NOT_APPLICABLE, best.get("confidence", 0), "not_applicable_terminal")
 
-    if len(top_tier_values) == 1:
+    if len(top_tier_decls) == 1:
         # Highest tier is unanimous — override lower tiers
-        winner_value = top_tier_values.pop()
+        winner = top_tier_decls.pop()
         best = max(
-            (c for c in top_tier_claims if c["value"] == winner_value),
+            (c for c in top_tier_claims if _claim_declaration(c) == winner),
             key=lambda c: c.get("confidence", 0),
         )
-        return {
-            "value": best["value"],
-            "confidence": best.get("confidence", 0),
-            "reason": "higher_specificity_override",
-            "is_conflict": False,
-        }
+        return _resolved(_claim_declaration(best), best.get("confidence", 0),
+                         "higher_specificity_override")
 
     # Same tier, different values — conflict
-    return {
-        "value": NOT_CLASSIFIED,
-        "confidence": 0.0,
-        "reason": "conflict",
-        "is_conflict": True,
-        "competing_values": sorted(top_tier_values),
-    }
+    return _resolved(NOT_CLASSIFIED, 0.0, "conflict",
+                     is_conflict=True, competing=sorted(top_tier_decls))
 
 
 class RuleEngine:
@@ -345,7 +388,7 @@ class RuleEngine:
         for fld in result._CLASSIFICATION_FIELDS:
             claims = result.field_evidence.get(fld, [])
             evaluation = evaluate_claims(claims)
-            setattr(result, fld, evaluation["value"])
+            result.set_field(fld, evaluation["value"], evaluation["status"])
 
             if evaluation["is_conflict"]:
                 result.field_evidence[fld].append({
@@ -353,7 +396,7 @@ class RuleEngine:
                     "reason": (f"Conflicting {fld}: {evaluation['competing_values']}"
                                " — ambiguous"),
                     "confidence": 0.0,
-                    "value": NOT_CLASSIFIED,
+                    "status": NOT_CLASSIFIED,
                     "competing_values": evaluation["competing_values"],
                     "is_conflict": True,
                 })
@@ -362,7 +405,7 @@ class RuleEngine:
                     "rule_id": "not_classified",
                     "reason": f"No rule determined a value for {fld}",
                     "confidence": 0.0,
-                    "value": NOT_CLASSIFIED,
+                    "status": NOT_CLASSIFIED,
                 })
 
     def _rule_matches(
@@ -415,18 +458,20 @@ class RuleEngine:
             if file_info.file_format != file_format:
                 return False
 
-        # Check modality_not_set — true if no real claims for data_modality yet
+        # Check modality_not_set — true unless data_modality already has a
+        # definitive declaration (a real value or an explicit not_applicable; a
+        # not_classified declaration does not count as "set").
         if when.get("modality_not_set"):
-            real_claims = [c for c in current.field_evidence.get("data_modality", [])
-                          if c.get("value") not in (None, NOT_CLASSIFIED)]
-            if real_claims:
+            declared = [c for c in current.field_evidence.get("data_modality", [])
+                        if _claim_declaration(c) not in (None, NOT_CLASSIFIED)]
+            if declared:
                 return False
 
-        # Check reference_not_set — true if no real claims for reference_assembly yet
+        # Check reference_not_set — same "definitive declaration" test as above.
         if when.get("reference_not_set"):
-            real_claims = [c for c in current.field_evidence.get("reference_assembly", [])
-                          if c.get("value") not in (None, NOT_CLASSIFIED)]
-            if real_claims:
+            declared = [c for c in current.field_evidence.get("reference_assembly", [])
+                        if _claim_declaration(c) not in (None, NOT_CLASSIFIED)]
+            if declared:
                 return False
 
         # Check header section (tier 3) — skip if checking for absence
@@ -535,13 +580,11 @@ class RuleEngine:
         """Collect claims from a rule without setting classification fields.
 
         A rule authors each field either as a real value (``then``) or as a
-        non-classified status (``then.status`` → ``rule.then_status``); the loader
-        guarantees never both. Both become a claim appended to field_evidence;
-        evaluation happens later in _finalize_result via evaluate_claims(). A
-        status is still carried internally as a sentinel string in the claim's
-        ``value`` so claim evaluation, the result attributes and the evidence
-        output are unchanged from the pre-#133 sentinel-as-value behavior — the
-        internal sentinel→status cleanup is deferred (see issue #136).
+        not_applicable / not_classified status (``then.status`` →
+        ``rule.then_status``); the loader guarantees never both. Each becomes a
+        claim appended to field_evidence — a value claim carries ``value``, a status
+        claim carries ``status`` (never a sentinel in the value slot — epic #116 /
+        #136); evaluation happens later in _finalize_result via evaluate_claims().
         Also updates result.confidence (running max, not a classification field).
         """
         then = rule.then
@@ -553,16 +596,12 @@ class RuleEngine:
             "tier": rule.tier,
         }
         for fld in result._CLASSIFICATION_FIELDS:
-            # A field is authored as a real value (`then`) or a status
-            # (`then.status`), never both; most rules author no status, so only
-            # consult then_status when the rule has one.
-            claim_value = then.get(fld)
-            if claim_value is None and then_status:
-                claim_value = then_status.get(fld)
-            if claim_value is not None:
-                entry = evidence_entry.copy()
-                entry["value"] = claim_value
-                result.field_evidence[fld].append(entry)
+            value = then.get(fld)
+            status = then_status.get(fld) if then_status else None
+            if value is not None:
+                result.field_evidence[fld].append({**evidence_entry, "value": value})
+            elif status is not None:
+                result.field_evidence[fld].append({**evidence_entry, "status": status})
 
         # Update overall confidence (take highest confidence from matching rules)
         if rule.confidence > result.confidence:
@@ -576,10 +615,10 @@ class RuleEngine:
         """Infer assay type from other classification signals.
 
         Sets result.assay_type and appends evidence when a matching
-        assay_type_rule is found. Skips if assay_type is already set
-        or conflicted.
+        assay_type_rule is found. Skips if assay_type is already declared
+        (a real value or an explicit not_applicable).
         """
-        if result.assay_type not in (None, NOT_CLASSIFIED):
+        if result.is_declared("assay_type"):
             return
         # Don't infer over conflicts
         assay_evidence = result.field_evidence.get("assay_type", [])
@@ -637,7 +676,7 @@ class RuleEngine:
                     continue
 
             # All conditions passed — apply and record evidence
-            result.assay_type = assay_rule.assay_type
+            result.set_field("assay_type", assay_rule.assay_type)
             # Remove stale not_classified placeholder if _finalize_result ran first
             result.field_evidence["assay_type"] = [
                 e for e in result.field_evidence["assay_type"]

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -88,13 +88,20 @@ class ExtendedClassificationResult:
         ``value`` is a real value or None; ``status`` defaults to
         ``status_for_value(value)``. A CLASSIFIED status stores the value; any
         non-classified status stores None (the sentinel lives only in
-        ``field_status``). The (value, status) pairing is checked against the
-        single coherence definition (``models._assert_coherent``): a CLASSIFIED
-        status without a real value, or a non-classified status carrying one,
-        raises rather than silently mis-storing.
+        ``field_status``). ``fld`` must be a known classification field and
+        ``status`` one of classified / not_applicable / not_classified — a typo
+        raises rather than silently creating a stray attribute or emitting an
+        invalid status. The (value, status) pairing is checked against the single
+        coherence definition (``models._assert_coherent``): a CLASSIFIED status
+        without a real value, or a non-classified status carrying one, raises
+        rather than silently mis-storing.
         """
+        if fld not in self.field_status:
+            raise ValueError(f"unknown classification field {fld!r}")
         if status is None:
             status = status_for_value(value)
+        if status not in (CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED):
+            raise ValueError(f"unknown status {status!r} for field {fld}")
         _assert_coherent(value, status)  # single coherence definition (models)
         setattr(self, fld, value if status == CLASSIFIED else None)
         self.field_status[fld] = status

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -68,13 +68,8 @@ class ExtendedClassificationResult:
     assay_type: str | None = None
     platform: str | None = None
     confidence: float = 0.0
-    field_evidence: dict[str, list[dict]] = field(default_factory=lambda: {
-        "data_modality": [],
-        "data_type": [],
-        "reference_assembly": [],
-        "assay_type": [],
-        "platform": [],
-    })
+    field_evidence: dict[str, list[dict]] = field(
+        default_factory=lambda: {fld: [] for fld in CLASSIFICATION_FIELDS})
     # Resolved status per dimension (epic #116 / #136): the dimension attributes
     # above hold a real value or None only — the sentinel (not_applicable /
     # not_classified) lives here, never in a value slot. Defaults to

--- a/tests/fixtures/golden/expected_output.json
+++ b/tests/fixtures/golden/expected_output.json
@@ -10,7 +10,7 @@
                 "confidence": 0.0,
                 "reason": "No rule determined a value for assay_type",
                 "rule_id": "not_classified",
-                "value": "not_classified"
+                "status": "not_classified"
               }
             ],
             "status": "not_classified",
@@ -23,7 +23,7 @@
                 "confidence": 0.0,
                 "reason": "No rule determined a value for data_modality",
                 "rule_id": "not_classified",
-                "value": "not_classified"
+                "status": "not_classified"
               }
             ],
             "status": "not_classified",
@@ -36,7 +36,7 @@
                 "confidence": 0.0,
                 "reason": "No rule determined a value for data_type",
                 "rule_id": "not_classified",
-                "value": "not_classified"
+                "status": "not_classified"
               }
             ],
             "status": "not_classified",
@@ -49,7 +49,7 @@
                 "confidence": 0.0,
                 "reason": "No rule determined a value for platform",
                 "rule_id": "not_classified",
-                "value": "not_classified"
+                "status": "not_classified"
               }
             ],
             "status": "not_classified",
@@ -62,8 +62,8 @@
                 "confidence": 0.9,
                 "reason": "Absence of @SQ lines indicates unaligned reads. Common for PacBio HiFi deliverables before alignment",
                 "rule_id": "unaligned_no_sq",
-                "tier": 3,
-                "value": "not_applicable"
+                "status": "not_applicable",
+                "tier": 3
               }
             ],
             "status": "not_applicable",
@@ -98,8 +98,8 @@
                 "confidence": 0.3,
                 "reason": "FASTA file detected; header inspection needed to determine if de novo assembly, reference genome, or transcript sequences",
                 "rule_id": "fasta_base",
-                "tier": 1,
-                "value": "not_applicable"
+                "status": "not_applicable",
+                "tier": 1
               }
             ],
             "status": "not_applicable",
@@ -161,8 +161,8 @@
                 "confidence": 0.3,
                 "reason": "FASTA file detected; header inspection needed to determine if de novo assembly, reference genome, or transcript sequences",
                 "rule_id": "fasta_base",
-                "tier": 1,
-                "value": "not_applicable"
+                "status": "not_applicable",
+                "tier": 1
               }
             ],
             "status": "not_applicable",
@@ -175,15 +175,15 @@
                 "confidence": 0.8,
                 "reason": "Filename contains assembly/assembler indicator \u2014 de novo assembly",
                 "rule_id": "fasta_assembly_filename",
-                "tier": 2,
-                "value": "not_applicable"
+                "status": "not_applicable",
+                "tier": 2
               },
               {
                 "confidence": 0.8,
                 "reason": "Filename contains haplotype/phasing indicator \u2014 de novo assembly",
                 "rule_id": "fasta_haplotype_filename",
-                "tier": 2,
-                "value": "not_applicable"
+                "status": "not_applicable",
+                "tier": 2
               }
             ],
             "status": "not_applicable",
@@ -220,7 +220,7 @@
                 "confidence": 0.0,
                 "reason": "No rule determined a value for assay_type",
                 "rule_id": "not_classified",
-                "value": "not_classified"
+                "status": "not_classified"
               }
             ],
             "status": "not_classified",
@@ -233,8 +233,8 @@
                 "confidence": 0.0,
                 "reason": "FASTQ modality cannot be determined from reads alone \u2014 could be genomic, transcriptomic, or epigenomic depending on assay",
                 "rule_id": "fastq_modality_unknown",
-                "tier": 3,
-                "value": "not_classified"
+                "status": "not_classified",
+                "tier": 3
               }
             ],
             "status": "not_classified",
@@ -264,7 +264,7 @@
                 "confidence": 0.0,
                 "reason": "No rule determined a value for platform",
                 "rule_id": "not_classified",
-                "value": "not_classified"
+                "status": "not_classified"
               }
             ],
             "status": "not_classified",
@@ -277,8 +277,8 @@
                 "confidence": 0.5,
                 "reason": "FASTQ files contain raw sequencing reads. Reference not applicable until alignment",
                 "rule_id": "reads_base",
-                "tier": 2,
-                "value": "not_applicable"
+                "status": "not_applicable",
+                "tier": 2
               }
             ],
             "status": "not_applicable",
@@ -313,7 +313,7 @@
                 "confidence": 0.0,
                 "reason": "No rule determined a value for assay_type",
                 "rule_id": "not_classified",
-                "value": "not_classified"
+                "status": "not_classified"
               }
             ],
             "status": "not_classified",
@@ -354,7 +354,7 @@
                 "confidence": 0.0,
                 "reason": "No rule determined a value for platform",
                 "rule_id": "not_classified",
-                "value": "not_classified"
+                "status": "not_classified"
               }
             ],
             "status": "not_classified",
@@ -367,7 +367,7 @@
                 "confidence": 0.0,
                 "reason": "No rule determined a value for reference_assembly",
                 "rule_id": "not_classified",
-                "value": "not_classified"
+                "status": "not_classified"
               }
             ],
             "status": "not_classified",

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -266,22 +266,22 @@ class TestRuleEngineE2E:
     def test_histology_svs(self):
         result = engine.classify_extended(FileInfo(filename="GTEX-18A6Q-1126.svs"))
         assert result.data_modality == "imaging.histology"
-        assert result.platform == NOT_APPLICABLE
-        assert result.reference_assembly == NOT_APPLICABLE
+        assert result.status_of("platform") == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_fast5_raw_signal(self):
         result = engine.classify_extended(FileInfo(filename="PAK57726.fast5"))
-        assert result.data_modality == NOT_CLASSIFIED
+        assert result.status_of("data_modality") == NOT_CLASSIFIED
         assert result.data_type == "raw_signal"
         assert result.platform == "ONT"
-        assert result.reference_assembly == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_pod5_raw_signal(self):
         result = engine.classify_extended(FileInfo(filename="sample_run.pod5"))
-        assert result.data_modality == NOT_CLASSIFIED
+        assert result.status_of("data_modality") == NOT_CLASSIFIED
         assert result.data_type == "raw_signal"
         assert result.platform == "ONT"
-        assert result.reference_assembly == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_flnc_bam_is_transcriptomic(self):
         """IsoSeq flnc BAM should be transcriptomic, not genomic."""
@@ -298,7 +298,7 @@ class TestRuleEngineE2E:
     def test_plain_bam_no_modality(self):
         """BAM without header or platform signals should not get genomic modality."""
         result = engine.classify_extended(FileInfo(filename="sample.reads.bam"))
-        assert result.data_modality == NOT_CLASSIFIED
+        assert result.status_of("data_modality") == NOT_CLASSIFIED
 
     def test_plink_1000g(self):
         result = engine.classify_extended(
@@ -318,34 +318,34 @@ class TestRuleEngineE2E:
     def test_fastq_rna_filename(self):
         result = engine.classify_extended(FileInfo(filename="sample_RNA_001.fastq.gz"))
         assert result.data_modality == "transcriptomic.bulk"
-        assert result.reference_assembly == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_checksum_not_applicable(self):
         result = engine.classify_extended(FileInfo(filename="sample.md5"))
-        assert result.data_modality == NOT_APPLICABLE
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_chunked_upload_not_applicable(self):
         result = engine.classify_extended(FileInfo(
             filename="c5ff4e67-1db9-4fd1.gs-chunked-io-part.000013"
         ))
-        assert result.data_modality == NOT_APPLICABLE
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_timestamp_filename_not_applicable(self):
         result = engine.classify_extended(FileInfo(
             filename="2020-11-20T212208.245537Z"
         ))
-        assert result.data_modality == NOT_APPLICABLE
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_png_derived(self):
         result = engine.classify_extended(FileInfo(filename="assembly_plot.png"))
-        assert result.data_modality == NOT_APPLICABLE
-        assert result.platform == NOT_APPLICABLE
-        assert result.reference_assembly == NOT_APPLICABLE
+        assert result.status_of("data_modality") == NOT_APPLICABLE
+        assert result.status_of("platform") == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_all_index_types_not_applicable(self):
         for ext in [".bai", ".crai", ".tbi", ".csi", ".pbi"]:
             result = engine.classify_extended(FileInfo(filename=f"sample{ext}"))
-            assert result.data_modality == NOT_APPLICABLE, f"{ext} should be not_applicable"
+            assert result.status_of("data_modality") == NOT_APPLICABLE, f"{ext} should be not_applicable"
 
     def test_narrowpeak_is_chromatin(self):
         result = engine.classify_extended(FileInfo(filename="sample.narrowPeak"))
@@ -368,36 +368,38 @@ class TestRuleEngineE2E:
     def test_no_crash_on_unknown(self):
         for name in ["readme.xyz", "data.parquet", "model.h5", ""]:
             result = engine.classify_extended(FileInfo(filename=name))
-            assert result.data_modality is not None
+            # Unknown files don't crash and resolve to a not_classified status
+            # (the value stays None — the sentinel lives in status now).
+            assert result.status_of("data_modality") == NOT_CLASSIFIED
 
     def test_fasta_base_rule(self):
         """FASTA files should get base rule classification."""
         for ext in [".fa", ".fasta", ".fa.gz", ".fasta.gz"]:
             result = engine.classify_extended(FileInfo(filename=f"sample{ext}"))
             assert result.data_type == "sequence", f"{ext} should be sequence"
-            assert result.platform == NOT_APPLICABLE
-            assert result.assay_type == NOT_APPLICABLE
+            assert result.status_of("platform") == NOT_APPLICABLE
+            assert result.status_of("assay_type") == NOT_APPLICABLE
 
     def test_fasta_assembly_filename(self):
         """FASTA with assembly keyword in filename."""
         result = engine.classify_extended(FileInfo(filename="HG00673.paternal.f1_assembly_v1.fa.gz"))
         assert result.data_modality == "genomic"
         assert result.data_type == "assembly"
-        assert result.reference_assembly == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_fasta_haplotype_filename(self):
         """FASTA with haplotype keyword in filename."""
         result = engine.classify_extended(FileInfo(filename="hapdup_contigs_2.fasta"))
         assert result.data_modality == "genomic"
         assert result.data_type == "assembly"
-        assert result.reference_assembly == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_fasta_verkko_filename(self):
         """FASTA with verkko assembler keyword."""
         result = engine.classify_extended(FileInfo(filename="HG02300_verkko_gfase_diploid.fasta.gz"))
         assert result.data_modality == "genomic"
         assert result.data_type == "assembly"
-        assert result.reference_assembly == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
 
 # =============================================================================
@@ -534,58 +536,58 @@ class TestDerivedFileTierPrecedence:
     def test_index_with_reference_in_filename(self):
         """Index file with GRCh38 in filename should get reference_assembly=GRCh38."""
         result = engine.classify_extended(FileInfo(filename="sample.GRCh38.bam.bai"))
-        assert result.data_modality == NOT_APPLICABLE
+        assert result.status_of("data_modality") == NOT_APPLICABLE
         assert result.reference_assembly == "GRCh38"
-        assert result.platform == NOT_APPLICABLE
+        assert result.status_of("platform") == NOT_APPLICABLE
 
     def test_index_with_chm13_in_filename(self):
         """Index file with CHM13 in filename should get reference_assembly=CHM13."""
         result = engine.classify_extended(FileInfo(filename="HG01879.CHM13v2.cram.crai"))
         assert result.reference_assembly == "CHM13"
-        assert result.data_modality == NOT_APPLICABLE
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_index_without_reference_in_filename(self):
         """Index file without reference hint should get reference_assembly=not_classified."""
         result = engine.classify_extended(FileInfo(filename="sample.bam.bai"))
-        assert result.reference_assembly == NOT_CLASSIFIED
-        assert result.data_modality == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_CLASSIFIED
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
     # --- Checksum files: all fields not_applicable, even with reference in filename ---
 
     def test_checksum_ignores_filename_reference(self):
         """Checksum file should stay not_applicable even with GRCh38 in filename."""
         result = engine.classify_extended(FileInfo(filename="sample.GRCh38.bam.md5"))
-        assert result.reference_assembly == NOT_APPLICABLE
-        assert result.data_modality == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
     # --- Log files: all fields not_applicable ---
 
     def test_log_ignores_filename_reference(self):
         """Log file should stay not_applicable even with hg38 in filename."""
         result = engine.classify_extended(FileInfo(filename="alignment.hg38.log"))
-        assert result.reference_assembly == NOT_APPLICABLE
-        assert result.data_modality == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
     # --- Image files: reference_assembly not_applicable at tier 2 ---
 
     def test_svs_ignores_filename_reference(self):
         """SVS histology image should stay not_applicable for reference_assembly."""
         result = engine.classify_extended(FileInfo(filename="hg38.sample.svs"))
-        assert result.reference_assembly == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
         assert result.data_modality == "imaging.histology"
 
     def test_png_ignores_filename_reference(self):
         """PNG plot with reference in filename should stay not_applicable."""
         result = engine.classify_extended(FileInfo(filename="GRCh38_coverage_plot.png"))
-        assert result.reference_assembly == NOT_APPLICABLE
-        assert result.data_modality == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
     # --- Nanopore raw signal: reference_assembly not_applicable ---
 
     def test_fast5_ignores_filename_reference(self):
         """FAST5 raw signal with reference in filename should stay not_applicable."""
         result = engine.classify_extended(FileInfo(filename="GRCh38_run.fast5"))
-        assert result.reference_assembly == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
         assert result.platform == "ONT"
 
     # --- Stats files: reference_assembly applicable, other fields not_applicable (#106) ---
@@ -594,14 +596,14 @@ class TestDerivedFileTierPrecedence:
         """Stats file with CHM13 in filename should get reference_assembly=CHM13."""
         result = engine.classify_extended(FileInfo(filename="HG01879.CHM13v2.chrX.samtools.stats.txt"))
         assert result.reference_assembly == "CHM13"
-        assert result.data_modality == NOT_APPLICABLE
-        assert result.platform == NOT_APPLICABLE
+        assert result.status_of("data_modality") == NOT_APPLICABLE
+        assert result.status_of("platform") == NOT_APPLICABLE
 
     def test_stats_without_reference_in_filename(self):
         """Stats file without reference hint should get not_classified, not not_applicable."""
         result = engine.classify_extended(FileInfo(filename="HG00345.mosdepth.region.dist.txt"))
-        assert result.reference_assembly == NOT_CLASSIFIED
-        assert result.data_modality == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_CLASSIFIED
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
     # --- BED tier precedence: specific rules beat fallbacks ---
 
@@ -620,4 +622,4 @@ class TestDerivedFileTierPrecedence:
     def test_capture_targets_not_applicable(self):
         """Capture target BED without competing rules should get not_applicable."""
         result = engine.classify_extended(FileInfo(filename="exome_capture_targets.bed"))
-        assert result.data_modality == NOT_APPLICABLE
+        assert result.status_of("data_modality") == NOT_APPLICABLE

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -10,7 +10,12 @@ from src.meta_disco.models import (
     ClassificationResult,
     FileInfo,
 )
-from src.meta_disco.rule_engine import ExtendedFileInfo, RuleEngine, evaluate_claims
+from src.meta_disco.rule_engine import (
+    ExtendedClassificationResult,
+    ExtendedFileInfo,
+    RuleEngine,
+    evaluate_claims,
+)
 
 
 @pytest.fixture
@@ -149,6 +154,29 @@ class TestThenStatus:
         assert out["data_type"]["value"] == "raw_signal"
         assert out["reference_assembly"]["status"] == NOT_APPLICABLE
         assert out["reference_assembly"]["value"] is None
+
+
+class TestSetFieldValidation:
+    """set_field rejects unknown fields/statuses instead of silently mis-storing."""
+
+    def test_rejects_unknown_field(self):
+        result = ExtendedClassificationResult()
+        with pytest.raises(ValueError, match="unknown classification field"):
+            result.set_field("platfrom", "ILLUMINA")  # typo
+
+    def test_rejects_unknown_status(self):
+        result = ExtendedClassificationResult()
+        with pytest.raises(ValueError, match="unknown status"):
+            result.set_field("data_modality", status="confict")  # typo for conflict
+
+    def test_accepts_known_field_and_status(self):
+        result = ExtendedClassificationResult()
+        result.set_field("platform", "ILLUMINA")
+        result.set_field("reference_assembly", status=NOT_APPLICABLE)
+        assert result.platform == "ILLUMINA"
+        assert result.status_of("platform") == CLASSIFIED
+        assert result.reference_assembly is None
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
 
 class TestDerivativeFiles:

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -178,6 +178,13 @@ class TestSetFieldValidation:
         assert result.reference_assembly is None
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
+    @pytest.mark.parametrize("accessor", ["status_of", "is_declared", "label"])
+    def test_read_accessors_reject_unknown_field(self, accessor):
+        # Read helpers raise a consistent ValueError (not a bare KeyError) on a typo.
+        result = ExtendedClassificationResult()
+        with pytest.raises(ValueError, match="unknown classification field"):
+            getattr(result, accessor)("platfrom")
+
 
 class TestDerivativeFiles:
     """Test that derivative files (indices, checksums, logs) get not_applicable."""

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -156,23 +156,23 @@ class TestDerivativeFiles:
 
     def test_index_bai(self, engine):
         """BAI index files should be not_applicable."""
-        result = engine.classify(FileInfo(filename="sample.bam.bai"))
-        assert result.data_modality == NOT_APPLICABLE
+        result = engine.classify_extended(FileInfo(filename="sample.bam.bai"))
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_index_crai(self, engine):
         """CRAI index files should be not_applicable."""
-        result = engine.classify(FileInfo(filename="sample.cram.crai"))
-        assert result.data_modality == NOT_APPLICABLE
+        result = engine.classify_extended(FileInfo(filename="sample.cram.crai"))
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_checksum_md5(self, engine):
         """MD5 checksum files should be not_applicable."""
-        result = engine.classify(FileInfo(filename="HG02558.final.cram.md5"))
-        assert result.data_modality == NOT_APPLICABLE
+        result = engine.classify_extended(FileInfo(filename="HG02558.final.cram.md5"))
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_log_files(self, engine):
         """Log files should be not_applicable."""
-        result = engine.classify(FileInfo(filename="pipeline.log"))
-        assert result.data_modality == NOT_APPLICABLE
+        result = engine.classify_extended(FileInfo(filename="pipeline.log"))
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
 
 class TestSpecialFileTypes:
@@ -219,8 +219,8 @@ class TestFastqFiles:
 
     def test_fastq_ambiguous(self, engine):
         """FASTQ without indicators is not classified for modality."""
-        result = engine.classify(FileInfo(filename="sample_R1.fastq.gz"))
-        assert result.data_modality == NOT_CLASSIFIED
+        result = engine.classify_extended(FileInfo(filename="sample_R1.fastq.gz"))
+        assert result.status_of("data_modality") == NOT_CLASSIFIED
 
 
 class TestSignalTracks:
@@ -273,8 +273,8 @@ class TestTextFiles:
 
     def test_stats_file(self, engine):
         """QC stats files should be not_applicable."""
-        result = engine.classify(FileInfo(filename="sample.stats.txt"))
-        assert result.data_modality == NOT_APPLICABLE
+        result = engine.classify_extended(FileInfo(filename="sample.stats.txt"))
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_count_matrix(self, engine):
         """Count matrix files should be transcriptomic."""
@@ -283,8 +283,8 @@ class TestTextFiles:
 
     def test_ambiguous_txt(self, engine):
         """Ambiguous text files are not classified for modality."""
-        result = engine.classify(FileInfo(filename="data.txt"))
-        assert result.data_modality == NOT_CLASSIFIED
+        result = engine.classify_extended(FileInfo(filename="data.txt"))
+        assert result.status_of("data_modality") == NOT_CLASSIFIED
 
 
 class TestIntegration:
@@ -312,13 +312,13 @@ class TestIntegration:
 
     def test_cram_md5(self, engine):
         """CRAM MD5 checksum should be not_applicable."""
-        result = engine.classify(FileInfo(filename="HG02558.final.cram.md5"))
-        assert result.data_modality == NOT_APPLICABLE
+        result = engine.classify_extended(FileInfo(filename="HG02558.final.cram.md5"))
+        assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_unknown_extension(self, engine):
         """Unknown extensions are not classified."""
-        result = engine.classify(FileInfo(filename="sample.xyz"))
-        assert result.data_modality == NOT_CLASSIFIED
+        result = engine.classify_extended(FileInfo(filename="sample.xyz"))
+        assert result.status_of("data_modality") == NOT_CLASSIFIED
 
 
 class TestConflictingReferenceRules:
@@ -327,12 +327,12 @@ class TestConflictingReferenceRules:
     def test_ambiguous_filename_two_refs(self, engine):
         """Filename with both CHM13 and hg38 should be not_classified."""
         result = engine.classify_extended(FileInfo(filename="CHM13.hg38.gff3.gz"))
-        assert result.reference_assembly == NOT_CLASSIFIED
+        assert result.status_of("reference_assembly") == NOT_CLASSIFIED
 
     def test_liftover_chain_two_refs(self, engine):
         """Liftover chain with two references should be not_classified."""
         result = engine.classify_extended(FileInfo(filename="liftover.hg19.to.hg38.chain"))
-        assert result.reference_assembly == NOT_CLASSIFIED
+        assert result.status_of("reference_assembly") == NOT_CLASSIFIED
 
     def test_single_ref_not_affected(self, engine):
         """Single reference in filename should still work."""
@@ -355,7 +355,7 @@ class TestConflictingClassificationFields:
     def test_data_modality_conflict(self, engine):
         """Same-tier rules disagreeing on data_modality produce not_classified."""
         result = engine.classify_extended(FileInfo(filename="sample_rnaseq_wgs_aligned.bam"))
-        assert result.data_modality == NOT_CLASSIFIED
+        assert result.status_of("data_modality") == NOT_CLASSIFIED
         evidence = result.field_evidence.get("data_modality", [])
         rule_ids = [e["rule_id"] for e in evidence]
         assert "conflicting_data_modality_rules" in rule_ids
@@ -369,12 +369,14 @@ class TestConflictingClassificationFields:
         assert "filename_ref_grch38" in rule_ids or "filename_ref_chm13" in rule_ids
         assert "conflicting_reference_assembly_rules" in rule_ids
 
-    def test_conflict_evidence_has_value_and_competing_values(self, engine):
-        """Conflict evidence should have structured value and competing_values fields."""
+    def test_conflict_evidence_has_status_and_competing_values(self, engine):
+        """Conflict evidence carries a not_classified status (in the status field,
+        not the value slot) and the structured competing_values field."""
         result = engine.classify_extended(FileInfo(filename="CHM13.hg38.gff3.gz"))
         evidence = result.field_evidence.get("reference_assembly", [])
         conflict = [e for e in evidence if "conflicting_" in e["rule_id"]][0]
-        assert conflict["value"] == NOT_CLASSIFIED
+        assert conflict["status"] == NOT_CLASSIFIED
+        assert "value" not in conflict
         assert set(conflict["competing_values"]) == {"GRCh38", "CHM13"}
 
     def test_normal_evidence_has_value_field(self, engine):
@@ -389,9 +391,10 @@ class TestEvaluateClaims:
     """Test the standalone evaluate_claims() function."""
 
     def test_no_claims(self):
-        """No claims → not_classified."""
+        """No claims → not_classified (status), no value."""
         result = evaluate_claims([])
-        assert result["value"] == NOT_CLASSIFIED
+        assert result["status"] == NOT_CLASSIFIED
+        assert result["value"] is None
         assert result["is_conflict"] is False
         assert result["reason"] == "no_claims"
 
@@ -427,12 +430,13 @@ class TestEvaluateClaims:
         assert result["is_conflict"] is False
 
     def test_disagree_same_tier(self):
-        """Same tier, different values → conflict."""
+        """Same tier, different values → conflict (not_classified status, no value)."""
         result = evaluate_claims([
             {"rule_id": "r1", "value": "GRCh38", "confidence": 0.90, "tier": 2},
             {"rule_id": "r2", "value": "CHM13", "confidence": 0.90, "tier": 2},
         ])
-        assert result["value"] == NOT_CLASSIFIED
+        assert result["status"] == NOT_CLASSIFIED
+        assert result["value"] is None
         assert result["is_conflict"] is True
         assert result["reason"] == "conflict"
         assert set(result["competing_values"]) == {"GRCh38", "CHM13"}
@@ -444,53 +448,56 @@ class TestEvaluateClaims:
             {"rule_id": "r2", "value": "genomic", "confidence": 0.90, "tier": 3},
             {"rule_id": "r3", "value": "transcriptomic.bulk", "confidence": 0.90, "tier": 3},
         ])
-        assert result["value"] == NOT_CLASSIFIED
+        assert result["status"] == NOT_CLASSIFIED
+        assert result["value"] is None
         assert result["is_conflict"] is True
 
     def test_not_classified_claims_ignored(self):
-        """Claims with value=NOT_CLASSIFIED are filtered out."""
+        """Claims declaring not_classified (status) don't assert a value."""
         result = evaluate_claims([
-            {"rule_id": "r1", "value": NOT_CLASSIFIED, "confidence": 0.0},
+            {"rule_id": "r1", "status": NOT_CLASSIFIED, "confidence": 0.0},
             {"rule_id": "r2", "value": "genomic", "confidence": 0.90, "tier": 2},
         ])
         assert result["value"] == "genomic"
         assert result["reason"] == "single_claim"
 
-    def test_not_applicable_is_real_value(self):
-        """NOT_APPLICABLE is a real value, not filtered out."""
+    def test_not_applicable_status_declaration(self):
+        """A not_applicable status claim resolves to status not_applicable, value None."""
         result = evaluate_claims([
-            {"rule_id": "r1", "value": NOT_APPLICABLE, "confidence": 1.0, "tier": 1},
+            {"rule_id": "r1", "status": NOT_APPLICABLE, "confidence": 1.0, "tier": 1},
         ])
-        assert result["value"] == NOT_APPLICABLE
+        assert result["status"] == NOT_APPLICABLE
+        assert result["value"] is None
         assert result["reason"] == "single_claim"
 
     def test_not_applicable_wins_over_real_value_same_tier(self):
         """NOT_APPLICABLE is a terminal declaration — wins without conflict."""
         result = evaluate_claims([
-            {"rule_id": "r1", "value": NOT_APPLICABLE, "confidence": 1.0, "tier": 1},
+            {"rule_id": "r1", "status": NOT_APPLICABLE, "confidence": 1.0, "tier": 1},
             {"rule_id": "r2", "value": "genomic", "confidence": 0.90, "tier": 1},
         ])
-        assert result["value"] == NOT_APPLICABLE
+        assert result["status"] == NOT_APPLICABLE
+        assert result["value"] is None
         assert result["is_conflict"] is False
         assert result["reason"] == "not_applicable_terminal"
 
-
     def test_rule_authored_not_classified_is_not_no_claims(self):
-        """A rule that intentionally sets NOT_CLASSIFIED is treated as a real claim, not no_claims."""
+        """A rule that intentionally declares not_classified is a real claim, not no_claims."""
         result = evaluate_claims([
-            {"rule_id": "fastq_modality_unknown", "value": NOT_CLASSIFIED,
+            {"rule_id": "fastq_modality_unknown", "status": NOT_CLASSIFIED,
              "confidence": 0.0, "tier": 3,
              "reason": "FASTQ modality cannot be determined from reads alone"},
         ])
-        assert result["value"] == NOT_CLASSIFIED
+        assert result["status"] == NOT_CLASSIFIED
+        assert result["value"] is None
         assert result["reason"] == "single_claim"
         # The claim should NOT be treated as "no_claims"
         assert result["reason"] != "no_claims"
 
     def test_rule_authored_not_classified_does_not_conflict_with_real(self):
-        """A rule's NOT_CLASSIFIED shouldn't conflict with a real value claim."""
+        """A rule's not_classified declaration shouldn't conflict with a real value claim."""
         result = evaluate_claims([
-            {"rule_id": "fastq_modality_unknown", "value": NOT_CLASSIFIED,
+            {"rule_id": "fastq_modality_unknown", "status": NOT_CLASSIFIED,
              "confidence": 0.0, "tier": 3},
             {"rule_id": "some_rule", "value": "genomic",
              "confidence": 0.90, "tier": 3},
@@ -539,14 +546,14 @@ class TestAssayTypeInference:
             file_size_gb=60.0, file_format=".bam",
         )
         result = engine.classify_extended(FileInfo(filename="sample.bam", file_size=60_000_000_000))
-        result.data_modality = "genomic"
-        result.platform = "ILLUMINA"
-        result.assay_type = NOT_CLASSIFIED
+        result.set_field("data_modality", "genomic")
+        result.set_field("platform", "ILLUMINA")
+        result.set_field("assay_type", status=NOT_CLASSIFIED)
         result.field_evidence["assay_type"] = [{
             "rule_id": "not_classified",
             "reason": "No rule determined a value for assay_type",
             "confidence": 0.0,
-            "value": NOT_CLASSIFIED,
+            "status": NOT_CLASSIFIED,
         }]
         engine.infer_assay_type(result, file_info)
         assert result.assay_type == "WGS"
@@ -577,16 +584,16 @@ class TestSentinelValues:
         """Index files get not_applicable for modality/platform/assay but not reference_assembly
         (reference IS applicable to indexes — it's determined by the parent file's alignment)."""
         result = engine.classify_extended(FileInfo(filename="sample.bam.bai"))
-        assert result.data_modality == NOT_APPLICABLE
-        assert result.reference_assembly == NOT_CLASSIFIED  # applicable but unknown without filename hint
-        assert result.platform == NOT_APPLICABLE
-        assert result.assay_type == NOT_APPLICABLE
+        assert result.status_of("data_modality") == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_CLASSIFIED  # applicable but unknown without filename hint
+        assert result.status_of("platform") == NOT_APPLICABLE
+        assert result.status_of("assay_type") == NOT_APPLICABLE
 
     def test_unclassified_fields_get_not_classified(self, engine):
         """Files with unset fields should get not_classified."""
         result = engine.classify_extended(FileInfo(filename="sample.xyz"))
-        assert result.data_modality == NOT_CLASSIFIED
-        assert result.reference_assembly == NOT_CLASSIFIED
+        assert result.status_of("data_modality") == NOT_CLASSIFIED
+        assert result.status_of("reference_assembly") == NOT_CLASSIFIED
 
     def test_not_classified_evidence_includes_field_name(self, engine):
         """Evidence reason for not_classified should name the specific field."""
@@ -605,18 +612,18 @@ class TestSentinelValues:
         """Image files should get not_applicable for platform and reference."""
         result = engine.classify_extended(FileInfo(filename="sample.svs"))
         assert result.data_modality == "imaging.histology"
-        assert result.platform == NOT_APPLICABLE
-        assert result.reference_assembly == NOT_APPLICABLE
+        assert result.status_of("platform") == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_fastq_gets_not_applicable_reference(self, engine):
         """FASTQ files should get not_applicable for reference (unaligned reads)."""
         result = engine.classify_extended(FileInfo(filename="sample.fastq.gz"))
-        assert result.reference_assembly == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_fast5_gets_not_applicable_reference(self, engine):
         """FAST5 files should get not_applicable for reference (raw signal)."""
         result = engine.classify_extended(FileInfo(filename="sample.fast5"))
-        assert result.reference_assembly == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
         assert result.platform == "ONT"
 
     def test_bam_without_header_not_classified(self, engine):
@@ -625,15 +632,15 @@ class TestSentinelValues:
             ExtendedFileInfo(filename="sample.bam", file_size_gb=60.0)
         )
         # No header = no modality evidence, even for large files
-        assert result.data_modality == NOT_CLASSIFIED
+        assert result.status_of("data_modality") == NOT_CLASSIFIED
 
     def test_png_all_fields_not_applicable(self, engine):
         """PNG files should get not_applicable for all non-applicable fields."""
         result = engine.classify_extended(FileInfo(filename="plot.png"))
-        assert result.data_modality == NOT_APPLICABLE
-        assert result.platform == NOT_APPLICABLE
-        assert result.reference_assembly == NOT_APPLICABLE
-        assert result.assay_type == NOT_APPLICABLE
+        assert result.status_of("data_modality") == NOT_APPLICABLE
+        assert result.status_of("platform") == NOT_APPLICABLE
+        assert result.status_of("reference_assembly") == NOT_APPLICABLE
+        assert result.status_of("assay_type") == NOT_APPLICABLE
 
 
 class TestOutputDictStatus:

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -562,10 +562,10 @@ class TestAssayTypeInference:
             file_size_gb=60.0, file_format=".bam",
         )
         result = engine.classify_extended(FileInfo(filename="sample.bam", file_size=60_000_000_000))
-        # Set conditions that trigger WGS inference
-        result.data_modality = "genomic"
-        result.platform = "ILLUMINA"
-        result.assay_type = None
+        # Set conditions that trigger WGS inference (via set_field to stay coherent)
+        result.set_field("data_modality", "genomic")
+        result.set_field("platform", "ILLUMINA")
+        result.set_field("assay_type", status=NOT_CLASSIFIED)
         result.field_evidence["assay_type"] = []
         engine.infer_assay_type(result, file_info)
         assert result.assay_type == "WGS"


### PR DESCRIPTION
## Summary

Completes epic **#116**: `not_applicable` / `not_classified` no longer sit in a value slot **anywhere** — internal or emitted. #133 moved sentinels out of the rule *authoring* surface; this PR moves them out of the engine's *runtime* representation and the emitted evidence.

## What changed

- **`ExtendedClassificationResult`** — dimension attributes now hold a real value or `None` only; a parallel `field_status` dict holds the status. New helpers:
  - `set_field(fld, value=None, status=None)` — coherent write, validated by the single coherence definition `models._assert_coherent`.
  - `status_of(fld)`, `is_declared(fld)` (a real value or explicit not_applicable), `label(fld)` (value-or-status, for flat/CSV views).
  - `to_output_dict` passes the resolved status straight to `build_field_entry`.
- **`evaluate_claims`** — resolves in "declaration space" (a claim's real `value`, else its `status`) via new `_claim_declaration` / `_resolved`, returning `value` (real|None) **and** `status`. Every branch is preserved (no_claims, unanimous, tier override, **not_applicable terminal**, conflict) — behavior unchanged.
- **Claims & evidence** carry a `status` key for sentinels instead of a sentinel `value`; synthetic conflict/no_claims evidence carry `status`.
- **`header_classifier`** — all ~10 attribute writes route through `set_field` (coherent value+status); sentinel reads use `is_declared`; NA/NC evidence carries `status`.
- **Scripts** — `run_batch_classification` uses `result.label()` for the CSV; `classify_index_files` / `classify_auxiliary_genomic` drop now-dead sentinel-in-value handling.

## Golden

Regenerated deliberately. The diff is **evidence-only**: each evidence entry's sentinel `value` (`"value": "not_applicable"`) becomes a `status` key (`"status": "not_applicable"`). Field-level `value`/`status` are unchanged (verified: the `value: null` count is identical, and no non-evidence line changed).

## Verification

- **446 tests** pass (engine, header, evals, golden shape) + the schema-component LinkML validation gate (6 passed).
- `/simplify` (applied one reuse fix: `set_field` routes coherence through `models._assert_coherent`) and `/code-review` at high effort (no confirmed correctness bugs; applied 3 docstring-precision fixes).

Follow-up to #133 / #135. Closes #136. Part of epic #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)