### PR TITLE
Model reference genome as assembly.reference in data_type (#143)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Meta-disco extracts and validates metadata from biological data files (BAM, CRAM, FASTQ, etc.) for the AnVIL Explorer and Terra Data Repository. It uses LLMs to infer `data_modality` (genomic/transcriptomic) and `reference_genome` (GRCh38/GRCh37/CHM13) from filenames and BAM/SAM headers.
+Meta-disco extracts and validates metadata from biological data files (BAM, CRAM, FASTQ, etc.) for the AnVIL Explorer and Terra Data Repository. It uses LLMs to infer `data_modality` (genomic/transcriptomic) and `reference_assembly` (GRCh38/GRCh37/CHM13) from filenames and BAM/SAM headers.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Meta-disco extracts and validates metadata from biological data files (BAM, CRAM, FASTQ, etc.) for the AnVIL Explorer and Terra Data Repository. It uses LLMs to infer `data_modality` (genomic/transcriptomic) and `reference_assembly` (GRCh38/GRCh37/CHM13) from filenames and BAM/SAM headers.
+Meta-disco extracts and validates metadata from biological data files (BAM, CRAM, FASTQ, etc.) for the AnVIL Explorer and Terra Data Repository. It uses LLMs to infer `data_modality` (genomic/transcriptomic) and `reference_genome` (GRCh38/GRCh37/CHM13) from filenames and BAM/SAM headers.
 
 ## Architecture
 

--- a/docs/classification-hierarchy.md
+++ b/docs/classification-hierarchy.md
@@ -98,7 +98,7 @@ file_format (extension)
 
 ## Sequences (.fasta, .fasta.gz, .fa, .fa.gz)
 
-**data_type**: `sequence`, `assembly`, `reference_genome`
+**data_type**: `sequence`, `assembly`, `assembly.reference`
 
 **data_modality**:
 - `genomic` ← filename (assembly keywords, haplotype keywords), contig names (assembler patterns)

--- a/schema/src/meta_disco/schema/classification.yaml
+++ b/schema/src/meta_disco/schema/classification.yaml
@@ -258,7 +258,7 @@ enums:
       reads:
       sequence:
       assembly:
-      "assembly.reference":   # a published reference genome (GRCh38/CHM13); de-novo stays `assembly`
+      "assembly.reference":   # a published reference genome (e.g. GRCh38/CHM13); de-novo stays `assembly`
       variants:
       "variants.germline":
       "variants.somatic":

--- a/schema/src/meta_disco/schema/classification.yaml
+++ b/schema/src/meta_disco/schema/classification.yaml
@@ -258,6 +258,7 @@ enums:
       reads:
       sequence:
       assembly:
+      "assembly.reference":   # a published reference genome (GRCh38/CHM13); de-novo stays `assembly`
       variants:
       "variants.germline":
       "variants.somatic":

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -434,7 +434,7 @@ def classify_from_fasta_header(
                 best_ref = None
 
             result.set_field("data_modality", "genomic")
-            result.set_field("data_type", "reference_genome")
+            result.set_field("data_type", "assembly.reference")
             ref_entry = {
                 "rule_id": "fasta_reference_contigs",
                 "reason": f"Matched {best_count} contigs to reference chromosomes"
@@ -455,7 +455,7 @@ def classify_from_fasta_header(
             result.field_evidence["data_type"] = [{
                 "rule_id": "fasta_reference_contigs",
                 "reason": "FASTA contains reference genome sequences",
-                "value": "reference_genome",
+                "value": "assembly.reference",
             }]
             return result.to_output_dict()
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -453,7 +453,7 @@ class TestFastaE2E:
         assert result is not None
         assert_output_format(result)
         assert get_val(result, "data_modality") == "genomic"
-        assert get_val(result, "data_type") == "reference_genome"
+        assert get_val(result, "data_type") == "assembly.reference"
         assert get_val(result, "reference_assembly") == "GRCh38"
         assert field_status(result, "assay_type") == NOT_APPLICABLE
 
@@ -465,7 +465,7 @@ class TestFastaE2E:
         assert result is not None
         assert_output_format(result)
         assert get_val(result, "data_modality") == "genomic"
-        assert get_val(result, "data_type") == "reference_genome"
+        assert get_val(result, "data_type") == "assembly.reference"
         assert get_val(result, "reference_assembly") == "CHM13"
         assert field_status(result, "assay_type") == NOT_APPLICABLE
 


### PR DESCRIPTION
Closes #143.

## Why

The FASTA classifier emitted `data_type: "reference_genome"`, but that value was **not in the schema's `data_type_enum`** — the last gap left by #33's "cover all dimensions." It went uncaught because the rule-drift check only validates rule-authored values (this one is hardcoded in `header_classifier.py`) and the whole-record gate's golden FASTA case is the de-novo `assembly` path.

## What

A reference genome is a kind of assembly (GRCh38/CHM13 are published assemblies), so it's modeled hierarchically per the existing `variants.*` pattern rather than as a sibling:

- `assembly` — de-novo assembly (unchanged; `reference_assembly: not_applicable`)
- `assembly.reference` — a published reference genome (`reference_assembly` = GRCh38/CHM13, or `not_classified` when the contigs match a reference set but can't be pinned to one assembly — a signal `reference_assembly` alone doesn't carry)

Changes: add `assembly.reference` to `data_type_enum` (regenerated artifacts); the two FASTA reference-path emissions in `header_classifier.py` now use it; the two `test_evals.py` assertions updated.

## Verification

- Golden unchanged (its FASTA case is the de-novo path).
- 452 root + 9 schema tests green; `make gen` compiles; ruff clean on changed files.
- Full-corpus re-run vs the prior run: **exactly 2 records** relabel `reference_genome` → `assembly.reference` (the 2 complete reference-genome FASTAs in the catalog); **all other dimensions and records 100% identical**.
- Verified the value is spelled identically across schema/producer/tests and that `schema_vocab.dimension_values("data_type")` now includes it.

## Out of scope

Pangenome graphs (GFA/GBZ/rGFA — a distinct content type, not linear assembly) → tracked in #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)