### PR TITLE
Remove the dead classification_rules.yaml legacy redirect (#169)

### DIFF
--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -313,15 +313,7 @@ class RuleEngine:
         Args:
             rules_path: Path to unified rules YAML. Defaults to the bundled
                        unified_rules.yaml (package data of meta_disco.rules).
-                       Legacy paths to classification_rules.yaml are automatically
-                       redirected to unified_rules.yaml.
         """
-        # Handle legacy path for backward compatibility
-        if rules_path is not None:
-            rules_path = Path(rules_path)
-            if rules_path.name == "classification_rules.yaml":
-                rules_path = rules_path.parent / "unified_rules.yaml"
-
         self.rules = get_unified_rules(rules_path)
 
     def classify(

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -685,17 +685,3 @@ class TestOutputDictStatus:
         n_c = engine.classify_extended(
             ExtendedFileInfo(filename="sample.bam", file_size_gb=60.0)).to_output_dict()["data_modality"]
         assert (n_c["value"], n_c["status"]) == (None, NOT_CLASSIFIED)
-
-
-class TestRulesPathHandling:
-    """RuleEngine treats an explicit rules_path literally (no legacy redirect)."""
-
-    def test_legacy_filename_is_not_special_cased(self, tmp_path):
-        # The classification_rules.yaml -> unified_rules.yaml redirect was removed
-        # in #169. That name now behaves like any other explicit path: a missing
-        # file raises FileNotFoundError naming that exact path, rather than being
-        # silently rerouted to a sibling unified_rules.yaml.
-        legacy = tmp_path / "classification_rules.yaml"
-        with pytest.raises(FileNotFoundError) as exc:
-            RuleEngine(legacy)
-        assert str(legacy) in str(exc.value)

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -685,3 +685,17 @@ class TestOutputDictStatus:
         n_c = engine.classify_extended(
             ExtendedFileInfo(filename="sample.bam", file_size_gb=60.0)).to_output_dict()["data_modality"]
         assert (n_c["value"], n_c["status"]) == (None, NOT_CLASSIFIED)
+
+
+class TestRulesPathHandling:
+    """RuleEngine treats an explicit rules_path literally (no legacy redirect)."""
+
+    def test_legacy_filename_is_not_special_cased(self, tmp_path):
+        # The classification_rules.yaml -> unified_rules.yaml redirect was removed
+        # in #169. That name now behaves like any other explicit path: a missing
+        # file raises FileNotFoundError naming that exact path, rather than being
+        # silently rerouted to a sibling unified_rules.yaml.
+        legacy = tmp_path / "classification_rules.yaml"
+        with pytest.raises(FileNotFoundError) as exc:
+            RuleEngine(legacy)
+        assert str(legacy) in str(exc.value)


### PR DESCRIPTION
## Summary

Closes #169. Removes a dead backward-compat shim in `RuleEngine.__init__`.

The shim rewrote an explicit `rules_path` whose name was `classification_rules.yaml` to a **sibling** `unified_rules.yaml`:

```python
if rules_path is not None:
    rules_path = Path(rules_path)
    if rules_path.name == "classification_rules.yaml":
        rules_path = rules_path.parent / "unified_rules.yaml"
```

It's obsolete:
- `classification_rules.yaml` was this project's own rules file, **deleted in the same migration commit** (`d95da0e`) that added this shim; it was renamed/consolidated into `unified_rules.yaml`.
- The sibling-path rewrite only worked when both files lived in repo-root `rules/`. Since #166 moved the rules into package data, the sibling doesn't exist, so the shim **dead-ended on `FileNotFoundError`** — it's been broken since #166 with no one noticing.
- **No in-repo caller** passes that name (surfaced by the #168 code review).

## Changes

- Delete the redirect block and its docstring lines; `__init__` now delegates straight to `get_unified_rules(rules_path)`.
- Add `test_legacy_filename_is_not_special_cased`: a missing `.../classification_rules.yaml` now raises `FileNotFoundError` naming that exact path, rather than being silently rerouted to a sibling — a regression guard against re-adding the shim.
- Leave the historical `CONSOLIDATED FROM` provenance note in `unified_rules.yaml` intact (it records lineage, not a live path).

## Verification

508 tests pass, lint clean, `/simplify` run (dropped one redundant smoke test on review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)