### PR TITLE
Classify pangenome graphs: new data_type pangenome / pangenome.reference (#144)

### DIFF
--- a/docs/classification-hierarchy.md
+++ b/docs/classification-hierarchy.md
@@ -116,6 +116,24 @@ file_format (extension)
 
 ---
 
+## Pangenome Graphs (.gfa, .gfa.gz, .rgfa, .rgfa.gz, .gbz, .vg, .gbwt, .xg)
+
+**data_type**: `pangenome`, `pangenome.reference`
+
+`data_type` describes structure: linear sequence is `assembly` (FASTA), a sequence graph (nodes/edges/haplotype paths) is `pangenome`. The reference-graph case — an HPRC minigraph-cactus (`mc`) graph used as the alignment coordinate system — refines to `pangenome.reference`. PGGB and single-sample assembly graphs stay `pangenome`.
+
+**data_modality**: `genomic` ← extension (all graph formats)
+
+**assay_type**: `not_applicable`
+
+**platform**: `not_applicable` (a graph is an assembled product, not raw reads)
+
+**reference_assembly**: `GRCh38/GRCh37/CHM13` ← filename (shared `filename_ref_*` rules; e.g. an `mc-grch38` graph's coordinate system)
+
+**Coverage**: Extension-driven, so all listed formats classify. `pangenome.reference` detection keys on the `-mc-` filename token. Auxiliary vg indices (`.min`, `.dist`, `.snarls`, `.gg`) are out of scope (issue #144).
+
+---
+
 ## Intervals/Peaks (.bed, .bed.gz, .narrowPeak, .broadPeak)
 
 **data_type**: `annotations`, `peaks`

--- a/docs/classification-hierarchy.md
+++ b/docs/classification-hierarchy.md
@@ -120,7 +120,7 @@ file_format (extension)
 
 **data_type**: `pangenome`, `pangenome.reference`
 
-`data_type` describes structure: linear sequence is `assembly` (FASTA), a sequence graph (nodes/edges/haplotype paths) is `pangenome`. The reference-graph case — an HPRC minigraph-cactus (`mc`) graph used as the alignment coordinate system — refines to `pangenome.reference`. PGGB and single-sample assembly graphs stay `pangenome`.
+`data_type` describes structure: linear sequence (FASTA — `sequence`, refining to `assembly`/`assembly.reference`) versus a sequence graph (nodes/edges/haplotype paths), which is `pangenome`. The reference-graph case — an HPRC minigraph-cactus (`mc`) graph used as the alignment coordinate system — refines to `pangenome.reference`. PGGB and single-sample assembly graphs stay `pangenome`.
 
 **data_modality**: `genomic` ← extension (all graph formats)
 

--- a/rules/unified_rules.yaml
+++ b/rules/unified_rules.yaml
@@ -214,6 +214,16 @@ extension_map:
   ".fasta.gz": sequence
   ".fa.gz": sequence
 
+  # Pangenome / sequence graphs (GFA/rGFA/GBZ/vg + graph indices)
+  ".gfa": pangenome
+  ".gfa.gz": pangenome
+  ".rgfa": pangenome
+  ".rgfa.gz": pangenome
+  ".gbz": pangenome
+  ".vg": pangenome
+  ".gbwt": pangenome
+  ".xg": pangenome
+
   # Archives (need special handling)
   ".tar": archive
   ".tar.gz": archive
@@ -466,6 +476,27 @@ rules:
         assay_type: not_applicable
     rationale: "FASTA file detected; header inspection needed to determine if de novo assembly, reference genome, or transcript sequences"
 
+  # ---------------------------------------------------------------------------
+  # Pangenome / sequence graphs (GFA, rGFA, GBZ, vg, GBWT, xg)
+  # ---------------------------------------------------------------------------
+  # data_type describes structure: linear sequence is `assembly` (FASTA), a
+  # sequence graph is `pangenome`. The reference-graph case (HPRC
+  # minigraph-cactus, used as the alignment coordinate system) refines to
+  # `pangenome.reference` via a tier-2 filename rule below. reference_assembly is
+  # left to the shared filename_ref_* rules (an mc graph's grch38/chm13 token).
+  - id: pangenome_graph
+    tier: 1
+    scope: extension
+    when:
+      extensions: [".gfa", ".gfa.gz", ".rgfa", ".rgfa.gz", ".gbz", ".vg", ".gbwt", ".xg"]
+    then:
+      data_modality: genomic
+      data_type: pangenome
+      status:
+        platform: not_applicable
+        assay_type: not_applicable
+    rationale: "Sequence-graph formats (GFA/rGFA/GBZ/vg/GBWT/xg) encode a pangenome graph — a genomic assembly product, so no sequencing platform or assay applies"
+
   # ===========================================================================
   # TIER 2: FILENAME-BASED RULES
   # ===========================================================================
@@ -578,6 +609,25 @@ rules:
       data_type: alignments
       assay_type: RNA-seq
     rationale: "STAR aligner output indicates RNA-seq"
+
+  # ---------------------------------------------------------------------------
+  # Pangenome reference graphs (minigraph-cactus)
+  # ---------------------------------------------------------------------------
+  # HPRC minigraph-cactus (`mc`) graphs are the published pangenome references
+  # used as the coordinate system for graph alignment (e.g. vg Giraffe), so they
+  # refine the tier-1 `pangenome` base to `pangenome.reference`. Scoped to graph
+  # extensions so the `-mc-` token can't match unrelated files. PGGB and
+  # single-sample assembly graphs stay `pangenome` (not alignment references).
+  - id: pangenome_reference_mc
+    tier: 2
+    scope: filename
+    when:
+      extensions: [".gfa", ".gfa.gz", ".rgfa", ".rgfa.gz", ".gbz", ".vg", ".gbwt", ".xg"]
+      filename_pattern: "(?i)-mc-"
+    then:
+      data_modality: genomic
+      data_type: pangenome.reference
+    rationale: "Minigraph-Cactus (mc) HPRC graphs are published pangenome references used as the alignment coordinate system"
 
   # ---------------------------------------------------------------------------
   # Reference assembly in filename

--- a/rules/unified_rules.yaml
+++ b/rules/unified_rules.yaml
@@ -479,8 +479,9 @@ rules:
   # ---------------------------------------------------------------------------
   # Pangenome / sequence graphs (GFA, rGFA, GBZ, vg, GBWT, xg)
   # ---------------------------------------------------------------------------
-  # data_type describes structure: linear sequence is `assembly` (FASTA), a
-  # sequence graph is `pangenome`. The reference-graph case (HPRC
+  # data_type describes structure: linear sequence is FASTA (`sequence`,
+  # refining to `assembly`/`assembly.reference`); a sequence graph is
+  # `pangenome`. The reference-graph case (HPRC
   # minigraph-cactus, used as the alignment coordinate system) refines to
   # `pangenome.reference` via a tier-2 filename rule below. reference_assembly is
   # left to the shared filename_ref_* rules (an mc graph's grch38/chm13 token).

--- a/schema/src/meta_disco/schema/classification.yaml
+++ b/schema/src/meta_disco/schema/classification.yaml
@@ -259,6 +259,8 @@ enums:
       sequence:
       assembly:
       "assembly.reference":   # a published reference genome (e.g. GRCh38/CHM13); de-novo stays `assembly`
+      pangenome:              # a sequence graph (GFA/rGFA/GBZ/vg/GBWT/xg); linear sequence stays `assembly`
+      "pangenome.reference":  # a graph used as an alignment reference (e.g. HPRC minigraph-cactus)
       variants:
       "variants.germline":
       "variants.somatic":

--- a/schema/src/meta_disco/schema/classification.yaml
+++ b/schema/src/meta_disco/schema/classification.yaml
@@ -259,7 +259,7 @@ enums:
       sequence:
       assembly:
       "assembly.reference":   # a published reference genome (e.g. GRCh38/CHM13); de-novo stays `assembly`
-      pangenome:              # a sequence graph (GFA/rGFA/GBZ/vg/GBWT/xg); linear sequence stays `assembly`
+      pangenome:              # a sequence graph (GFA/rGFA/GBZ/vg/GBWT/xg); linear sequence is FASTA (`sequence`/`assembly`)
       "pangenome.reference":  # a graph used as an alignment reference (e.g. HPRC minigraph-cactus)
       variants:
       "variants.germline":

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -85,6 +85,8 @@ class UnifiedRules:
         ".fa.gz",
         ".bed.gz",
         ".sam.gz",
+        ".rgfa.gz",
+        ".gfa.gz",
         ".fast5.tar.gz",  # Must come before .tar.gz
         ".fast5.tar",     # Must come before .tar
         ".tar.gz",

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -403,6 +403,56 @@ class TestRuleEngineE2E:
 
 
 # =============================================================================
+# Pangenome / sequence graphs (issue #144) — rule engine from filename only
+# =============================================================================
+
+class TestPangenomeGraphs:
+    """Sequence-graph formats classify as data_type `pangenome`; HPRC
+    minigraph-cactus reference graphs refine to `pangenome.reference`."""
+
+    def test_gfa_assembly_graph_is_pangenome(self):
+        """A single-sample assembly graph (.gfa) is still a sequence graph."""
+        result = engine.classify_extended(
+            FileInfo(filename="HG002-full-0.14.1.hap1.p_ctg.gfa")
+        )
+        assert result.data_modality == "genomic"
+        assert result.data_type == "pangenome"
+        assert result.status_of("platform") == NOT_APPLICABLE
+        assert result.status_of("assay_type") == NOT_APPLICABLE
+
+    def test_pggb_gfa_gz_is_pangenome(self):
+        """PGGB pangenome graph (.gfa.gz compound extension) — not an mc reference."""
+        result = engine.classify_extended(
+            FileInfo(filename="chr1.hprc-v1.0-pggb.gfa.gz")
+        )
+        assert result.data_modality == "genomic"
+        assert result.data_type == "pangenome"
+
+    def test_vg_and_xg_are_pangenome(self):
+        for name in ("sample.vg", "graph.xg"):
+            result = engine.classify_extended(FileInfo(filename=name))
+            assert result.data_type == "pangenome", name
+            assert result.data_modality == "genomic", name
+
+    def test_mc_gbz_is_pangenome_reference(self):
+        """HPRC minigraph-cactus GBZ — the published alignment reference graph."""
+        result = engine.classify_extended(
+            FileInfo(filename="hprc-v1.0-mc-grch38.gbz")
+        )
+        assert result.data_modality == "genomic"
+        assert result.data_type == "pangenome.reference"
+        # reference_assembly comes from the shared filename_ref_* rules
+        assert result.reference_assembly == "GRCh38"
+
+    def test_mc_gbwt_chm13_is_pangenome_reference(self):
+        result = engine.classify_extended(
+            FileInfo(filename="hprc-v1.0-mc-chm13.gbwt")
+        )
+        assert result.data_type == "pangenome.reference"
+        assert result.reference_assembly == "CHM13"
+
+
+# =============================================================================
 # FASTA — end-to-end through classify_fasta_files.classify_single_fasta
 # =============================================================================
 


### PR DESCRIPTION
Closes #144.

## Problem

Sequence-graph files (GFA, rGFA, GBZ, `.vg`, `.gbwt`, `.xg`) were unclassified. The #136 validation flagged the HPRC `hprc-v1.0-mc-*` minigraph-cactus graphs as its only ground-truth misses, and 598 `.gfa` + assorted graph files sit in the AnVIL corpus.

## Model

`data_type` describes structure: linear sequence is `assembly` (FASTA); a sequence graph (nodes/edges/haplotype paths) is a distinct content type, `pangenome`. Modeled hierarchically like `assembly`/`assembly.reference` (#143) and `variants.*`:

- `pangenome` — a sequence graph.
- `pangenome.reference` — a graph used as an alignment reference (HPRC minigraph-cactus, the coordinate system for vg Giraffe).

A single-sample assembly graph (e.g. hifiasm `p_ctg.gfa`) is still a sequence graph → `pangenome`. PGGB graphs stay `pangenome` (not alignment references).

## Changes

- **Schema**: add `pangenome`, `pangenome.reference` to `data_type_enum`.
- **Rules** (`unified_rules.yaml`): extension_map + tier-1 `pangenome_graph` (8 graph extensions → `data_modality: genomic`, `data_type: pangenome`, `platform`/`assay_type` `not_applicable`, mirroring `fasta_base`); tier-2 `pangenome_reference_mc` refines to `pangenome.reference` on the `-mc-` filename token, scoped to graph extensions so it can't match unrelated files.
- **`COMPOUND_EXTENSIONS`**: add `.gfa.gz` / `.rgfa.gz` so compound graph extensions resolve (also flows to `generate_coverage_report` via reuse of the shared list).
- `reference_assembly` for mc graphs comes from the existing shared `filename_ref_*` rules (the `mc-grch38`/`mc-chm13` token) — no new logic.
- Tests (`TestPangenomeGraphs`) + `classification-hierarchy.md` doc section.

## Validation

Real corpus filenames classify as expected:

| filename | data_type | reference_assembly |
|---|---|---|
| `hprc-v1.0-mc-grch38.gbz` | `pangenome.reference` | GRCh38 |
| `hprc-v1.0-mc-chm13.gbwt` | `pangenome.reference` | CHM13 |
| `chr1.hprc-v1.0-pggb.gfa.gz` | `pangenome` | — |
| `HG002-full-0.14.1.hap1.p_ctg.gfa` | `pangenome` | — |

457 root + 9 schema tests green; ruff clean; `/simplify` clean (reuse, simplification, efficiency, altitude all consistent with existing patterns).

Refs: #136 (HPRC graph misses), #143 (assembly.reference), #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)