### PR TITLE
Remove vestigial confidence from the rule engine and records (#56, Stage 4c)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ The project has two main components:
    - Expects Ollama running on `localhost:11434`
 
 2. **Schema Validation** (`schema/` directory): LinkML-based validation of extracted metadata
-   - `src/meta_disco/schema/classification.yaml`: LinkML schema defining the `ClassificationRecord` (the five metadata dimensions nested under `classifications`, each a `{value, status, confidence, evidence}` entry) and the controlled vocabulary
+   - `src/meta_disco/schema/classification.yaml`: LinkML schema defining the `ClassificationRecord` (the five metadata dimensions nested under `classifications`, each a `{value, status, evidence}` entry) and the controlled vocabulary
    - `scripts/validate_outputs.py`: Validates YAML instances against the schema
    - Uses Poetry for dependency management (Python 3.10+)
 
@@ -50,7 +50,7 @@ python metadisco-inference.py <row_index> <model_name> <output_tsv_path>
 
 The LinkML schema (`classification.yaml`) defines the `ClassificationRecord` — the
 five metadata dimensions nested under `classifications`, each a `{value, status,
-confidence, evidence}` entry — plus the controlled vocabulary:
+evidence}` entry — plus the controlled vocabulary:
 - **reference_assembly_enum**: GRCh37, GRCh38, CHM13
 - **data_modality_enum**: genomic, transcriptomic.*, epigenomic.*, imaging.histology
 - **classification_status_enum**: classified, not_applicable, not_classified, conflict

--- a/docs/derived-file-data-model.md
+++ b/docs/derived-file-data-model.md
@@ -283,7 +283,7 @@ of this is already built. `classify_index_files.py` already writes
 is **materialize** the parent's values: lines 214–218 copy the parent's
 `data_modality / data_type / assay_type / platform / reference_assembly` onto the
 index, and lines 311–316 wrap them in per-field `classifications` blocks carrying
-an `inherited_from_parent` evidence entry at confidence `0.95`. So the refactor is
+an `inherited_from_parent` evidence entry. So the refactor is
 narrower than it first appears: keep the pointer (already there), stop treating
 the copied-in values as the index's own identity, and move "what it inherits" to
 query time (next section).
@@ -753,7 +753,7 @@ roadmap starts to cash in on generation.
   doesn't *add* the link — it stops the materialization that sits next to it.
 - **Materialization is real and localized.** Parent values are copied at lines
   214–218 and re-wrapped as per-field `classifications` with an
-  `inherited_from_parent` evidence entry (confidence `0.95`) at lines 311–316.
+  `inherited_from_parent` evidence entry at lines 311–316.
   That's the exact code this design changes.
 - **No in-repo search layer.** Discovery lives in the external Explorer/TDR.
   In-repo consumers are the report generators, which already index everything by

--- a/rules/unified_rules.yaml
+++ b/rules/unified_rules.yaml
@@ -34,8 +34,7 @@
 # 6. TERMINAL RULES: If terminal=true and the rule matches, processing stops
 #    immediately. Use for definitive classifications.
 #
-# 7. CONFIDENCE & REASONS: Each matching rule adds its rationale to the reasons
-#    list. The highest confidence from matching rules is used.
+# 7. REASONS: Each matching rule adds its rationale to the reasons list.
 #
 #
 # KEY CONCEPTS
@@ -72,7 +71,6 @@
 # - scope: extension|filename|header|vcf_header|fastq_header|file_size (required)
 # - when: conditions that must all match (required)
 # - then: effects to apply when rule matches (required)
-# - confidence: 0.0-1.0 confidence score (default: 0.0)
 # - rationale: explanation for this classification (recommended)
 #
 #
@@ -255,7 +253,6 @@ rules:
         data_type: not_applicable
         assay_type: not_applicable
         platform: not_applicable
-    confidence: 1.0
     rationale: "Index file — metadata inherited from parent data file"
 
   # ---------------------------------------------------------------------------
@@ -273,7 +270,6 @@ rules:
         reference_assembly: not_applicable
         assay_type: not_applicable
         platform: not_applicable
-    confidence: 1.0
     rationale: "Checksum file — not data"
 
   # ---------------------------------------------------------------------------
@@ -291,7 +287,6 @@ rules:
         reference_assembly: not_applicable
         assay_type: not_applicable
         platform: not_applicable
-    confidence: 1.0
     rationale: "Log file — not data"
 
   # ---------------------------------------------------------------------------
@@ -309,7 +304,6 @@ rules:
         reference_assembly: not_applicable
         assay_type: not_applicable
         platform: not_applicable
-    confidence: 1.0
     rationale: "Incomplete chunked upload artifact — not usable data"
 
   # ---------------------------------------------------------------------------
@@ -327,7 +321,6 @@ rules:
         reference_assembly: not_applicable
         assay_type: not_applicable
         platform: not_applicable
-    confidence: 1.0
     rationale: "Bare ISO timestamp filename — metadata artifact, not data"
 
   # ---------------------------------------------------------------------------
@@ -341,7 +334,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants
-    confidence: 0.85
     rationale: "VCF files contain variant calls (genomic data)"
 
   # ---------------------------------------------------------------------------
@@ -355,7 +347,6 @@ rules:
     then:
       data_modality: genomic
       data_type: genotypes
-    confidence: 0.95
     rationale: "PLINK files contain genotype data (genomic)"
 
   # ---------------------------------------------------------------------------
@@ -370,7 +361,6 @@ rules:
       data_modality: epigenomic.methylation
       data_type: array_signal
       assay_type: Methylation array
-    confidence: 0.95
     rationale: "IDAT files are Illumina methylation array data"
 
   # ---------------------------------------------------------------------------
@@ -384,7 +374,6 @@ rules:
     then:
       data_modality: transcriptomic.single_cell
       data_type: expression_matrix
-    confidence: 0.90
     rationale: "Single-cell matrix format indicates scRNA-seq"
 
   # ---------------------------------------------------------------------------
@@ -402,7 +391,6 @@ rules:
       status:
         platform: not_applicable
         reference_assembly: not_applicable
-    confidence: 0.95
     rationale: "SVS files are Aperio whole-slide histology images used for pathology analysis"
 
   # ---------------------------------------------------------------------------
@@ -420,7 +408,6 @@ rules:
         platform: not_applicable
         reference_assembly: not_applicable
         assay_type: not_applicable
-    confidence: 0.90
     rationale: "Image files are derived visualizations (QC plots, assembly graphs) — not primary experimental data"
 
   # ---------------------------------------------------------------------------
@@ -436,7 +423,6 @@ rules:
       platform: ONT
       status:
         reference_assembly: not_applicable
-    confidence: 0.90
     rationale: "FAST5 files contain raw Oxford Nanopore electrical signal data. Reference not applicable until basecalling/alignment"
 
   - id: nanopore_pod5
@@ -449,7 +435,6 @@ rules:
       platform: ONT
       status:
         reference_assembly: not_applicable
-    confidence: 0.90
     rationale: "POD5 files contain raw Oxford Nanopore electrical signal data (newer format replacing FAST5)"
 
   # ---------------------------------------------------------------------------
@@ -464,7 +449,6 @@ rules:
       data_type: reads
       status:
         reference_assembly: not_applicable
-    confidence: 0.50
     rationale: "FASTQ files contain raw sequencing reads. Reference not applicable until alignment"
 
   # ---------------------------------------------------------------------------
@@ -480,7 +464,6 @@ rules:
       status:
         platform: not_applicable
         assay_type: not_applicable
-    confidence: 0.30
     rationale: "FASTA file detected; header inspection needed to determine if de novo assembly, reference genome, or transcript sequences"
 
   # ===========================================================================
@@ -499,7 +482,6 @@ rules:
     then:
       data_modality: transcriptomic.bulk
       data_type: alignments
-    confidence: 0.80
     rationale: "Filename contains RNA-seq indicator"
 
   - id: alignment_isoseq_filename
@@ -511,7 +493,6 @@ rules:
     then:
       data_modality: transcriptomic.bulk
       data_type: alignments
-    confidence: 0.85
     rationale: "Filename contains IsoSeq indicator (flnc = full-length non-chimeric transcript reads)"
 
   - id: alignment_scrna_filename
@@ -523,7 +504,6 @@ rules:
     then:
       data_modality: transcriptomic.single_cell
       data_type: alignments
-    confidence: 0.85
     rationale: "Filename contains single-cell RNA indicator"
 
   - id: alignment_atac_filename
@@ -536,7 +516,6 @@ rules:
       data_modality: epigenomic.chromatin_accessibility
       data_type: alignments
       assay_type: ATAC-seq
-    confidence: 0.85
     rationale: "Filename contains ATAC-seq indicator"
 
   - id: alignment_chip_filename
@@ -549,7 +528,6 @@ rules:
       data_modality: epigenomic.histone_modification
       data_type: alignments
       assay_type: ChIP-seq
-    confidence: 0.80
     rationale: "Filename contains ChIP-seq indicator"
 
   - id: alignment_wgs_filename
@@ -562,7 +540,6 @@ rules:
       data_modality: genomic
       data_type: alignments
       assay_type: WGS
-    confidence: 0.85
     rationale: "Filename contains WGS indicator"
 
   - id: alignment_wes_filename
@@ -575,7 +552,6 @@ rules:
       data_modality: genomic
       data_type: alignments
       assay_type: WES
-    confidence: 0.85
     rationale: "Filename contains exome indicator"
 
   - id: alignment_hifi_filename
@@ -589,7 +565,6 @@ rules:
       data_type: alignments
       assay_type: WGS
       platform: PACBIO
-    confidence: 0.70
     rationale: "HiFi/PacBio reads typically used for genome assembly"
 
   - id: alignment_star_aligner
@@ -602,7 +577,6 @@ rules:
       data_modality: transcriptomic.bulk
       data_type: alignments
       assay_type: RNA-seq
-    confidence: 0.90
     rationale: "STAR aligner output indicates RNA-seq"
 
   # ---------------------------------------------------------------------------
@@ -615,7 +589,6 @@ rules:
       filename_pattern: "(?i)hg38|grch38|hs38"
     then:
       reference_assembly: GRCh38
-    confidence: 0.90
     rationale: "Filename contains GRCh38/hg38 reference indicator"
 
   - id: filename_ref_grch37
@@ -625,7 +598,6 @@ rules:
       filename_pattern: "(?i)hg19|grch37|hs37|b37"
     then:
       reference_assembly: GRCh37
-    confidence: 0.90
     rationale: "Filename contains GRCh37/hg19 reference indicator"
 
   - id: filename_ref_chm13
@@ -635,7 +607,6 @@ rules:
       filename_pattern: "(?i)chm13|t2t|CHM13v2|hs1"
     then:
       reference_assembly: CHM13
-    confidence: 0.90
     rationale: "Filename contains CHM13/T2T reference indicator"
 
   # ---------------------------------------------------------------------------
@@ -653,7 +624,6 @@ rules:
       dataset_pattern: "ANVIL_1000G_PRIMED_data_model"
     then:
       reference_assembly: GRCh38
-    confidence: 0.95
     rationale: "1000 Genomes Project high-coverage data uses GRCh38 reference"
 
   # ---------------------------------------------------------------------------
@@ -668,7 +638,6 @@ rules:
     then:
       data_modality: transcriptomic.bulk
       data_type: reads
-    confidence: 0.80
     rationale: "Filename contains RNA indicator"
 
   - id: reads_scrna_filename
@@ -680,7 +649,6 @@ rules:
     then:
       data_modality: transcriptomic.single_cell
       data_type: reads
-    confidence: 0.85
     rationale: "Filename contains single-cell indicator"
 
   - id: reads_atac_filename
@@ -693,7 +661,6 @@ rules:
       data_modality: epigenomic.chromatin_accessibility
       data_type: reads
       assay_type: ATAC-seq
-    confidence: 0.85
     rationale: "Filename contains ATAC indicator"
 
   - id: reads_wgs_filename
@@ -706,7 +673,6 @@ rules:
       data_modality: genomic
       data_type: reads
       assay_type: WGS
-    confidence: 0.80
     rationale: "Filename contains WGS indicator"
 
   # ---------------------------------------------------------------------------
@@ -723,7 +689,6 @@ rules:
       data_type: assembly
       status:
         reference_assembly: not_applicable
-    confidence: 0.80
     rationale: "Filename contains assembly/assembler indicator — de novo assembly"
 
   - id: fasta_haplotype_filename
@@ -737,7 +702,6 @@ rules:
       data_type: assembly
       status:
         reference_assembly: not_applicable
-    confidence: 0.80
     rationale: "Filename contains haplotype/phasing indicator — de novo assembly"
 
   # ---------------------------------------------------------------------------
@@ -753,7 +717,6 @@ rules:
       data_modality: epigenomic.chromatin_accessibility
       data_type: expression_matrix
       assay_type: ATAC-seq
-    confidence: 0.85
     rationale: "Single-cell matrix with ATAC indicator"
 
   # ---------------------------------------------------------------------------
@@ -769,7 +732,6 @@ rules:
       data_modality: transcriptomic.bulk
       data_type: raw_signal
       platform: ONT
-    confidence: 0.80
     rationale: "Nanopore direct RNA sequencing"
 
   # ---------------------------------------------------------------------------
@@ -785,7 +747,6 @@ rules:
       data_modality: epigenomic.methylation
       data_type: annotations
       assay_type: Bisulfite-seq
-    confidence: 0.90
     rationale: "BED file contains CpG methylation calls or bisulfite sequencing regions"
 
   - id: bed_expression
@@ -798,7 +759,6 @@ rules:
       data_modality: transcriptomic.bulk
       data_type: annotations
       assay_type: RNA-seq
-    confidence: 0.90
     rationale: "BED file contains gene expression quantification or splicing data"
 
   - id: bed_atac_peaks
@@ -811,7 +771,6 @@ rules:
       data_modality: epigenomic.chromatin_accessibility
       data_type: peaks
       assay_type: ATAC-seq
-    confidence: 0.90
     rationale: "BED file contains ATAC-seq peak calls for chromatin accessibility"
 
   - id: bed_chip_peaks
@@ -824,7 +783,6 @@ rules:
       data_modality: epigenomic.histone_modification
       data_type: peaks
       assay_type: ChIP-seq
-    confidence: 0.90
     rationale: "BED file contains ChIP-seq peak calls for histone marks or TF binding"
 
   - id: bed_peaks_generic
@@ -836,7 +794,6 @@ rules:
     then:
       data_modality: epigenomic.chromatin_accessibility
       data_type: peaks
-    confidence: 0.85
     rationale: "BED file contains ChIP-seq or ATAC-seq peak calls"
 
   - id: bed_assembly_qc
@@ -848,7 +805,6 @@ rules:
     then:
       data_modality: genomic
       data_type: annotations
-    confidence: 0.85
     rationale: "BED file is assembly QC output (haplotype regions, error flags) on de novo genomic assemblies"
 
   - id: bed_regions
@@ -860,7 +816,6 @@ rules:
     then:
       data_modality: genomic
       data_type: annotations
-    confidence: 0.80
     rationale: "BED file contains genomic analysis regions (callable, target, etc.)"
 
   # ---------------------------------------------------------------------------
@@ -876,7 +831,6 @@ rules:
       data_modality: epigenomic.histone_modification
       data_type: signal
       assay_type: ChIP-seq
-    confidence: 0.85
     rationale: "Signal track with ChIP/histone indicator"
 
   - id: signal_atac
@@ -889,7 +843,6 @@ rules:
       data_modality: epigenomic.chromatin_accessibility
       data_type: signal
       assay_type: ATAC-seq
-    confidence: 0.85
     rationale: "Signal track with ATAC indicator"
 
   - id: signal_rnaseq
@@ -901,7 +854,6 @@ rules:
     then:
       data_modality: transcriptomic.bulk
       data_type: signal
-    confidence: 0.75
     rationale: "Signal track with RNA/coverage indicator"
 
   # ---------------------------------------------------------------------------
@@ -919,7 +871,6 @@ rules:
         data_type: not_applicable
         assay_type: not_applicable
         platform: not_applicable
-    confidence: 0.85
     rationale: "Target/capture region file — reference data, not primary experimental data"
 
   # ---------------------------------------------------------------------------
@@ -935,7 +886,6 @@ rules:
       data_modality: epigenomic.histone_modification
       data_type: peaks
       assay_type: ChIP-seq
-    confidence: 0.90
     rationale: "ChIP-seq histone modification peaks"
 
   # ---------------------------------------------------------------------------
@@ -953,7 +903,6 @@ rules:
         data_type: not_applicable
         assay_type: not_applicable
         platform: not_applicable
-    confidence: 0.90
     rationale: "QC/stats file — supplementary data, not primary experimental data"
 
   - id: text_counts
@@ -965,7 +914,6 @@ rules:
     then:
       data_modality: transcriptomic.bulk
       data_type: expression_matrix
-    confidence: 0.70
     rationale: "Filename suggests expression count data"
 
   # ---------------------------------------------------------------------------
@@ -981,7 +929,6 @@ rules:
     then:
       data_modality: genomic
       data_type: archive
-    confidence: 0.75
     rationale: "T2T project genomic region archive"
 
   # ===========================================================================
@@ -1010,7 +957,6 @@ rules:
       header_pattern: "PACBIO"
     then:
       platform: PACBIO
-    confidence: 0.70
     rationale: "PL:PACBIO indicates PacBio long-read sequencing"
 
   - id: platform_illumina
@@ -1023,7 +969,6 @@ rules:
       header_pattern: "ILLUMINA"
     then:
       platform: ILLUMINA
-    confidence: 0.95
     rationale: "PL:ILLUMINA in @RG header — definitive Illumina platform tag"
 
   - id: platform_ont
@@ -1036,7 +981,6 @@ rules:
       header_pattern: "ONT"
     then:
       platform: ONT
-    confidence: 0.70
     rationale: "PL:ONT indicates Oxford Nanopore long-read sequencing"
 
   - id: platform_ont_alt
@@ -1049,7 +993,6 @@ rules:
       header_pattern: "NANOPORE"
     then:
       platform: ONT
-    confidence: 0.70
     rationale: "Alternative platform identifier for Oxford Nanopore Technology"
 
   # ---------------------------------------------------------------------------
@@ -1065,7 +1008,6 @@ rules:
       header_pattern: "basecall_model=[^;\\s]*dna_"
     then:
       data_modality: genomic
-    confidence: 0.90
     rationale: "ONT basecall model containing dna_ indicates DNA sequencing (genomic data). Handles both modern (dna_r10...) and legacy date-prefixed (2021-05-05_dna_r9...) formats"
 
   - id: ont_basecall_rna
@@ -1078,7 +1020,6 @@ rules:
       header_pattern: "basecall_model=[^;\\s]*rna_"
     then:
       data_modality: transcriptomic.bulk
-    confidence: 0.90
     rationale: "ONT basecall model containing rna_ indicates RNA sequencing (transcriptomic data). Handles both modern (rna_r9...) and legacy date-prefixed formats"
 
   # ---------------------------------------------------------------------------
@@ -1096,7 +1037,6 @@ rules:
       data_modality: transcriptomic.bulk
       data_type: alignments
       assay_type: RNA-seq
-    confidence: 0.95
     rationale: "STAR (Spliced Transcripts Alignment to a Reference) is the most widely used RNA-seq aligner. Presence strongly indicates RNA-seq data"
 
   - id: program_hisat2
@@ -1111,7 +1051,6 @@ rules:
       data_modality: transcriptomic.bulk
       data_type: alignments
       assay_type: RNA-seq
-    confidence: 0.95
     rationale: "HISAT2 is a splice-aware aligner optimized for RNA-seq"
 
   - id: program_tophat
@@ -1126,7 +1065,6 @@ rules:
       data_modality: transcriptomic.bulk
       data_type: alignments
       assay_type: RNA-seq
-    confidence: 0.95
     rationale: "TopHat was an early splice-aware aligner for RNA-seq (now superseded by HISAT2)"
 
   - id: program_salmon
@@ -1140,7 +1078,6 @@ rules:
     then:
       data_modality: transcriptomic.bulk
       assay_type: RNA-seq
-    confidence: 0.95
     rationale: "Salmon is a transcript-level quantification tool for RNA-seq"
 
   - id: program_kallisto
@@ -1154,7 +1091,6 @@ rules:
     then:
       data_modality: transcriptomic.bulk
       assay_type: RNA-seq
-    confidence: 0.95
     rationale: "Kallisto performs rapid transcript quantification using pseudoalignment"
 
   # ---------------------------------------------------------------------------
@@ -1171,7 +1107,6 @@ rules:
     then:
       data_modality: genomic
       data_type: alignments
-    confidence: 0.80
     rationale: "BWA (Burrows-Wheeler Aligner) is the standard short-read aligner for DNA sequencing. Commonly used for WGS, WES, and ChIP-seq"
 
   - id: program_minimap2
@@ -1185,7 +1120,6 @@ rules:
     then:
       data_modality: genomic
       data_type: alignments
-    confidence: 0.75
     rationale: "Minimap2 is a versatile aligner for long reads (PacBio, ONT) and assemblies. Can also be used for direct RNA with -ax splice preset"
 
   - id: program_bowtie2
@@ -1199,7 +1133,6 @@ rules:
     then:
       data_modality: genomic
       data_type: alignments
-    confidence: 0.75
     rationale: "Bowtie2 is a fast short-read aligner commonly used for ChIP-seq, ATAC-seq, and WGS"
 
   # ---------------------------------------------------------------------------
@@ -1215,7 +1148,6 @@ rules:
       header_pattern: "ccs"
     then:
       platform: PACBIO
-    confidence: 0.85
     rationale: "The 'ccs' program generates HiFi reads from PacBio subreads. Confirms PacBio platform (used for both WGS and IsoSeq)"
 
   - id: program_isoseq
@@ -1230,7 +1162,6 @@ rules:
       data_modality: transcriptomic.bulk
       platform: PACBIO
       assay_type: RNA-seq
-    confidence: 0.95
     rationale: "IsoSeq is PacBio's full-length transcript sequencing method for isoform characterization"
 
   - id: program_lima
@@ -1243,7 +1174,6 @@ rules:
       header_pattern: "lima"
     then:
       platform: PACBIO
-    confidence: 0.0
     rationale: "Lima is PacBio's barcode demultiplexer. Doesn't indicate modality"
 
   # ---------------------------------------------------------------------------
@@ -1259,7 +1189,6 @@ rules:
       header_pattern: "(?i)(grch38|hg38|hs38)"
     then:
       reference_assembly: GRCh38
-    confidence: 0.95
     rationale: "Contig names containing GRCh38/hg38/hs38 indicate alignment to GRCh38 reference"
 
   - id: header_ref_grch37
@@ -1272,7 +1201,6 @@ rules:
       header_pattern: "(?i)(grch37|hg19|hs37)"
     then:
       reference_assembly: GRCh37
-    confidence: 0.95
     rationale: "Contig names containing GRCh37/hg19/hs37 indicate alignment to GRCh37 reference"
 
   - id: header_ref_chm13
@@ -1285,7 +1213,6 @@ rules:
       header_pattern: "(?i)(chm13|t2t|hs1)"
     then:
       reference_assembly: CHM13
-    confidence: 0.95
     rationale: "Contig names containing CHM13/T2T/hs1 indicate alignment to T2T-CHM13 reference"
 
   - id: header_ref_as_grch38
@@ -1298,7 +1225,6 @@ rules:
       header_pattern: "(?i)(grch38|hg38|hs38)"
     then:
       reference_assembly: GRCh38
-    confidence: 0.95
     rationale: "AS field containing GRCh38/hg38/hs38 explicitly identifies the reference assembly"
 
   - id: header_ref_as_grch37
@@ -1311,7 +1237,6 @@ rules:
       header_pattern: "(?i)(grch37|hg19|hs37|b37)"
     then:
       reference_assembly: GRCh37
-    confidence: 0.95
     rationale: "AS field containing GRCh37/hg19/hs37/b37 explicitly identifies the reference assembly"
 
   - id: header_ref_as_chm13
@@ -1324,7 +1249,6 @@ rules:
       header_pattern: "(?i)(chm13|t2t|hs1)"
     then:
       reference_assembly: CHM13
-    confidence: 0.95
     rationale: "AS field containing CHM13/T2T/hs1 explicitly identifies the reference assembly"
 
   # ---------------------------------------------------------------------------
@@ -1340,7 +1264,6 @@ rules:
     then:
       status:
         reference_assembly: not_applicable
-    confidence: 0.90
     rationale: "Absence of @SQ lines indicates unaligned reads. Common for PacBio HiFi deliverables before alignment"
 
   # ===========================================================================
@@ -1359,7 +1282,6 @@ rules:
       vcf_pattern: "(?i)(grch38|hg38|hs38|GCA_000001405\\.15)"
     then:
       reference_assembly: GRCh38
-    confidence: 0.95
     rationale: "##reference line containing GRCh38, hg38, or the GRCh38 GenBank accession indicates variants called against GRCh38"
 
   - id: vcf_ref_grch37
@@ -1371,7 +1293,6 @@ rules:
       vcf_pattern: "(?i)(grch37|hg19|hs37|GCA_000001405\\.[^5]|b37)"
     then:
       reference_assembly: GRCh37
-    confidence: 0.95
     rationale: "##reference line containing GRCh37, hg19, b37, or earlier accessions indicates variants called against GRCh37"
 
   - id: vcf_ref_chm13
@@ -1383,7 +1304,6 @@ rules:
       vcf_pattern: "(?i)(chm13|t2t|hs1)"
     then:
       reference_assembly: CHM13
-    confidence: 0.95
     rationale: "##reference line containing CHM13 or T2T indicates variants called against T2T-CHM13"
 
   - id: vcf_contig_grch38
@@ -1395,7 +1315,6 @@ rules:
       vcf_pattern: "(?i)assembly=(grch38|hg38|GCA_000001405\\.15)"
     then:
       reference_assembly: GRCh38
-    confidence: 0.95
     rationale: "##contig lines with assembly=GRCh38 explicitly declare the reference genome"
 
   - id: vcf_contig_grch37
@@ -1407,7 +1326,6 @@ rules:
       vcf_pattern: "(?i)assembly=(grch37|hg19|b37)"
     then:
       reference_assembly: GRCh37
-    confidence: 0.95
     rationale: "##contig lines with assembly=GRCh37 explicitly declare the reference genome"
 
   - id: vcf_contig_chm13
@@ -1419,7 +1337,6 @@ rules:
       vcf_pattern: "(?i)assembly=(chm13|t2t|hs1)"
     then:
       reference_assembly: CHM13
-    confidence: 0.95
     rationale: "##contig lines with assembly=CHM13 explicitly declare the reference genome"
 
   # ---------------------------------------------------------------------------
@@ -1435,7 +1352,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.germline
-    confidence: 0.90
     rationale: "GATK HaplotypeCaller is the standard germline SNV/indel caller"
 
   - id: vcf_deepvariant
@@ -1448,7 +1364,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.germline
-    confidence: 0.90
     rationale: "DeepVariant is Google's deep learning-based germline variant caller"
 
   - id: vcf_gatk_genotypegvcfs
@@ -1461,7 +1376,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.germline
-    confidence: 0.90
     rationale: "GATK GenotypeGVCFs performs joint genotyping on gVCF files"
 
   - id: vcf_glnexus
@@ -1474,7 +1388,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.germline
-    confidence: 0.90
     rationale: "GLnexus is a scalable gVCF merging and joint genotyping tool"
 
   - id: vcf_bcftools_call
@@ -1487,7 +1400,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.germline
-    confidence: 0.85
     rationale: "bcftools call is a lightweight germline variant caller"
 
   - id: vcf_freebayes
@@ -1500,7 +1412,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.germline
-    confidence: 0.85
     rationale: "FreeBayes is a Bayesian haplotype-based germline variant caller"
 
   - id: vcf_strelka2_germline
@@ -1513,7 +1424,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.germline
-    confidence: 0.85
     rationale: "Strelka2 in germline mode calls SNVs and indels from germline samples"
 
   # ---------------------------------------------------------------------------
@@ -1529,7 +1439,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.somatic
-    confidence: 0.95
     rationale: "GATK Mutect2 is the standard somatic SNV/indel caller for tumor-normal analysis"
 
   - id: vcf_strelka_somatic
@@ -1542,7 +1451,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.somatic
-    confidence: 0.90
     rationale: "Strelka in somatic mode calls somatic variants from tumor-normal pairs"
 
   - id: vcf_varscan_somatic
@@ -1555,7 +1463,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.somatic
-    confidence: 0.90
     rationale: "VarScan somatic mode calls somatic variants from tumor-normal pairs"
 
   - id: vcf_somaticsniper
@@ -1568,7 +1475,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.somatic
-    confidence: 0.90
     rationale: "SomaticSniper identifies somatic point mutations in tumor-normal pairs"
 
   - id: vcf_muse
@@ -1581,7 +1487,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.somatic
-    confidence: 0.90
     rationale: "MuSE calls somatic point mutations using a Markov substitution model"
 
   # ---------------------------------------------------------------------------
@@ -1597,7 +1502,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.structural
-    confidence: 0.90
     rationale: "Manta calls structural variants (deletions, insertions, inversions, translocations)"
 
   - id: vcf_delly
@@ -1610,7 +1514,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.structural
-    confidence: 0.90
     rationale: "DELLY discovers structural variants using paired-end and split-read analysis"
 
   - id: vcf_lumpy
@@ -1623,7 +1526,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.structural
-    confidence: 0.90
     rationale: "LUMPY is a probabilistic SV caller using multiple alignment signals"
 
   - id: vcf_smoove
@@ -1636,7 +1538,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.structural
-    confidence: 0.90
     rationale: "Smoove simplifies SV calling by wrapping LUMPY with additional filtering"
 
   - id: vcf_svim
@@ -1649,7 +1550,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.structural
-    confidence: 0.90
     rationale: "SVIM detects structural variants from long-read sequencing data (PacBio/ONT)"
 
   - id: vcf_sniffles
@@ -1662,7 +1562,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.structural
-    confidence: 0.90
     rationale: "Sniffles is a long-read SV caller optimized for PacBio and ONT data"
 
   - id: vcf_pbsv
@@ -1675,7 +1574,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.structural
-    confidence: 0.90
     rationale: "PBSV is PacBio's structural variant caller for HiFi and CLR data"
 
   - id: vcf_cutesv
@@ -1688,7 +1586,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.structural
-    confidence: 0.90
     rationale: "CuteSV is a fast long-read SV caller using clustering of signatures"
 
   # ---------------------------------------------------------------------------
@@ -1704,7 +1601,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.cnv
-    confidence: 0.90
     rationale: "CNVkit detects copy number variants from targeted/exome or WGS data"
 
   - id: vcf_gatk_cnv
@@ -1717,7 +1613,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.cnv
-    confidence: 0.90
     rationale: "GATK CNV tools (ModelSegments, etc.) call copy number variants from read depth data"
 
   - id: vcf_canvas
@@ -1730,7 +1625,6 @@ rules:
     then:
       data_modality: genomic
       data_type: variants.cnv
-    confidence: 0.90
     rationale: "Canvas is Illumina's CNV caller for WGS and tumor-normal analysis"
 
   # ---------------------------------------------------------------------------
@@ -1745,7 +1639,6 @@ rules:
       vcf_pattern: "^(SOMATIC|TUMOR_|NORMAL_|TumorVAF|NormalVAF)"
     then:
       data_type: variants.somatic
-    confidence: 0.85
     rationale: "INFO fields with SOMATIC, TUMOR_, or NORMAL_ prefixes indicate somatic variant calls"
 
   - id: vcf_info_sv
@@ -1757,7 +1650,6 @@ rules:
       vcf_pattern: "^(SVTYPE|SVLEN|CIPOS|CIEND|MATEID|IMPRECISE)$"
     then:
       data_type: variants.structural
-    confidence: 0.80
     rationale: "Standard SV INFO fields (SVTYPE, SVLEN, CIPOS, etc.) indicate structural variant calls"
 
   - id: vcf_info_cnv
@@ -1769,7 +1661,6 @@ rules:
       vcf_pattern: "^(CN|FOLD_CHANGE|PROBES|LOG2_COPY_RATIO)$"
     then:
       data_type: variants.cnv
-    confidence: 0.80
     rationale: "CNV-specific INFO fields indicate copy number variant calls"
 
   # ===========================================================================
@@ -1787,7 +1678,6 @@ rules:
       fastq_pattern: "^@[A-Z0-9-]+:\\d+:[A-Z0-9]+:\\d+:\\d+:\\d+:\\d+"
     then:
       platform: ILLUMINA
-    confidence: 0.90
     rationale: "Modern Illumina read names (Casava 1.8+) follow the format @instrument:run:flowcell:lane:tile:x:y"
 
   - id: fastq_illumina_legacy
@@ -1798,7 +1688,6 @@ rules:
       fastq_pattern: "^@[A-Z0-9-]+:\\d+:\\d+:\\d+:\\d+#"
     then:
       platform: ILLUMINA
-    confidence: 0.85
     rationale: "Legacy Illumina read names follow @instrument:lane:tile:x:y#index format"
 
   - id: fastq_illumina_srr
@@ -1809,7 +1698,6 @@ rules:
       fastq_pattern: "^@SRR\\d+\\.\\d+"
     then:
       platform: ILLUMINA
-    confidence: 0.70
     rationale: "SRA-reformatted read names starting with @SRR typically indicate Illumina data from NCBI SRA"
 
   - id: fastq_illumina_hiseq_desc
@@ -1820,7 +1708,6 @@ rules:
       fastq_pattern: " HS2[05]00[-_]"
     then:
       platform: ILLUMINA
-    confidence: 0.85
     rationale: "HiSeq 2000/2500 instrument identifier found in read description"
 
   - id: fastq_illumina_ena_hiseq
@@ -1831,7 +1718,6 @@ rules:
       fastq_pattern: "^@[EDS]RR\\d+\\.\\d+ HS2[05]00"
     then:
       platform: ILLUMINA
-    confidence: 0.90
     rationale: "ENA/SRA-reformatted read names with HiSeq 2000/2500 instrument ID in description"
 
   # ---------------------------------------------------------------------------
@@ -1846,7 +1732,6 @@ rules:
     then:
       platform: PACBIO
       data_type: reads
-    confidence: 0.95
     rationale: "PacBio CCS (HiFi) read names follow @movie/zmw/ccs format. The 'ccs' suffix indicates high-accuracy long reads (>Q20)"
 
   - id: fastq_pacbio_clr
@@ -1858,7 +1743,6 @@ rules:
     then:
       platform: PACBIO
       data_type: reads
-    confidence: 0.90
     rationale: "PacBio CLR (Continuous Long Read) subread names follow @movie/zmw/start_end format"
 
   - id: fastq_pacbio_generic
@@ -1870,7 +1754,6 @@ rules:
     then:
       platform: PACBIO
       data_type: reads
-    confidence: 0.85
     rationale: "Generic PacBio read names follow @movie/zmw format"
 
   # ---------------------------------------------------------------------------
@@ -1885,7 +1768,6 @@ rules:
     then:
       platform: ONT
       data_type: reads
-    confidence: 0.95
     rationale: "ONT read names are UUIDs (format: 8-4-4-4-12 hex characters). Uniquely identifies Oxford Nanopore data"
 
   - id: fastq_ont_metadata
@@ -1897,7 +1779,6 @@ rules:
     then:
       platform: ONT
       data_type: reads
-    confidence: 0.95
     rationale: "ONT reads often include 'runid=' metadata in the header line"
 
   # ---------------------------------------------------------------------------
@@ -1911,7 +1792,6 @@ rules:
       fastq_pattern: "^@[A-Z]\\d{9}L\\dC\\d{3}R\\d{3}\\d+"
     then:
       platform: MGI
-    confidence: 0.90
     rationale: "MGI/BGI-SEQ read names follow @flowcellLaneCcolumnRrow format"
 
   - id: fastq_mgi_alt
@@ -1922,7 +1802,6 @@ rules:
       fastq_pattern: "^@[A-Z]\\d+L\\d+C\\d+R\\d+"
     then:
       platform: MGI
-    confidence: 0.85
     rationale: "Alternative MGI/BGI read name format with varying digit lengths"
 
   # ---------------------------------------------------------------------------
@@ -1936,7 +1815,6 @@ rules:
       fastq_pattern: "^@[A-Z0-9]+:[A-Z0-9]+:\\d+:\\d+:\\d+:\\d+:\\d+"
     then:
       platform: ELEMENT
-    confidence: 0.80
     rationale: "Element Biosciences AVITI read names follow a similar format to Illumina"
 
   # ---------------------------------------------------------------------------
@@ -1950,7 +1828,6 @@ rules:
       fastq_pattern: "^@[A-Z0-9]+_\\d+_\\d+_\\d+_[ACGT]+"
     then:
       platform: ULTIMA
-    confidence: 0.80
     rationale: "Ultima Genomics read names include flow-space encoded sequences"
 
   # ---------------------------------------------------------------------------
@@ -1963,7 +1840,6 @@ rules:
       extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
       fastq_pattern: "^@ERR\\d+\\.\\d+"
     then: {}
-    confidence: 0.60
     rationale: "ERR accessions indicate data from the European Nucleotide Archive (ENA)"
 
   - id: fastq_sra_srr
@@ -1973,7 +1849,6 @@ rules:
       extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
       fastq_pattern: "^@SRR\\d+\\.\\d+"
     then: {}
-    confidence: 0.60
     rationale: "SRR accessions indicate data from NCBI Sequence Read Archive (SRA)"
 
   - id: fastq_ddbj_drr
@@ -1983,7 +1858,6 @@ rules:
       extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
       fastq_pattern: "^@DRR\\d+\\.\\d+"
     then: {}
-    confidence: 0.60
     rationale: "DRR accessions indicate data from DDBJ Sequence Read Archive (Japan)"
 
   # ---------------------------------------------------------------------------
@@ -1996,7 +1870,6 @@ rules:
       extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
       fastq_pattern: "[/\\s][12]$|[/\\s][12]:|_R[12]_|\\.R[12]\\.|_r[12]_|\\.r[12]\\."
     then: {}
-    confidence: 0.80
     rationale: "Read 1/2 indicators (/1, /2, _R1_, _R2_) suggest paired-end sequencing"
 
   # ---------------------------------------------------------------------------
@@ -2011,7 +1884,6 @@ rules:
     then:
       status:
         data_modality: not_classified
-    confidence: 0.0
     rationale: "FASTQ modality cannot be determined from reads alone — could be genomic, transcriptomic, or epigenomic depending on assay"
 
   # ===========================================================================
@@ -2027,7 +1899,6 @@ rules:
     then:
       data_modality: genomic
       data_type: annotations
-    confidence: 0.60
     rationale: "BED file with no specific pattern - defaulting to genomic intervals"
 
 
@@ -2043,14 +1914,12 @@ validators:
     module: "meta_disco.validators.contig_lengths"
     function: "detect_reference_from_contig_lengths"
     applies_to: ["header", "vcf_header"]
-    confidence: 0.98
 
   max_position_detector:
     description: "Detect reference assembly by ruling out references where variant positions exceed chromosome lengths"
     module: "meta_disco.validators.contig_lengths"
     function: "detect_reference_from_max_positions"
     applies_to: ["vcf_header"]
-    confidence: 0.90
 
   illumina_read_parser:
     description: "Parse Illumina read names to extract instrument, flowcell, lane"

--- a/schema/src/meta_disco/schema/classification.yaml
+++ b/schema/src/meta_disco/schema/classification.yaml
@@ -87,7 +87,6 @@ classes:
     slots:
       - value
       - status
-      - confidence
       - evidence
 
   DataModalityClassification:
@@ -125,7 +124,6 @@ classes:
     slots:
       - rule_id
       - reason
-      - confidence
       - value
       - status
       - tier
@@ -199,9 +197,6 @@ slots:
     description: Whether the field was classified, is not applicable, etc.
     range: classification_status_enum
     required: true
-  confidence:
-    description: "Confidence in [0, 1]; vestigial, see issue #56."
-    range: float
   evidence:
     range: Evidence
     multivalued: true

--- a/schema/tests/test_data/invalid_file.yaml
+++ b/schema/tests/test_data/invalid_file.yaml
@@ -11,25 +11,20 @@ classifications:
   data_modality:
     value: "proteomic"          # ❌ not in data_modality_enum
     status: "classified"
-    confidence: 0.9
     evidence: []
   data_type:
     value: "alignments"
     status: "classified"
-    confidence: 0.9
     evidence: []
   reference_assembly:
     value: "GRCh39"             # ❌ not in reference_assembly_enum
     status: "classified"
-    confidence: 0.9
     evidence: []
   assay_type:
     value: null
     # ❌ missing required `status`
-    confidence: 0.0
     evidence: []
   platform:
     value: "ILLUMINA"
     status: "classified"
-    confidence: 0.8
     evidence: []

--- a/schema/tests/test_data/valid_file.yaml
+++ b/schema/tests/test_data/valid_file.yaml
@@ -11,30 +11,24 @@ classifications:
   data_modality:
     value: "genomic"
     status: "classified"
-    confidence: 0.95
     evidence:
       - rule_id: "aligned_reads_bam"
         reason: "BAM with @SQ lines aligned to a human assembly"
-        confidence: 0.95
         value: "genomic"
         tier: 1
   data_type:
     value: "alignments"
     status: "classified"
-    confidence: 0.9
     evidence: []
   reference_assembly:
     value: "GRCh38"
     status: "classified"
-    confidence: 0.9
     evidence: []
   assay_type:
     value: null
     status: "not_classified"
-    confidence: 0.0
     evidence: []
   platform:
     value: "ILLUMINA"
     status: "classified"
-    confidence: 0.8
     evidence: []

--- a/schema/tests/test_output_validation.py
+++ b/schema/tests/test_output_validation.py
@@ -10,7 +10,7 @@ dimension's enum.
 
 Two levels of validation:
 
-* per-field *entries* (value/status/confidence/evidence) against their
+* per-field *entries* (value/status/evidence) against their
   ``Classification`` subclass, and
 * the whole record against ``ClassificationRecord`` — enabled by #134, which added
   the ``classifications`` container so the schema matches the pipeline output shape
@@ -147,8 +147,8 @@ def test_record_gate_rejects_missing_classifications(validator):
 def test_record_gate_rejects_bad_dimension_value(validator):
     # A bad enum value nested inside the container must fail record validation.
     entry = {"value": "not_a_real_modality", "status": "classified",
-             "confidence": 1.0, "evidence": []}
-    ok = {"value": None, "status": "not_classified", "confidence": 0.0, "evidence": []}
+             "evidence": []}
+    ok = {"value": None, "status": "not_classified", "evidence": []}
     classifications = {dim: (entry if dim == "data_modality" else ok)
                        for dim in DIMENSION_CLASS}
     bad = {"md5sum": "x", "file_name": "f.bam", "classifications": classifications}
@@ -161,13 +161,13 @@ def test_record_gate_rejects_bad_dimension_value(validator):
 
 def test_gate_rejects_missing_status(validator):
     # status is required — an entry without it must fail (proves the gate bites).
-    bad = {"value": "genomic", "confidence": 1.0, "evidence": []}
+    bad = {"value": "genomic", "evidence": []}
     report = validator.validate(bad, target_class="DataModalityClassification")
     assert report.results, "missing status should have failed validation"
 
 
 def test_gate_rejects_out_of_enum_value(validator):
     bad = {"value": "not_a_real_modality", "status": "classified",
-           "confidence": 1.0, "evidence": []}
+           "evidence": []}
     report = validator.validate(bad, target_class="DataModalityClassification")
     assert report.results, "an out-of-enum value should have failed validation"

--- a/scripts/classify_index_files.py
+++ b/scripts/classify_index_files.py
@@ -20,19 +20,6 @@ from src.meta_disco.models import (
     status_for_value,
 )
 
-
-def _get_max_confidence(record: dict) -> float:
-    """Extract max confidence from either format."""
-    cls = record.get("classifications", {})
-    if isinstance(cls, dict):
-        confs = []
-        for v in cls.values():
-            if isinstance(v, dict) and "confidence" in v:
-                confs.append(v["confidence"])
-        if confs:
-            return max(confs)
-    return record.get("confidence", 0.0) or 0.0
-
 # Index extension -> parent extension mapping
 # List specific compound extensions to avoid false candidates from bare .gz
 INDEX_TO_PARENT = {
@@ -95,7 +82,6 @@ def load_classifications(*paths: Path) -> dict[str, dict]:
                     "assay_type": field_label(c, "assay_type"),
                     "platform": field_label(c, "platform"),
                     "reference_assembly": field_label(c, "reference_assembly"),
-                    "confidence": _get_max_confidence(c),
                     "source_file": c.get("file_name"),
                 }
 
@@ -211,7 +197,6 @@ def propagate_to_index_files(
                 "assay_type": parent_class.get("assay_type") or nc,
                 "platform": parent_class.get("platform") or nc,
                 "reference_assembly": parent_class.get("reference_assembly") or nc,
-                "confidence": parent_class.get("confidence") or 0.0,
                 "inheritance_source": "parent_file",
             }
 
@@ -283,7 +268,6 @@ def propagate_to_index_files(
         if field_val and field_val not in _sentinels:
             return [{"rule_id": "inherited_from_parent",
                      "reason": f"Inherited from parent file: {parent}",
-                     "confidence": 0.95,
                      "value": field_val}]
         status = status_for_value(field_val)
         # An explicit not_applicable parent isn't "no value" — the field is
@@ -295,7 +279,6 @@ def propagate_to_index_files(
             reason = f"Parent file {parent} had no value for {field_name}"
         return [{"rule_id": "inherited_from_parent",
                  "reason": reason,
-                 "confidence": 0.0,
                  "status": status}]
 
     standard_results = []
@@ -307,8 +290,7 @@ def propagate_to_index_files(
         for fld in CLASSIFICATION_FIELDS:
             value = r.get(fld)
             evidence = inherited_evidence(fld, value, parent)
-            classifications[fld] = build_field_entry(
-                value, confidence=evidence[0]["confidence"], evidence=evidence)
+            classifications[fld] = build_field_entry(value, evidence=evidence)
         standard_results.append({
             "file_name": r["file_name"],
             "file_format": r["file_format"],

--- a/scripts/run_batch_classification.py
+++ b/scripts/run_batch_classification.py
@@ -65,7 +65,6 @@ def run_classification(files: list[dict], engine: RuleEngine) -> list[dict]:
             # Classification results (label = value when classified, else the status)
             "predicted_modality": result.label("data_modality"),
             "predicted_reference": result.label("reference_assembly"),
-            "confidence": result.confidence,
             "rules_matched": "|".join(result.rules_matched),
             "reasons": "|".join(result.reasons),
         })
@@ -81,9 +80,6 @@ def compute_stats(results: list[dict]) -> dict:
         "total_files": total,
         "classified_with_modality": 0,
         "classified_with_reference": 0,
-        "high_confidence": 0,  # >= 0.9
-        "medium_confidence": 0,  # 0.7-0.89
-        "low_confidence": 0,  # < 0.7
         "modality_breakdown": {},
         "reference_breakdown": {},
         "file_format_breakdown": {},
@@ -105,14 +101,6 @@ def compute_stats(results: list[dict]) -> dict:
             stats["classified_with_reference"] += 1
         if ref:
             stats["reference_breakdown"][ref] = stats["reference_breakdown"].get(ref, 0) + 1
-
-        conf = r["confidence"]
-        if conf >= 0.9:
-            stats["high_confidence"] += 1
-        elif conf >= 0.7:
-            stats["medium_confidence"] += 1
-        elif conf > 0:
-            stats["low_confidence"] += 1
 
         # Track file formats
         fmt = r.get("file_format", "unknown")
@@ -181,11 +169,6 @@ def save_results(results: list[dict], stats: dict, output_dir: Path):
     print(f"  Classified with reference:  {stats['classified_with_reference']:,} ({100*stats['classified_with_reference']/stats['total_files']:.1f}%)")
     print(f"  API had reference:          {stats['api_had_reference']:,} ({100*stats['api_had_reference']/stats['total_files']:.1f}%)")
     print(f"  Filled missing reference:   {stats['filled_missing_reference']:,}")
-    print()
-    print("CONFIDENCE LEVELS:")
-    print(f"  High (>=90%):               {stats['high_confidence']:,}")
-    print(f"  Medium (70-89%):            {stats['medium_confidence']:,}")
-    print(f"  Low (<70%):                 {stats['low_confidence']:,}")
     print()
     print("TOP MODALITIES:")
     for mod, count in sorted(stats["modality_breakdown"].items(), key=lambda x: -x[1])[:10]:

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -635,10 +635,12 @@ def classify_from_bed_signals(
     if max_coordinates:
         coord_ref, coord_rationale = _infer_bed_reference(signals)
 
-        if coord_ref:
+        if coord_ref and result.status_of("reference_assembly") != NOT_APPLICABLE:
             # Coordinate detection reads the actual file content, so it overrides
-            # any filename-based reference guess (CLAUDE.md design principle:
-            # prefer reading actual file content over guessing from filenames).
+            # a filename-based reference guess (CLAUDE.md design principle: prefer
+            # reading actual file content over guessing from filenames). But it does
+            # not overturn an existing not_applicable — that is a positive
+            # determination ("no reference applies"), not a filename guess.
             result.set_field("reference_assembly", coord_ref)
             result.field_evidence["reference_assembly"] = [{
                 "rule_id": "bed_coordinate_reference",

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -56,7 +56,7 @@ def classify_from_header(
 
     Returns:
         Dict with per-field classifications:
-            - {field}: {value, status, confidence, evidence[]} for each of
+            - {field}: {value, status, evidence[]} for each of
               data_modality, data_type, assay_type, reference_assembly, platform
     """
     from .rule_engine import ExtendedFileInfo
@@ -80,10 +80,9 @@ def classify_from_header(
 
     from .validators.contig_lengths import detect_reference_from_contig_lengths as detect_from_contigs
     contig_ref = None
-    contig_conf = 0.0
     contig_matches = 0
     if sq_lines:
-        contig_ref, contig_matches, contig_conf = detect_from_contigs(sq_lines)
+        contig_ref, contig_matches = detect_from_contigs(sq_lines)
 
     # Run classification with tier 3 (header rules)
     engine = _get_engine()
@@ -92,12 +91,10 @@ def classify_from_header(
     # Apply contig-based reference (overrides everything — definitive signal)
     if contig_ref:
         result.set_field("reference_assembly", contig_ref)
-        result.confidence = max(result.confidence, contig_conf)
         reason = f"Reference {contig_ref} detected from {contig_matches} matching contig lengths (definitive)"
         result.field_evidence["reference_assembly"] = [{
             "rule_id": "contig_length_detection",
             "reason": reason,
-            "confidence": contig_conf,
             "value": contig_ref,
         }]
         # Aligned to a known reference genome = genomic data
@@ -106,7 +103,6 @@ def classify_from_header(
             result.field_evidence["data_modality"] = [{
                 "rule_id": "aligned_to_reference",
                 "reason": f"Aligned to {contig_ref} — file contains genomic alignments",
-                "confidence": contig_conf,
                 "value": "genomic",
             }]
 
@@ -136,7 +132,7 @@ def classify_from_vcf_header(
 
     Returns:
         Dict with per-field classifications:
-            - {field}: {value, status, confidence, evidence[]} for each of
+            - {field}: {value, status, evidence[]} for each of
               data_modality, data_type, assay_type, reference_assembly, platform
     """
     from .rule_engine import ExtendedFileInfo
@@ -158,12 +154,11 @@ def classify_from_vcf_header(
     from .validators.contig_lengths import detect_reference_from_contig_lengths as detect_from_contigs
 
     contig_ref = None
-    contig_conf = 0.0
     contig_matches = 0
     if header_text:
         contig_lines = [line for line in header_text.split("\n") if line.startswith("##contig")]
         if contig_lines:
-            contig_ref, contig_matches, contig_conf = detect_from_contigs(contig_lines)
+            contig_ref, contig_matches = detect_from_contigs(contig_lines)
 
     # Run classification with tier 3 (header rules)
     engine = _get_engine()
@@ -172,12 +167,10 @@ def classify_from_vcf_header(
     # Apply contig-based reference (overrides everything — definitive signal)
     if contig_ref:
         result.set_field("reference_assembly", contig_ref)
-        result.confidence = max(result.confidence, contig_conf)
         reason = f"Reference {contig_ref} detected from {contig_matches} matching contig lengths (definitive)"
         result.field_evidence["reference_assembly"] = [{
             "rule_id": "vcf_contig_length",
             "reason": reason,
-            "confidence": contig_conf,
             "value": contig_ref,
         }]
 
@@ -207,7 +200,6 @@ def classify_from_fastq_header(
             - data_modality: str or None
             - data_type: str (typically "reads")
             - platform: str or None (ILLUMINA, PACBIO, ONT, etc.)
-            - confidence: float
             - is_paired_end: bool or None
             - instrument_model: str or None (for Illumina)
             - instrument_hint: str or None (instrument ID from read name)
@@ -274,7 +266,6 @@ def classify_from_fastq_header(
             if result_stripped.is_declared("data_modality"):
                 result.set_field("data_modality", result_stripped.data_modality,
                                  result_stripped.status_of("data_modality"))
-            result.confidence = max(result.confidence, result_stripped.confidence)
             # Merge per-field evidence
             for fld, entries in result_stripped.field_evidence.items():
                 result.field_evidence[fld].extend(entries)
@@ -409,16 +400,13 @@ def classify_from_fasta_header(
         result.field_evidence["data_modality"] = [{
             "rule_id": "fasta_transcript_contigs",
             "reason": f"Found {len(transcript_contigs)} transcript IDs (e.g., {transcript_contigs[0]})",
-            "confidence": 0.90,
             "value": "transcriptomic.bulk",
         }]
         result.field_evidence["data_type"] = [{
             "rule_id": "fasta_transcript_contigs",
             "reason": "Transcript sequences in FASTA",
-            "confidence": 0.90,
             "value": "sequence",
         }]
-        result.confidence = 0.90
         return result.to_output_dict()
 
     # 2. Contigs match a known reference set → reference genome
@@ -451,27 +439,22 @@ def classify_from_fasta_header(
                 "rule_id": "fasta_reference_contigs",
                 "reason": f"Matched {best_count} contigs to reference chromosomes"
                           + (f" ({best_ref})" if best_ref else " (ambiguous — multiple references share these names)"),
-                "confidence": 0.95 if best_ref else 0.50,
             }
             if best_ref:
                 result.set_field("reference_assembly", best_ref)
-                result.confidence = 0.95
                 ref_entry["value"] = best_ref
             else:
                 result.set_field("reference_assembly", status=NOT_CLASSIFIED)
-                result.confidence = 0.80
                 ref_entry["status"] = NOT_CLASSIFIED
             result.field_evidence["reference_assembly"] = [ref_entry]
             result.field_evidence["data_modality"] = [{
                 "rule_id": "fasta_reference_contigs",
                 "reason": "Contig names match known reference genome",
-                "confidence": 0.95,
                 "value": "genomic",
             }]
             result.field_evidence["data_type"] = [{
                 "rule_id": "fasta_reference_contigs",
                 "reason": "FASTA contains reference genome sequences",
-                "confidence": 0.95,
                 "value": "reference_genome",
             }]
             return result.to_output_dict()
@@ -481,24 +464,20 @@ def classify_from_fasta_header(
         result.set_field("data_modality", "genomic")
         result.set_field("data_type", "assembly")
         result.set_field("reference_assembly", status=NOT_APPLICABLE)
-        result.confidence = 0.90
         sample = assembler_contigs[0]
         result.field_evidence["data_modality"] = [{
             "rule_id": "fasta_assembler_contigs",
             "reason": f"Found {len(assembler_contigs)} assembler-named contigs (e.g., {sample})",
-            "confidence": 0.90,
             "value": "genomic",
         }]
         result.field_evidence["data_type"] = [{
             "rule_id": "fasta_assembler_contigs",
             "reason": "Contig names indicate assembler output",
-            "confidence": 0.90,
             "value": "assembly",
         }]
         result.field_evidence["reference_assembly"] = [{
             "rule_id": "fasta_assembler_contigs",
             "reason": "De novo assembly — no reference genome applicable",
-            "confidence": 0.90,
             "status": NOT_APPLICABLE,
         }]
         return result.to_output_dict()
@@ -508,23 +487,19 @@ def classify_from_fasta_header(
         result.set_field("data_modality", "genomic")
         result.set_field("data_type", "assembly")
         result.set_field("reference_assembly", status=NOT_APPLICABLE)
-        result.confidence = 0.75
         result.field_evidence["data_modality"] = [{
             "rule_id": "fasta_many_contigs",
             "reason": f"Large number of contigs ({num_contigs}) with non-standard names suggests de novo assembly",
-            "confidence": 0.75,
             "value": "genomic",
         }]
         result.field_evidence["data_type"] = [{
             "rule_id": "fasta_many_contigs",
             "reason": "High contig count suggests assembly",
-            "confidence": 0.75,
             "value": "assembly",
         }]
         result.field_evidence["reference_assembly"] = [{
             "rule_id": "fasta_many_contigs",
             "reason": "De novo assembly — no reference genome applicable",
-            "confidence": 0.75,
             "status": NOT_APPLICABLE,
         }]
         return result.to_output_dict()
@@ -536,7 +511,6 @@ def classify_from_fasta_header(
         result.field_evidence["data_modality"] = [{
             "rule_id": "fasta_default_genomic",
             "reason": f"FASTA with {num_contigs} contigs — defaulting to genomic",
-            "confidence": 0.50,
             "value": "genomic",
         }]
     if not result.is_declared("data_type"):
@@ -544,10 +518,8 @@ def classify_from_fasta_header(
         result.field_evidence["data_type"] = [{
             "rule_id": "fasta_default_genomic",
             "reason": "Unable to determine specific FASTA type from headers",
-            "confidence": 0.50,
             "value": "sequence",
         }]
-    result.confidence = max(result.confidence, 0.50)
     return result.to_output_dict()
 
 
@@ -558,71 +530,30 @@ def classify_from_fasta_header(
 _STANDARD_CHROM_PATTERN = re.compile(r'^(chr)?(\d{1,2}|X|Y|M|MT)$', re.IGNORECASE)
 
 
-def _pick_closest_reference(
-    max_coords: dict[str, int],
-    ref_lengths: dict[str, dict[str, int]],
-    candidates: list[str],
-) -> str | None:
-    """Pick the reference whose chromosome lengths best match observed max coordinates.
-
-    When max coordinates don't rule out multiple references, we pick the one where
-    coordinates come closest to (but don't exceed) the chromosome lengths. Files
-    covering the full chromosome will have max coordinates near the chromosome length.
-    """
-    scores = {}
-    for assembly in candidates:
-        chrom_lengths = ref_lengths[assembly]
-        score = 0
-        matched = 0
-
-        for chrom, max_coord in max_coords.items():
-            chrom_key = chrom if chrom in chrom_lengths else f"chr{chrom}"
-            if chrom_key not in chrom_lengths:
-                continue
-
-            ref_len = chrom_lengths[chrom_key]
-            ratio = max_coord / ref_len
-            if ratio <= 1.0:
-                score += ratio
-                matched += 1
-
-        if matched > 0:
-            scores[assembly] = score / matched
-
-    if not scores:
-        return None
-
-    best_score = max(scores.values())
-    tied = [a for a, s in scores.items() if abs(s - best_score) < 0.001]
-    if len(tied) > 1:
-        return None  # Ambiguous — don't guess
-    return tied[0]
-
-
-def _infer_bed_reference(signals: dict) -> tuple[str | None, float, str]:
+def _infer_bed_reference(signals: dict) -> tuple[str | None, str]:
     """Infer reference assembly from BED coordinate signals.
 
     Uses max coordinates to rule out references where coordinates exceed
     chromosome lengths. The remaining reference(s) are candidates.
 
     Returns:
-        Tuple of (assembly, confidence, rationale)
+        Tuple of (assembly, rationale)
     """
     max_coords = signals.get("max_coordinates", {})
     has_chr_prefix = signals.get("has_chr_prefix", True)
 
     if not max_coords:
-        return None, 0.0, "No coordinates found"
+        return None, "No coordinates found"
 
     standard_chroms = [c for c in signals.get("chromosomes", [])
                        if _STANDARD_CHROM_PATTERN.match(c)]
 
     if not standard_chroms:
-        return None, 0.0, ("Non-standard chromosome names — likely de novo assembly, "
-                           "not aligned to a standard reference")
+        return None, ("Non-standard chromosome names — likely de novo assembly, "
+                      "not aligned to a standard reference")
 
     if not has_chr_prefix:
-        return "GRCh37", 0.85, "Chromosomes lack 'chr' prefix, consistent with GRCh37/b37 naming"
+        return "GRCh37", "Chromosomes lack 'chr' prefix, consistent with GRCh37/b37 naming"
 
     ref_lengths = _get_engine().rules.reference_contig_lengths
 
@@ -652,15 +583,17 @@ def _infer_bed_reference(signals: dict) -> tuple[str | None, float, str]:
 
     if len(candidates) == 1:
         rationale = f"Only {candidates[0]} not ruled out. {'; '.join(evidence_details)}"
-        return candidates[0], 0.92, rationale
+        return candidates[0], rationale
     elif len(candidates) == 0:
-        return None, 0.0, f"All references ruled out: {'; '.join(evidence_details)}"
+        return None, f"All references ruled out: {'; '.join(evidence_details)}"
     else:
-        best = _pick_closest_reference(max_coords, ref_lengths, candidates)
-        if best:
-            return best, 0.80, (f"Multiple references possible ({', '.join(candidates)}), "
-                                f"{best} is closest match by coordinates")
-        return None, 0.0, f"Cannot distinguish between {', '.join(candidates)}"
+        # More than one reference is still consistent with these coordinates —
+        # the file's coordinates don't reach into regions where the candidates'
+        # chromosome lengths differ, so we genuinely can't tell them apart. Return
+        # "can't tell" (None) rather than guessing a closest match: an undefined
+        # coordinate result must not override a filename-based reference.
+        return None, (f"Cannot distinguish between {', '.join(candidates)} — "
+                      "coordinates fit multiple references")
 
 
 def classify_from_bed_signals(
@@ -700,32 +633,25 @@ def classify_from_bed_signals(
     result = engine.classify_extended(file_info, include_tier3=False)
 
     if max_coordinates:
-        coord_ref, coord_conf, coord_rationale = _infer_bed_reference(signals)
+        coord_ref, coord_rationale = _infer_bed_reference(signals)
 
-        if coord_ref and coord_conf > 0:
-            existing_ref_evidence = result.field_evidence.get("reference_assembly") or []
-            existing_ref_conf = max(
-                (ev.get("confidence", 0.0) for ev in existing_ref_evidence),
-                default=0.0,
-            )
-            if not result.is_declared("reference_assembly") or coord_conf > existing_ref_conf:
-                result.set_field("reference_assembly", coord_ref)
-                result.confidence = max(result.confidence, coord_conf)
-                result.field_evidence["reference_assembly"] = [{
-                    "rule_id": "bed_coordinate_reference",
-                    "reason": coord_rationale,
-                    "confidence": coord_conf,
-                    "value": coord_ref,
-                }]
-        elif coord_ref is None and coord_conf == 0.0:
-            if "Non-standard chromosome" in coord_rationale:
-                result.set_field("reference_assembly", status=NOT_APPLICABLE)
-                result.field_evidence["reference_assembly"] = [{
-                    "rule_id": "bed_nonstandard_contigs",
-                    "reason": coord_rationale,
-                    "confidence": 0.0,
-                    "status": NOT_APPLICABLE,
-                }]
+        if coord_ref:
+            # Coordinate detection reads the actual file content, so it overrides
+            # any filename-based reference guess (CLAUDE.md design principle:
+            # prefer reading actual file content over guessing from filenames).
+            result.set_field("reference_assembly", coord_ref)
+            result.field_evidence["reference_assembly"] = [{
+                "rule_id": "bed_coordinate_reference",
+                "reason": coord_rationale,
+                "value": coord_ref,
+            }]
+        elif "Non-standard chromosome" in coord_rationale:
+            result.set_field("reference_assembly", status=NOT_APPLICABLE)
+            result.field_evidence["reference_assembly"] = [{
+                "rule_id": "bed_nonstandard_contigs",
+                "reason": coord_rationale,
+                "status": NOT_APPLICABLE,
+            }]
 
     return result.to_output_dict()
 
@@ -752,7 +678,6 @@ Each rule has:
 - `scope`: extension, filename, header, vcf_header, fastq_header, or file_size
 - `when`: Conditions that must match
 - `then`: Effects to apply
-- `confidence`: 0.0-1.0
 - `rationale`: Explanation
 
 ## Viewing Rules

--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -74,13 +74,13 @@ def _assert_coherent(value, status) -> None:
             f"incoherent entry: {status!r} status must not carry a real value, got {value!r}")
 
 
-def build_field_entry(value, status=None, confidence=0.0, evidence=None) -> dict:
+def build_field_entry(value, status=None, evidence=None) -> dict:
     """Build a serialized per-field classification entry.
 
-    The single place that assembles the ``{value, status, confidence, evidence}``
-    output shape and enforces epic #116's Stage 3 invariant: sentinels live only
-    in ``status`` and ``value`` is ``None`` unless the field is CLASSIFIED. Every
-    producer (rule_engine's ``to_output_dict``, the index-propagation script, the
+    The single place that assembles the ``{value, status, evidence}`` output shape
+    and enforces epic #116's Stage 3 invariant: sentinels live only in ``status``
+    and ``value`` is ``None`` unless the field is CLASSIFIED. Every producer
+    (rule_engine's ``to_output_dict``, the index-propagation script, the
     header_classifier empty-input fallback) goes through here, so the invariant is
     defined once. When an explicit ``status`` is passed it must be coherent with
     ``value``: a CLASSIFIED status requires a real value, and a non-CLASSIFIED
@@ -99,7 +99,6 @@ def build_field_entry(value, status=None, confidence=0.0, evidence=None) -> dict
     return {
         "value": value if status == CLASSIFIED else None,
         "status": status,
-        "confidence": confidence,
         "evidence": evidence if evidence is not None else [],
     }
 
@@ -185,6 +184,5 @@ class ClassificationResult:
 
     data_modality: str | None = None
     reference_assembly: str | None = None
-    confidence: float = 0.0
     reasons: list[str] = field(default_factory=list)
     rules_matched: list[str] = field(default_factory=list)

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -67,7 +67,6 @@ class ExtendedClassificationResult:
     reference_assembly: str | None = None
     assay_type: str | None = None
     platform: str | None = None
-    confidence: float = 0.0
     field_evidence: dict[str, list[dict]] = field(
         default_factory=lambda: {fld: [] for fld in CLASSIFICATION_FIELDS})
     # Resolved status per dimension (epic #116 / #136): the dimension attributes
@@ -160,7 +159,6 @@ class ExtendedClassificationResult:
         return ClassificationResult(
             data_modality=self.data_modality,
             reference_assembly=self.reference_assembly,
-            confidence=self.confidence,
             reasons=self.reasons,
             rules_matched=self.rules_matched,
         )
@@ -168,7 +166,7 @@ class ExtendedClassificationResult:
     def to_output_dict(self) -> dict:
         """Convert to the per-field output format.
 
-        Each dimension emits ``{value, status, confidence, evidence}`` via
+        Each dimension emits ``{value, status, evidence}`` via
         ``models.build_field_entry``. The dimension attribute holds a real value or
         None and ``field_status`` holds the resolved status (epic #116 / #136), so
         both are passed straight through — the sentinel is never in ``value``,
@@ -177,10 +175,8 @@ class ExtendedClassificationResult:
         classifications = {}
         for fld in self._CLASSIFICATION_FIELDS:
             evidence = self.field_evidence.get(fld, [])
-            fld_conf = max((e.get("confidence", 0) for e in evidence), default=0.0)
             classifications[fld] = build_field_entry(
-                getattr(self, fld), status=self.field_status[fld],
-                confidence=fld_conf, evidence=evidence)
+                getattr(self, fld), status=self.field_status[fld], evidence=evidence)
         return classifications
 
     # Classification field names (single source of truth: models.CLASSIFICATION_FIELDS)
@@ -196,7 +192,7 @@ def _claim_declaration(claim: dict) -> str | None:
     return value if value is not None else claim.get("status")
 
 
-def _resolved(declaration: str | None, confidence: float, reason: str,
+def _resolved(declaration: str | None, reason: str,
               is_conflict: bool = False, competing: list | None = None) -> dict:
     """Package a winning declaration as ``{value, status, ...}``: a real declaration
     becomes value with status CLASSIFIED; a status declaration becomes that status
@@ -205,7 +201,6 @@ def _resolved(declaration: str | None, confidence: float, reason: str,
     out = {
         "value": declaration if status == CLASSIFIED else None,
         "status": status,
-        "confidence": confidence,
         "reason": reason,
         "is_conflict": is_conflict,
     }
@@ -224,17 +219,17 @@ def evaluate_claims(claims: list[dict]) -> dict:
     Resolution rules:
     - No claims → not_classified
     - Single claim → use it
-    - All claims agree → use declaration, max confidence
+    - All claims agree → use that declaration
     - Claims disagree, highest tier is unique → highest tier wins (override)
     - Claims disagree, NOT_APPLICABLE at top tier → not_applicable wins (terminal)
     - Claims disagree, same max tier → conflict (not_classified)
 
     Args:
-        claims: List of evidence dicts, each with a ``value`` or a ``status``, plus
-                ``confidence`` and optionally ``tier`` / ``rule_id`` / ``reason``.
+        claims: List of evidence dicts, each with a ``value`` or a ``status`` and
+                optionally ``tier`` / ``rule_id`` / ``reason``.
 
     Returns:
-        Dict with: value (real or None), status, confidence, reason, is_conflict,
+        Dict with: value (real or None), status, reason, is_conflict,
         competing_values (if conflict).
     """
     # Drop the synthetic not_classified placeholder and empty claims, but keep
@@ -248,23 +243,20 @@ def evaluate_claims(claims: list[dict]) -> dict:
     assertive_claims = [c for c in real_claims if _claim_declaration(c) != NOT_CLASSIFIED]
 
     if not real_claims:
-        return _resolved(NOT_CLASSIFIED, 0.0, "no_claims")
+        return _resolved(NOT_CLASSIFIED, "no_claims")
 
     # Only not_classified declarations present → resolve as not_classified
     # (the rule's rationale is preserved in field_evidence, not in this return value)
     if not assertive_claims:
-        best = max(real_claims, key=lambda c: c.get("confidence", 0))
-        return _resolved(NOT_CLASSIFIED, best.get("confidence", 0),
+        return _resolved(NOT_CLASSIFIED,
                          "single_claim" if len(real_claims) == 1 else "unanimous")
 
     # Check if all assertive declarations agree
     declarations = {_claim_declaration(c) for c in assertive_claims}
 
     if len(declarations) == 1:
-        # Unanimous — use the highest-confidence claim
-        best = max(assertive_claims, key=lambda c: c.get("confidence", 0))
-        return _resolved(_claim_declaration(best),
-                         max(c.get("confidence", 0) for c in assertive_claims),
+        # Unanimous — every assertive claim declares the same value
+        return _resolved(next(iter(declarations)),
                          "unanimous" if len(assertive_claims) > 1 else "single_claim")
 
     # Assertive declarations disagree — check tiers
@@ -276,22 +268,14 @@ def evaluate_claims(claims: list[dict]) -> dict:
     # at the same tier without triggering a conflict (e.g., text_stats
     # setting not_applicable shouldn't conflict with filename_ref patterns)
     if NOT_APPLICABLE in top_tier_decls:
-        na_claims = [c for c in top_tier_claims if _claim_declaration(c) == NOT_APPLICABLE]
-        best = max(na_claims, key=lambda c: c.get("confidence", 0))
-        return _resolved(NOT_APPLICABLE, best.get("confidence", 0), "not_applicable_terminal")
+        return _resolved(NOT_APPLICABLE, "not_applicable_terminal")
 
     if len(top_tier_decls) == 1:
         # Highest tier is unanimous — override lower tiers
-        winner = top_tier_decls.pop()
-        best = max(
-            (c for c in top_tier_claims if _claim_declaration(c) == winner),
-            key=lambda c: c.get("confidence", 0),
-        )
-        return _resolved(_claim_declaration(best), best.get("confidence", 0),
-                         "higher_specificity_override")
+        return _resolved(top_tier_decls.pop(), "higher_specificity_override")
 
     # Same tier, different values — conflict
-    return _resolved(NOT_CLASSIFIED, 0.0, "conflict",
+    return _resolved(NOT_CLASSIFIED, "conflict",
                      is_conflict=True, competing=sorted(top_tier_decls))
 
 
@@ -406,7 +390,6 @@ class RuleEngine:
                     "rule_id": f"conflicting_{fld}_rules",
                     "reason": (f"Conflicting {fld}: {evaluation['competing_values']}"
                                " — ambiguous"),
-                    "confidence": 0.0,
                     "status": NOT_CLASSIFIED,
                     "competing_values": evaluation["competing_values"],
                     "is_conflict": True,
@@ -415,7 +398,6 @@ class RuleEngine:
                 result.field_evidence[fld].append({
                     "rule_id": "not_classified",
                     "reason": f"No rule determined a value for {fld}",
-                    "confidence": 0.0,
                     "status": NOT_CLASSIFIED,
                 })
 
@@ -596,14 +578,12 @@ class RuleEngine:
         claim appended to field_evidence — a value claim carries ``value``, a status
         claim carries ``status`` (never a sentinel in the value slot — epic #116 /
         #136); evaluation happens later in _finalize_result via evaluate_claims().
-        Also updates result.confidence (running max, not a classification field).
         """
         then = rule.then
         then_status = rule.then_status
         evidence_entry = {
             "rule_id": rule.id,
             "reason": rule.rationale or "",
-            "confidence": rule.confidence,
             "tier": rule.tier,
         }
         for fld in result._CLASSIFICATION_FIELDS:
@@ -613,10 +593,6 @@ class RuleEngine:
                 result.field_evidence[fld].append({**evidence_entry, "value": value})
             elif status is not None:
                 result.field_evidence[fld].append({**evidence_entry, "status": status})
-
-        # Update overall confidence (take highest confidence from matching rules)
-        if rule.confidence > result.confidence:
-            result.confidence = rule.confidence
 
     def infer_assay_type(
         self,
@@ -696,7 +672,6 @@ class RuleEngine:
             result.field_evidence["assay_type"].append({
                 "rule_id": "infer_assay_type",
                 "reason": f"Inferred {assay_rule.assay_type} from platform/modality/file size signals",
-                "confidence": 0.70,
                 "value": assay_rule.assay_type,
             })
             return

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -25,7 +25,6 @@ class UnifiedRule:
     scope: str
     when: dict[str, Any]
     then: dict[str, Any]
-    confidence: float
     rationale: str
     then_status: dict[str, str] = field(default_factory=dict)
     def matches_extension(self, extension: str) -> bool:
@@ -44,7 +43,6 @@ class ValidatorConfig:
     module: str
     function: str
     applies_to: list[str]
-    confidence: float = 0.0
 
 
 @dataclass
@@ -307,7 +305,6 @@ class RuleLoader:
                 scope=scope,
                 when=when,
                 then=then_values,
-                confidence=rule_data.get("confidence", 0.0),
                 rationale=rule_data.get("rationale", ""),
                 then_status=then_status,
             ))
@@ -363,7 +360,6 @@ class RuleLoader:
                 module=config.get("module", ""),
                 function=config.get("function", ""),
                 applies_to=config.get("applies_to", []),
-                confidence=config.get("confidence", 0.0),
             )
 
         return validators

--- a/src/meta_disco/validators/contig_lengths.py
+++ b/src/meta_disco/validators/contig_lengths.py
@@ -64,7 +64,7 @@ CHROMOSOME_MAX_LENGTHS: dict[str, tuple[int, int, int]] = {
 def detect_reference_from_contig_lengths(
     contig_lines: list[str],
     tolerance: int = 1000
-) -> tuple[str | None, int, float]:
+) -> tuple[str | None, int]:
     """
     Detect reference assembly from contig lengths in VCF ##contig lines or BAM @SQ lines.
 
@@ -77,13 +77,11 @@ def detect_reference_from_contig_lengths(
         tolerance: Max difference in bp to consider a match (default 1000)
 
     Returns:
-        Tuple of (assembly, vote_count, confidence)
+        Tuple of (assembly, vote_count)
         - assembly: "GRCh38", "GRCh37", "CHM13", or None
         - vote_count: Number of contigs that matched
-        - confidence: 0.98 for exact match, 0.95 for fuzzy match
     """
     votes: dict[str, int] = {}
-    exact_matches = 0
 
     # VCF contig fields can appear in any order: ##contig=<ID=chr1,length=248387497>
     # or ##contig=<ID=chr1,assembly=GRCh38,length=248387497>
@@ -120,7 +118,6 @@ def detect_reference_from_contig_lengths(
         if key in _CONTIG_LENGTH_TO_ASSEMBLY:
             assembly = _CONTIG_LENGTH_TO_ASSEMBLY[key]
             votes[assembly] = votes.get(assembly, 0) + 1
-            exact_matches += 1
         else:
             # Fuzzy match: find closest assembly within tolerance
             best_match = None
@@ -143,17 +140,15 @@ def detect_reference_from_contig_lengths(
         top_count = votes[winner]
         # If multiple assemblies are tied, evidence is ambiguous — don't guess
         if sum(1 for v in votes.values() if v == top_count) > 1:
-            return None, 0, 0.0
-        # Lower confidence if no exact matches (fuzzy only)
-        confidence = 0.98 if exact_matches > 0 else 0.95
-        return winner, top_count, confidence
+            return None, 0
+        return winner, top_count
 
-    return None, 0, 0.0
+    return None, 0
 
 
 def detect_reference_from_max_positions(
     max_positions: dict[str, int],
-) -> tuple[str | None, int, float]:
+) -> tuple[str | None, int]:
     """
     Detect reference assembly by ruling out references where variant
     positions exceed chromosome lengths.
@@ -166,13 +161,12 @@ def detect_reference_from_max_positions(
         max_positions: Dict mapping chromosome (without 'chr') to max position seen
 
     Returns:
-        Tuple of (assembly, evidence_count, confidence)
+        Tuple of (assembly, evidence_count)
         - assembly: "GRCh38", "GRCh37", "CHM13", or None if inconclusive
         - evidence_count: Number of chromosomes used for ruling out
-        - confidence: 0.90 when narrowed to one reference
     """
     if not max_positions:
-        return None, 0, 0.0
+        return None, 0
 
     possible = {"GRCh37", "GRCh38", "CHM13"}
     evidence_count = 0
@@ -200,6 +194,6 @@ def detect_reference_from_max_positions(
 
     # If narrowed to exactly one reference
     if len(possible) == 1 and evidence_count > 0:
-        return possible.pop(), evidence_count, 0.90
+        return possible.pop(), evidence_count
 
-    return None, 0, 0.0
+    return None, 0

--- a/tests/fixtures/golden/expected_output.json
+++ b/tests/fixtures/golden/expected_output.json
@@ -4,10 +4,8 @@
       {
         "classifications": {
           "assay_type": {
-            "confidence": 0.0,
             "evidence": [
               {
-                "confidence": 0.0,
                 "reason": "No rule determined a value for assay_type",
                 "rule_id": "not_classified",
                 "status": "not_classified"
@@ -17,10 +15,8 @@
             "value": null
           },
           "data_modality": {
-            "confidence": 0.0,
             "evidence": [
               {
-                "confidence": 0.0,
                 "reason": "No rule determined a value for data_modality",
                 "rule_id": "not_classified",
                 "status": "not_classified"
@@ -30,10 +26,8 @@
             "value": null
           },
           "data_type": {
-            "confidence": 0.0,
             "evidence": [
               {
-                "confidence": 0.0,
                 "reason": "No rule determined a value for data_type",
                 "rule_id": "not_classified",
                 "status": "not_classified"
@@ -43,10 +37,8 @@
             "value": null
           },
           "platform": {
-            "confidence": 0.0,
             "evidence": [
               {
-                "confidence": 0.0,
                 "reason": "No rule determined a value for platform",
                 "rule_id": "not_classified",
                 "status": "not_classified"
@@ -56,10 +48,8 @@
             "value": null
           },
           "reference_assembly": {
-            "confidence": 0.9,
             "evidence": [
               {
-                "confidence": 0.9,
                 "reason": "Absence of @SQ lines indicates unaligned reads. Common for PacBio HiFi deliverables before alignment",
                 "rule_id": "unaligned_no_sq",
                 "status": "not_applicable",
@@ -92,10 +82,8 @@
       {
         "classifications": {
           "assay_type": {
-            "confidence": 0.3,
             "evidence": [
               {
-                "confidence": 0.3,
                 "reason": "FASTA file detected; header inspection needed to determine if de novo assembly, reference genome, or transcript sequences",
                 "rule_id": "fasta_base",
                 "status": "not_applicable",
@@ -106,17 +94,14 @@
             "value": null
           },
           "data_modality": {
-            "confidence": 0.8,
             "evidence": [
               {
-                "confidence": 0.8,
                 "reason": "Filename contains assembly/assembler indicator \u2014 de novo assembly",
                 "rule_id": "fasta_assembly_filename",
                 "tier": 2,
                 "value": "genomic"
               },
               {
-                "confidence": 0.8,
                 "reason": "Filename contains haplotype/phasing indicator \u2014 de novo assembly",
                 "rule_id": "fasta_haplotype_filename",
                 "tier": 2,
@@ -127,24 +112,20 @@
             "value": "genomic"
           },
           "data_type": {
-            "confidence": 0.8,
             "evidence": [
               {
-                "confidence": 0.3,
                 "reason": "FASTA file detected; header inspection needed to determine if de novo assembly, reference genome, or transcript sequences",
                 "rule_id": "fasta_base",
                 "tier": 1,
                 "value": "sequence"
               },
               {
-                "confidence": 0.8,
                 "reason": "Filename contains assembly/assembler indicator \u2014 de novo assembly",
                 "rule_id": "fasta_assembly_filename",
                 "tier": 2,
                 "value": "assembly"
               },
               {
-                "confidence": 0.8,
                 "reason": "Filename contains haplotype/phasing indicator \u2014 de novo assembly",
                 "rule_id": "fasta_haplotype_filename",
                 "tier": 2,
@@ -155,10 +136,8 @@
             "value": "assembly"
           },
           "platform": {
-            "confidence": 0.3,
             "evidence": [
               {
-                "confidence": 0.3,
                 "reason": "FASTA file detected; header inspection needed to determine if de novo assembly, reference genome, or transcript sequences",
                 "rule_id": "fasta_base",
                 "status": "not_applicable",
@@ -169,17 +148,14 @@
             "value": null
           },
           "reference_assembly": {
-            "confidence": 0.8,
             "evidence": [
               {
-                "confidence": 0.8,
                 "reason": "Filename contains assembly/assembler indicator \u2014 de novo assembly",
                 "rule_id": "fasta_assembly_filename",
                 "status": "not_applicable",
                 "tier": 2
               },
               {
-                "confidence": 0.8,
                 "reason": "Filename contains haplotype/phasing indicator \u2014 de novo assembly",
                 "rule_id": "fasta_haplotype_filename",
                 "status": "not_applicable",
@@ -214,10 +190,8 @@
           "archive_accession": null,
           "archive_source": null,
           "assay_type": {
-            "confidence": 0.0,
             "evidence": [
               {
-                "confidence": 0.0,
                 "reason": "No rule determined a value for assay_type",
                 "rule_id": "not_classified",
                 "status": "not_classified"
@@ -227,10 +201,8 @@
             "value": null
           },
           "data_modality": {
-            "confidence": 0.0,
             "evidence": [
               {
-                "confidence": 0.0,
                 "reason": "FASTQ modality cannot be determined from reads alone \u2014 could be genomic, transcriptomic, or epigenomic depending on assay",
                 "rule_id": "fastq_modality_unknown",
                 "status": "not_classified",
@@ -241,10 +213,8 @@
             "value": null
           },
           "data_type": {
-            "confidence": 0.5,
             "evidence": [
               {
-                "confidence": 0.5,
                 "reason": "FASTQ files contain raw sequencing reads. Reference not applicable until alignment",
                 "rule_id": "reads_base",
                 "tier": 2,
@@ -258,10 +228,8 @@
           "instrument_model": null,
           "is_paired_end": false,
           "platform": {
-            "confidence": 0.0,
             "evidence": [
               {
-                "confidence": 0.0,
                 "reason": "No rule determined a value for platform",
                 "rule_id": "not_classified",
                 "status": "not_classified"
@@ -271,10 +239,8 @@
             "value": null
           },
           "reference_assembly": {
-            "confidence": 0.5,
             "evidence": [
               {
-                "confidence": 0.5,
                 "reason": "FASTQ files contain raw sequencing reads. Reference not applicable until alignment",
                 "rule_id": "reads_base",
                 "status": "not_applicable",
@@ -307,10 +273,8 @@
       {
         "classifications": {
           "assay_type": {
-            "confidence": 0.0,
             "evidence": [
               {
-                "confidence": 0.0,
                 "reason": "No rule determined a value for assay_type",
                 "rule_id": "not_classified",
                 "status": "not_classified"
@@ -320,10 +284,8 @@
             "value": null
           },
           "data_modality": {
-            "confidence": 0.85,
             "evidence": [
               {
-                "confidence": 0.85,
                 "reason": "VCF files contain variant calls (genomic data)",
                 "rule_id": "variant_default_genomic",
                 "tier": 1,
@@ -334,10 +296,8 @@
             "value": "genomic"
           },
           "data_type": {
-            "confidence": 0.85,
             "evidence": [
               {
-                "confidence": 0.85,
                 "reason": "VCF files contain variant calls (genomic data)",
                 "rule_id": "variant_default_genomic",
                 "tier": 1,
@@ -348,10 +308,8 @@
             "value": "variants"
           },
           "platform": {
-            "confidence": 0.0,
             "evidence": [
               {
-                "confidence": 0.0,
                 "reason": "No rule determined a value for platform",
                 "rule_id": "not_classified",
                 "status": "not_classified"
@@ -361,10 +319,8 @@
             "value": null
           },
           "reference_assembly": {
-            "confidence": 0.0,
             "evidence": [
               {
-                "confidence": 0.0,
                 "reason": "No rule determined a value for reference_assembly",
                 "rule_id": "not_classified",
                 "status": "not_classified"

--- a/tests/test_bed_classification.py
+++ b/tests/test_bed_classification.py
@@ -34,7 +34,6 @@ def classify_bed(filename: str, dataset_title: str = "") -> dict:
         "data_type": result.data_type,
         "assay_type": result.assay_type,
         "reference_assembly": result.reference_assembly,
-        "confidence": result.confidence,
         "rules_matched": result.rules_matched,
     }
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -52,8 +52,8 @@ def assert_output_format(record):
         entry = cls[field]
         assert isinstance(entry, dict), f"{field} should be dict"
         assert "value" in entry, f"{field} missing 'value'"
+        assert "status" in entry, f"{field} missing 'status'"
         assert "evidence" in entry, f"{field} missing 'evidence'"
-        assert "confidence" in entry, f"{field} missing 'confidence'"
         # assay_type may be set by post-hoc inference which doesn't produce evidence
         if field != "assay_type":
             assert len(entry["evidence"]) > 0, f"{field} has empty evidence"
@@ -117,13 +117,13 @@ class TestBamE2E:
         assert get_val(result, "data_type") == "alignments"
         assert get_val(result, "assay_type") == "RNA-seq"
 
-    def test_platform_confidence_meaningful(self):
-        """Platform detection from @RG PL: should have non-zero confidence."""
+    def test_platform_detection_meaningful(self):
+        """Platform detection from @RG PL: should classify a platform value."""
         result = classify_bam("000ebc5cfdeb4e799aa047e2c54022af", "HG03516.GRCh38_no_alt.bam",
                               file_size=239579784536, file_format=".bam")
         cls = result["classifications"]
-        platform_conf = cls["platform"]["confidence"]
-        assert platform_conf > 0, f"Platform confidence should be > 0, got {platform_conf}"
+        platform_val = cls["platform"]["value"]
+        assert platform_val is not None, f"Platform should be classified, got {platform_val}"
 
     def test_illumina_cram_wgs_assay_type(self):
         """HG00741.final.cram — 15.9 GB Illumina CRAM should infer WGS.

--- a/tests/test_field_accessors.py
+++ b/tests/test_field_accessors.py
@@ -207,9 +207,9 @@ class TestCoherenceGuard:
 
 class TestBuildFieldEntry:
     def test_classified_keeps_value(self):
-        e = build_field_entry("genomic", confidence=0.9, evidence=[{"x": 1}])
+        e = build_field_entry("genomic", evidence=[{"x": 1}])
         assert e == {"value": "genomic", "status": CLASSIFIED,
-                     "confidence": 0.9, "evidence": [{"x": 1}]}
+                     "evidence": [{"x": 1}]}
 
     def test_derived_sentinel_nulls_value(self):
         # Sentinel-carrying value with no explicit status → status derived, value nulled.

--- a/tests/test_header_classifier.py
+++ b/tests/test_header_classifier.py
@@ -8,17 +8,10 @@ from src.meta_disco.models import CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED, fi
 def val(result: dict, field: str):
     """Extract a classification value (or a derived test aggregate) from output.
 
-    Field values delegate to models.field_value. Two test-only pseudo-fields are
+    Field values delegate to models.field_value. One test-only pseudo-field is
     derived from the per-field structure:
-    - "confidence": max confidence across all fields
     - "matched_rules": flattened, de-duplicated rule_ids from all evidence
     """
-    if field == "confidence" and result.get(field) is None:
-        max_conf = 0.0
-        for fld_val in result.values():
-            if isinstance(fld_val, dict) and "confidence" in fld_val:
-                max_conf = max(max_conf, fld_val["confidence"])
-        return max_conf
     if field == "matched_rules" and result.get(field) is None:
         rules = []
         for fld_val in result.values():
@@ -320,7 +313,6 @@ class TestFastqClassification:
         assert val(result, "platform") == "ILLUMINA"
         assert field_status(result, "data_modality") == NOT_CLASSIFIED
         assert val(result, "data_type") == "reads"
-        assert val(result, "confidence") >= 0.90
 
     def test_illumina_instrument_model(self):
         """Extract Illumina instrument model."""
@@ -337,7 +329,6 @@ class TestFastqClassification:
         ]
         result = classify_from_fastq_header(reads)
         assert val(result, "platform") == "ILLUMINA"
-        assert val(result, "confidence") >= 0.85
 
     def test_ena_reformatted(self):
         """Classify ENA-reformatted FASTQ with accession extraction."""
@@ -368,7 +359,6 @@ class TestFastqClassification:
         assert val(result, "platform") == "ILLUMINA"
         assert field_status(result, "data_modality") == NOT_CLASSIFIED
         assert result["archive_accession"] == "ERR1395578"
-        assert val(result, "confidence") >= 0.85
 
     def test_ena_hiseq_2500(self):
         """Classify ENA-reformatted FASTQ with HiSeq 2500 instrument."""
@@ -378,7 +368,6 @@ class TestFastqClassification:
         result = classify_from_fastq_header(reads)
         assert val(result, "platform") == "ILLUMINA"
         assert field_status(result, "data_modality") == NOT_CLASSIFIED
-        assert val(result, "confidence") >= 0.85
 
     def test_pacbio_ccs(self):
         """Classify PacBio CCS/HiFi FASTQ."""
@@ -391,7 +380,6 @@ class TestFastqClassification:
         assert val(result, "platform") == "PACBIO"
         assert field_status(result, "data_modality") == NOT_CLASSIFIED
         assert val(result, "data_type") == "reads"
-        assert val(result, "confidence") >= 0.95
 
     def test_pacbio_clr(self):
         """Classify PacBio CLR FASTQ."""
@@ -462,7 +450,6 @@ class TestFastqClassification:
         """Handle empty input gracefully."""
         result = classify_from_fastq_header([])
         assert val(result, "platform") is None
-        assert val(result, "confidence") == 0.0
         # The empty-input fallback mirrors to_output_dict's Stage 3 shape (#116):
         # sentinels live in `status`, `value` is None unless CLASSIFIED.
         assert "status" in result["data_modality"]
@@ -474,16 +461,16 @@ class TestFastqClassification:
         assert field_status(result, "reference_assembly") == NOT_APPLICABLE
         assert val(result, "reference_assembly") is None
 
-    def test_confidence_boost_on_agreement(self):
-        """Confidence should increase when all reads agree."""
+    def test_platform_on_agreement(self):
+        """Platform should be classified when all reads agree."""
         reads = [
             "@A00297:44:HFKH3DSXX:2:1354:30508:28839",
             "@A00297:44:HFKH3DSXX:2:1354:30509:28840",
             "@A00297:44:HFKH3DSXX:2:1354:30510:28841",
         ]
         result = classify_from_fastq_header(reads)
-        # Should get boost for consistent reads
-        assert val(result, "confidence") >= 0.90
+        # Consistent reads should classify platform as ILLUMINA
+        assert val(result, "platform") == "ILLUMINA"
 
 
 # =============================================================================
@@ -501,8 +488,6 @@ class TestVcfClassification:
 #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO"""
         result = classify_from_vcf_header(header)
         assert val(result, "reference_assembly") == "GRCh38"
-        # Reference detection is lower confidence than caller detection
-        assert val(result, "confidence") >= 0.50
 
     def test_grch37_reference(self):
         """Detect GRCh37/hg19 reference."""
@@ -578,7 +563,7 @@ class TestVcfClassification:
         header = """##fileformat=VCFv4.2
 #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO"""
         result = classify_from_vcf_header(header)
-        # Should still work but with lower confidence
+        # Should still produce a well-formed result
         assert "data_modality" in result
 
 
@@ -806,7 +791,6 @@ class TestContigLengthDetection:
         header += "@SQ\tSN:chr22\tLN:50818468"
         result = classify_from_header(header)
         assert val(result, "reference_assembly") == "GRCh38"
-        assert val(result, "confidence") >= 0.9
 
     def test_vcf_contig_with_assembly_tag(self):
         """VCF ##contig assembly= is matched via contig pattern rules."""

--- a/tests/test_hprc_validation.py
+++ b/tests/test_hprc_validation.py
@@ -115,7 +115,7 @@ class TestExtractRefFromAnnotationType:
 
 class TestFieldValue:
     def test_per_field_format(self):
-        record = {"classifications": {"platform": {"value": "PACBIO", "confidence": 0.9}}}
+        record = {"classifications": {"platform": {"value": "PACBIO"}}}
         assert field_value(record, "platform") == "PACBIO"
 
     def test_flat_format(self):

--- a/tests/test_index_propagation.py
+++ b/tests/test_index_propagation.py
@@ -131,11 +131,11 @@ class TestLoadClassifications:
                 "md5sum": "abc123",
                 "file_name": "sample.bam",
                 "classifications": {
-                    "data_modality": {"value": "genomic", "confidence": 0.9, "evidence": []},
-                    "data_type": {"value": "alignments", "confidence": 0.9, "evidence": []},
-                    "platform": {"value": "ILLUMINA", "confidence": 0.9, "evidence": []},
-                    "reference_assembly": {"value": "GRCh38", "confidence": 0.9, "evidence": []},
-                    "assay_type": {"value": "WGS", "confidence": 0.9, "evidence": []},
+                    "data_modality": {"value": "genomic", "evidence": []},
+                    "data_type": {"value": "alignments", "evidence": []},
+                    "platform": {"value": "ILLUMINA", "evidence": []},
+                    "reference_assembly": {"value": "GRCh38", "evidence": []},
+                    "assay_type": {"value": "WGS", "evidence": []},
                 },
             }],
         }))
@@ -152,11 +152,11 @@ class TestLoadClassifications:
                 "md5sum": "bam_md5",
                 "file_name": "sample.bam",
                 "classifications": {
-                    "data_modality": {"value": "genomic", "confidence": 0.9, "evidence": []},
-                    "data_type": {"value": "alignments", "confidence": 0.9, "evidence": []},
-                    "platform": {"value": "ILLUMINA", "confidence": 0.9, "evidence": []},
-                    "reference_assembly": {"value": "GRCh38", "confidence": 0.9, "evidence": []},
-                    "assay_type": {"value": "WGS", "confidence": 0.9, "evidence": []},
+                    "data_modality": {"value": "genomic", "evidence": []},
+                    "data_type": {"value": "alignments", "evidence": []},
+                    "platform": {"value": "ILLUMINA", "evidence": []},
+                    "reference_assembly": {"value": "GRCh38", "evidence": []},
+                    "assay_type": {"value": "WGS", "evidence": []},
                 },
             }],
         }))
@@ -166,11 +166,11 @@ class TestLoadClassifications:
                 "md5sum": "bed_md5",
                 "file_name": "sample.regions.bed.gz",
                 "classifications": {
-                    "data_modality": {"value": "genomic", "confidence": 0.8, "evidence": []},
-                    "data_type": {"value": "annotations", "confidence": 0.8, "evidence": []},
-                    "platform": {"value": "not_classified", "confidence": 0.0, "evidence": []},
-                    "reference_assembly": {"value": "GRCh38", "confidence": 0.8, "evidence": []},
-                    "assay_type": {"value": "not_classified", "confidence": 0.0, "evidence": []},
+                    "data_modality": {"value": "genomic", "evidence": []},
+                    "data_type": {"value": "annotations", "evidence": []},
+                    "platform": {"value": "not_classified", "evidence": []},
+                    "reference_assembly": {"value": "GRCh38", "evidence": []},
+                    "assay_type": {"value": "not_classified", "evidence": []},
                 },
             }],
         }))
@@ -218,11 +218,11 @@ class TestLoadClassifications:
                 "md5sum": "bed_parent_md5",
                 "file_name": "HG03652.regions.bed.gz",
                 "classifications": {
-                    "data_modality": {"value": "genomic", "confidence": 0.8, "evidence": []},
-                    "data_type": {"value": "annotations", "confidence": 0.8, "evidence": []},
-                    "platform": {"value": "not_classified", "confidence": 0.0, "evidence": []},
-                    "reference_assembly": {"value": "CHM13", "confidence": 0.9, "evidence": []},
-                    "assay_type": {"value": "not_classified", "confidence": 0.0, "evidence": []},
+                    "data_modality": {"value": "genomic", "evidence": []},
+                    "data_type": {"value": "annotations", "evidence": []},
+                    "platform": {"value": "not_classified", "evidence": []},
+                    "reference_assembly": {"value": "CHM13", "evidence": []},
+                    "assay_type": {"value": "not_classified", "evidence": []},
                 },
             }],
         }))
@@ -263,11 +263,11 @@ class TestLoadClassifications:
         vcf_cls.write_text(json.dumps({"classifications": [{
             "md5sum": "vcf_md5", "file_name": "sample.vcf.gz",
             "classifications": {
-                "data_modality": {"value": "genomic", "confidence": 0.85, "evidence": []},
-                "data_type": {"value": "variants.germline", "confidence": 0.9, "evidence": []},
-                "platform": {"value": "not_classified", "confidence": 0.0, "evidence": []},
-                "reference_assembly": {"value": "GRCh38", "confidence": 0.98, "evidence": []},
-                "assay_type": {"value": "not_classified", "confidence": 0.0, "evidence": []},
+                "data_modality": {"value": "genomic", "evidence": []},
+                "data_type": {"value": "variants.germline", "evidence": []},
+                "platform": {"value": "not_classified", "evidence": []},
+                "reference_assembly": {"value": "GRCh38", "evidence": []},
+                "assay_type": {"value": "not_classified", "evidence": []},
             },
         }]}))
         output_file = tmp_path / "out.json"
@@ -295,11 +295,11 @@ class TestLoadClassifications:
         bam_cls.write_text(json.dumps({"classifications": [{
             "md5sum": "bam_md5", "file_name": "sample.bam",
             "classifications": {
-                "data_modality": {"value": "transcriptomic.bulk", "confidence": 0.95, "evidence": []},
-                "data_type": {"value": "alignments", "confidence": 0.9, "evidence": []},
-                "platform": {"value": "ILLUMINA", "confidence": 0.95, "evidence": []},
-                "reference_assembly": {"value": "GRCh38", "confidence": 0.98, "evidence": []},
-                "assay_type": {"value": "RNA-seq", "confidence": 0.95, "evidence": []},
+                "data_modality": {"value": "transcriptomic.bulk", "evidence": []},
+                "data_type": {"value": "alignments", "evidence": []},
+                "platform": {"value": "ILLUMINA", "evidence": []},
+                "reference_assembly": {"value": "GRCh38", "evidence": []},
+                "assay_type": {"value": "RNA-seq", "evidence": []},
             },
         }]}))
         output_file = tmp_path / "out.json"

--- a/tests/test_output_shape.py
+++ b/tests/test_output_shape.py
@@ -33,7 +33,7 @@ Regenerate with::
     python -m tests.test_output_shape   # writes tests/fixtures/golden/expected_output.json
 
 Note: the golden deep-equal is intentionally *value-sensitive* — it pins exact
-values/confidence/reason strings so the migration's pure-refactor stages can prove
+values/reason strings so the migration's pure-refactor stages can prove
 the output is unchanged. That couples it to rule content for the duration of epic
 #116; once the shape stabilizes (after #122) this file should be de-tuned to
 shape-only (drop the deep-equal layer, keep the structural + vocabulary layers).
@@ -87,8 +87,8 @@ STUB_HEADER = "stub-header-no-network"
 # the golden exercises realistic classifier input and stays robust if a classifier
 # later type-guards its argument.
 LIST_RETURNING_TYPES = {"fastq", "fasta"}
-EVIDENCE_KEYS = {"rule_id", "reason", "confidence"}
-FIELD_KEYS = {"value", "status", "confidence", "evidence"}
+EVIDENCE_KEYS = {"rule_id", "reason"}
+FIELD_KEYS = {"value", "status", "evidence"}
 RECORD_KEYS = {
     "file_name", "md5sum", "file_size", "file_format",
     "dataset_title", "classifications", "entry_id",
@@ -198,8 +198,6 @@ def test_output_structural_contract(output):
                 f"{ftype}.{field}: status={entry['status']!r}"
             assert (entry["status"] == CLASSIFIED) == (entry["value"] is not None), \
                 f"{ftype}.{field}: incoherent value={entry['value']!r} status={entry['status']!r}"
-            conf = entry["confidence"]
-            assert isinstance(conf, (int, float)) and not isinstance(conf, bool)
             assert isinstance(entry["evidence"], list)
             for ev in entry["evidence"]:
                 assert EVIDENCE_KEYS <= set(ev), f"{ftype}.{field} evidence: {set(ev)}"

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -568,7 +568,8 @@ class TestAssayTypeInference:
         result.set_field("assay_type", status=NOT_CLASSIFIED)
         result.field_evidence["assay_type"] = [{
             "rule_id": "not_classified",
-            "reason": "No rule determined a value for assay_type",            "status": NOT_CLASSIFIED,
+            "reason": "No rule determined a value for assay_type",
+            "status": NOT_CLASSIFIED,
         }]
         engine.infer_assay_type(result, file_info)
         assert result.assay_type == "WGS"

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -57,20 +57,17 @@ class TestRuleMatching:
         """RNA-seq indicators in filename should set transcriptomic modality."""
         result = engine.classify(FileInfo(filename="sample_RNA_aligned.bam"))
         assert result.data_modality == "transcriptomic.bulk"
-        assert result.confidence >= 0.80
         assert "alignment_rnaseq_filename" in result.rules_matched
 
     def test_alignment_wgs_filename(self, engine):
         """WGS indicators should set genomic modality with WGS assay_type."""
         result = engine.classify(FileInfo(filename="sample_WGS_aligned.bam"))
         assert result.data_modality == "genomic"
-        assert result.confidence >= 0.85
 
     def test_alignment_ref_grch38(self, engine):
         """hg38/GRCh38 in filename should set reference assembly."""
         result = engine.classify(FileInfo(filename="sample.hg38.cram"))
         assert result.reference_assembly == "GRCh38"
-        assert result.confidence >= 0.90
 
     def test_alignment_ref_grch37(self, engine):
         """hg19/GRCh37 in filename should set reference assembly."""
@@ -95,7 +92,6 @@ class TestRuleMatching:
             FileInfo(filename="sample.Aligned.sortedByCoord.out.bam")
         )
         assert result.data_modality == "transcriptomic.bulk"
-        assert result.confidence >= 0.90
 
 
 class TestVariantFiles:
@@ -105,7 +101,6 @@ class TestVariantFiles:
         """VCF files should default to genomic."""
         result = engine.classify(FileInfo(filename="sample.vcf"))
         assert result.data_modality == "genomic"
-        assert result.confidence >= 0.85
 
     def test_vcf_gz_default_genomic(self, engine):
         """Compressed VCF files should default to genomic."""
@@ -130,7 +125,7 @@ class TestThenStatus:
                 {"extension_map": {".foo": "foo"}},
                 {"rules": [{
                     "id": "foo_rule", "tier": 1, "scope": "extension",
-                    "when": {"extensions": [".foo"]}, "then": then, "confidence": 1.0,
+                    "when": {"extensions": [".foo"]}, "then": then,
                 }]},
             ], f)
         return RuleEngine(path)
@@ -218,13 +213,11 @@ class TestSpecialFileTypes:
         for ext in [".pgen", ".pvar", ".psam"]:
             result = engine.classify(FileInfo(filename=f"sample{ext}"))
             assert result.data_modality == "genomic"
-            assert result.confidence >= 0.95
 
     def test_single_cell_matrix(self, engine):
         """Single-cell matrix files should be transcriptomic.single_cell."""
         result = engine.classify(FileInfo(filename="sample.h5ad"))
         assert result.data_modality == "transcriptomic.single_cell"
-        assert result.confidence >= 0.90
 
     def test_single_cell_atac(self, engine):
         """Single-cell ATAC matrix should be epigenomic."""
@@ -235,13 +228,11 @@ class TestSpecialFileTypes:
         """IDAT files should be epigenomic.methylation."""
         result = engine.classify(FileInfo(filename="sample.idat"))
         assert result.data_modality == "epigenomic.methylation"
-        assert result.confidence >= 0.95
 
     def test_histology_svs(self, engine):
         """SVS files should be imaging.histology."""
         result = engine.classify(FileInfo(filename="GTEX-18A6Q-1126.svs"))
         assert result.data_modality == "imaging.histology"
-        assert result.confidence >= 0.95
 
 
 class TestFastqFiles:
@@ -279,7 +270,6 @@ class TestPeakFiles:
         """narrowPeak files should be epigenomic.chromatin_accessibility."""
         result = engine.classify(FileInfo(filename="sample.narrowPeak"))
         assert result.data_modality == "epigenomic.chromatin_accessibility"
-        assert result.confidence >= 0.85
 
     def test_broadpeak_chromatin_accessibility(self, engine):
         """broadPeak files should be epigenomic.chromatin_accessibility."""
@@ -295,7 +285,6 @@ class TestPeakFiles:
         """ChIP-seq peak files should be epigenomic.histone_modification."""
         result = engine.classify(FileInfo(filename="H3K27ac_chip_peaks.bed"))
         assert result.data_modality == "epigenomic.histone_modification"
-        assert result.confidence >= 0.90
 
     def test_summit_bed_chromatin_accessibility(self, engine):
         """Summit files should be epigenomic.chromatin_accessibility."""
@@ -331,19 +320,16 @@ class TestIntegration:
             FileInfo(filename="m64043_210211_005516.hifi_reads.bam")
         )
         assert result.data_modality == "genomic"
-        assert result.confidence >= 0.70
 
     def test_vcf_with_chr(self, engine):
         """VCF with chromosome in filename."""
         result = engine.classify(FileInfo(filename="NA19189.chr2.hc.vcf.gz"))
         assert result.data_modality == "genomic"
-        assert result.confidence >= 0.85
 
     def test_gtex_histology(self, engine):
         """GTEx histology image."""
         result = engine.classify(FileInfo(filename="GTEX-18A6Q-1126.svs"))
         assert result.data_modality == "imaging.histology"
-        assert result.confidence >= 0.95
 
     def test_cram_md5(self, engine):
         """CRAM MD5 checksum should be not_applicable."""
@@ -436,39 +422,36 @@ class TestEvaluateClaims:
     def test_single_claim(self):
         """Single claim → use it."""
         result = evaluate_claims([
-            {"rule_id": "r1", "value": "genomic", "confidence": 0.90, "tier": 2},
+            {"rule_id": "r1", "value": "genomic", "tier": 2},
         ])
         assert result["value"] == "genomic"
-        assert result["confidence"] == 0.90
         assert result["reason"] == "single_claim"
         assert result["is_conflict"] is False
 
     def test_two_claims_agree(self):
-        """Two claims with same value → unanimous, max confidence."""
+        """Two claims with same value → unanimous."""
         result = evaluate_claims([
-            {"rule_id": "r1", "value": "genomic", "confidence": 0.80, "tier": 2},
-            {"rule_id": "r2", "value": "genomic", "confidence": 0.95, "tier": 3},
+            {"rule_id": "r1", "value": "genomic", "tier": 2},
+            {"rule_id": "r2", "value": "genomic", "tier": 3},
         ])
         assert result["value"] == "genomic"
-        assert result["confidence"] == 0.95
         assert result["reason"] == "unanimous"
 
     def test_disagree_different_tiers(self):
         """Higher tier wins when claims disagree."""
         result = evaluate_claims([
-            {"rule_id": "r1", "value": "sequence", "confidence": 0.30, "tier": 1},
-            {"rule_id": "r2", "value": "assembly", "confidence": 0.80, "tier": 2},
+            {"rule_id": "r1", "value": "sequence", "tier": 1},
+            {"rule_id": "r2", "value": "assembly", "tier": 2},
         ])
         assert result["value"] == "assembly"
-        assert result["confidence"] == 0.80
         assert result["reason"] == "higher_specificity_override"
         assert result["is_conflict"] is False
 
     def test_disagree_same_tier(self):
         """Same tier, different values → conflict (not_classified status, no value)."""
         result = evaluate_claims([
-            {"rule_id": "r1", "value": "GRCh38", "confidence": 0.90, "tier": 2},
-            {"rule_id": "r2", "value": "CHM13", "confidence": 0.90, "tier": 2},
+            {"rule_id": "r1", "value": "GRCh38", "tier": 2},
+            {"rule_id": "r2", "value": "CHM13", "tier": 2},
         ])
         assert result["status"] == NOT_CLASSIFIED
         assert result["value"] is None
@@ -479,9 +462,9 @@ class TestEvaluateClaims:
     def test_three_claims_conflict_at_top_tier(self):
         """Lower tier agrees but top tier has conflict → conflict wins."""
         result = evaluate_claims([
-            {"rule_id": "r1", "value": "genomic", "confidence": 0.30, "tier": 1},
-            {"rule_id": "r2", "value": "genomic", "confidence": 0.90, "tier": 3},
-            {"rule_id": "r3", "value": "transcriptomic.bulk", "confidence": 0.90, "tier": 3},
+            {"rule_id": "r1", "value": "genomic", "tier": 1},
+            {"rule_id": "r2", "value": "genomic", "tier": 3},
+            {"rule_id": "r3", "value": "transcriptomic.bulk", "tier": 3},
         ])
         assert result["status"] == NOT_CLASSIFIED
         assert result["value"] is None
@@ -490,8 +473,8 @@ class TestEvaluateClaims:
     def test_not_classified_claims_ignored(self):
         """Claims declaring not_classified (status) don't assert a value."""
         result = evaluate_claims([
-            {"rule_id": "r1", "status": NOT_CLASSIFIED, "confidence": 0.0},
-            {"rule_id": "r2", "value": "genomic", "confidence": 0.90, "tier": 2},
+            {"rule_id": "r1", "status": NOT_CLASSIFIED},
+            {"rule_id": "r2", "value": "genomic", "tier": 2},
         ])
         assert result["value"] == "genomic"
         assert result["reason"] == "single_claim"
@@ -499,7 +482,7 @@ class TestEvaluateClaims:
     def test_not_applicable_status_declaration(self):
         """A not_applicable status claim resolves to status not_applicable, value None."""
         result = evaluate_claims([
-            {"rule_id": "r1", "status": NOT_APPLICABLE, "confidence": 1.0, "tier": 1},
+            {"rule_id": "r1", "status": NOT_APPLICABLE, "tier": 1},
         ])
         assert result["status"] == NOT_APPLICABLE
         assert result["value"] is None
@@ -508,8 +491,8 @@ class TestEvaluateClaims:
     def test_not_applicable_wins_over_real_value_same_tier(self):
         """NOT_APPLICABLE is a terminal declaration — wins without conflict."""
         result = evaluate_claims([
-            {"rule_id": "r1", "status": NOT_APPLICABLE, "confidence": 1.0, "tier": 1},
-            {"rule_id": "r2", "value": "genomic", "confidence": 0.90, "tier": 1},
+            {"rule_id": "r1", "status": NOT_APPLICABLE, "tier": 1},
+            {"rule_id": "r2", "value": "genomic", "tier": 1},
         ])
         assert result["status"] == NOT_APPLICABLE
         assert result["value"] is None
@@ -520,7 +503,7 @@ class TestEvaluateClaims:
         """A rule that intentionally declares not_classified is a real claim, not no_claims."""
         result = evaluate_claims([
             {"rule_id": "fastq_modality_unknown", "status": NOT_CLASSIFIED,
-             "confidence": 0.0, "tier": 3,
+             "tier": 3,
              "reason": "FASTQ modality cannot be determined from reads alone"},
         ])
         assert result["status"] == NOT_CLASSIFIED
@@ -533,9 +516,9 @@ class TestEvaluateClaims:
         """A rule's not_classified declaration shouldn't conflict with a real value claim."""
         result = evaluate_claims([
             {"rule_id": "fastq_modality_unknown", "status": NOT_CLASSIFIED,
-             "confidence": 0.0, "tier": 3},
+             "tier": 3},
             {"rule_id": "some_rule", "value": "genomic",
-             "confidence": 0.90, "tier": 3},
+             "tier": 3},
         ])
         assert result["value"] == "genomic"
         assert result["is_conflict"] is False
@@ -556,7 +539,7 @@ class TestAssayTypeInference:
     """Test that infer_assay_type records evidence correctly."""
 
     def test_inferred_assay_type_has_evidence(self, engine):
-        """Inferred assay_type should have evidence with confidence 0.70."""
+        """Inferred assay_type should have evidence from the infer_assay_type rule."""
         file_info = ExtendedFileInfo(
             filename="sample.bam", file_size=60_000_000_000,
             file_size_gb=60.0, file_format=".bam",
@@ -572,7 +555,6 @@ class TestAssayTypeInference:
         evidence = result.field_evidence["assay_type"]
         assert len(evidence) == 1
         assert evidence[0]["rule_id"] == "infer_assay_type"
-        assert evidence[0]["confidence"] == 0.70
 
     def test_inferred_assay_type_removes_not_classified_placeholder(self, engine):
         """Inference should remove stale not_classified placeholder evidence."""
@@ -586,9 +568,7 @@ class TestAssayTypeInference:
         result.set_field("assay_type", status=NOT_CLASSIFIED)
         result.field_evidence["assay_type"] = [{
             "rule_id": "not_classified",
-            "reason": "No rule determined a value for assay_type",
-            "confidence": 0.0,
-            "status": NOT_CLASSIFIED,
+            "reason": "No rule determined a value for assay_type",            "status": NOT_CLASSIFIED,
         }]
         engine.infer_assay_type(result, file_info)
         assert result.assay_type == "WGS"
@@ -688,7 +668,7 @@ class TestOutputDictStatus:
         for filename in ("sample_WGS_aligned.bam", "sample.fastq.gz", "plot.png"):
             out = engine.classify_extended(FileInfo(filename=filename)).to_output_dict()
             for fld in CLASSIFICATION_FIELDS:
-                assert set(out[fld]) == {"value", "status", "confidence", "evidence"}
+                assert set(out[fld]) == {"value", "status", "evidence"}
 
     def test_status_pins_each_sentinel_state(self, engine):
         # Stage 3 shape: a real value classifies (value kept); each sentinel lives


### PR DESCRIPTION
Closes #56.

## Why

`confidence` is an LLM-era artifact. In the deterministic rule engine the per-rule values (0.0–0.95) are **hand-authored constants**, never calibrated — a float masquerading as a probability, which cuts against the repo's "no speculation as fact" principle. It **never decided a classification value** (`tier` resolves disagreements; confidence only picked which agreeing claim's number surfaced), and the AnVIL Explorer / TDR does not consume or surface it. `tier` and `source_type` carry the honest "how strong / how did we know" signal; a derived high/low can be re-added later if a consumer asks (see #56 decision note — do not re-introduce authored floats).

## What

Full strip across all three levels:
- **Rules:** dropped `confidence:` from all 127 rules.
- **Loader/engine/models:** removed the field from `UnifiedRule`/`ValidatorConfig`/`ClassificationResult`/`ExtendedClassificationResult`, the running-max, and the `confidence=` param on `build_field_entry`. `evaluate_claims` no longer takes/emits confidence — the 5 `max(claims, key=confidence)` tiebreakers collapsed away because they only sourced a number and an already-known declaration (labels/values unchanged).
- **header_classifier + contig_lengths:** removed ~30 literals and the running-max; detector tuples are now `(assembly, count)`.
- **Scripts:** dropped confidence propagation in index inheritance and the high/med/low histogram in `run_batch_classification`.
- **Schema:** removed the `confidence` slot (Classification + Evidence); regenerated. Records now emit `{value, status, evidence}`; evidence is `{rule_id, reason, ...}`.

## BED reference override — resolved honestly

The one place confidence drove a *decision* was the BED reference override. Coordinate detection now returns a real assembly **or "can't tell" (None)**, and "can't tell" never overrides a filename. The old closest-match guesser (`_pick_closest_reference`) fabricated a reference when coordinates fit multiple assemblies — it's removed. Coordinate content beats a filename only when it actually determines a single surviving assembly. This mirrors what the BAM/VCF contig detector already does (returns None on a tie) and follows CLAUDE.md's "better to leave `not_classified` than guess wrong."

## Verification

Re-classified the full **~760K-file corpus** on cached headers and diffed effective labels vs the pre-change baseline:
- data_modality, data_type, assay_type, platform: **100% identical**.
- reference_assembly: **9 BED files** move from a fabricated closest-match guess to an honest `not_classified` (no filename reference + ambiguous coordinates, or a filename naming two assemblies). Spot-checked — all genuine "can't tell" cases; the CHM13-named files are correctly preserved as CHM13.

Golden diff is confidence-key removals only (no value/status drift). **452 root + 9 schema tests green**; `make gen` compiles; ruff clean. `/simplify` and `/code-review high` both clean (no correctness bugs).

## Follow-up (out of scope)

- `docs/classification_report.md` is stale on a broader front (predates #116 status split and #134 container — shows the old flat record shape); needs a dedicated refresh, not a confidence-only patch.
- Optional: consolidate the two coordinate rule-out paths (`_infer_bed_reference` / `detect_reference_from_max_positions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)