### PR TITLE
Adopt team Claude Code standards from cc-claude-tools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "extraKnownMarketplaces": {
+    "cc-claude-tools": {
+      "source": {
+        "source": "github",
+        "repo": "clevercanary/cc-claude-tools"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "cc@cc-claude-tools": true,
+    "pyright-lsp@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ output/
 # Literal $TMPDIR dir, created when a script writes to an unexpanded "$TMPDIR"
 ${TMPDIR}/
 $TMPDIR/
+
+# Claude Code personal overrides — never shared
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,18 +71,75 @@ evidence}` entry — plus the controlled vocabulary:
 - **Accuracy over coverage**: It is better to leave a file as `not_classified` than to guess wrong. Only classify when evidence supports it.
 - **No speculation as fact**: Never confidently assert something unless you actually know it. If inferring or guessing, say "I think" or "it could be". This applies to root cause analysis, data interpretation, and codebase history.
 
+## Team roster
+
+| Name   | GitHub handle |
+|--------|---------------|
+| Dave   | NoopDog       |
+| Fran   | frano-m       |
+| Hunter | hunterckx     |
+| Mim    | MillenniumFalconMechanic |
+
+"Assign to Fran" always means the GitHub handle in this table. Never guess a
+handle. If someone is not in this table, ask.
+
+## Error handling philosophy
+
+Validate at trust boundaries only, and trust everything inside them.
+
+- The trust boundaries are: user input, network responses, file contents,
+  environment variables, CLI arguments, and data crossing a public API.
+  Validate at the boundary, once, and fail with a clear error that names
+  what was wrong.
+- Inside the boundary, where our functions call our functions, do not check
+  for null, missing, or wrong-typed values. A caller passing bad input is a
+  bug in the caller, so let the code throw. A stack trace at the real call
+  site is what enables the fix. A defensive fallback hides the bug.
+- Never silently coerce, default, or catch-and-continue to "handle" bad
+  input, and never rewrite a caller's input for backward compatibility. The
+  removal of the `classification_rules.yaml` legacy redirect (#169, #170)
+  is the model: update callers or fail loudly, do not add a silent shim.
+- When a reviewer suggests defensive handling of internal inputs, decline
+  and cite this section.
+
 ## Workflow
 
-1. Create a GitHub issue for every change
-2. Create a feature branch `noopdog/{issue#}-short-description`
-3. Implement with tests, run `make test` before committing
-4. **Run /simplify before pushing** — catches reuse, quality, and efficiency issues early
-5. Push and create a PR
-6. Check Copilot review feedback via GraphQL — **you are always authorized to fetch and resolve CP threads without asking**
-7. **Scan for same class of error** — for each CP comment, search the codebase for other instances of the same pattern in files not in the diff
-8. **Summarize CP feedback for the user first** — present each comment with analysis, recommendation, and any additional instances found. Do not fix automatically.
-9. After approval, fix issues (including same-class instances), push, and resolve threads via GraphQL
-10. Repeat until Copilot passes clean
+1. Create a GitHub issue for every change, with a definition-of-done
+   checklist. The issue is the record the result is checked against.
+2. Create a feature branch `noopdog/{issue#}-short-description`.
+3. Implement with tests. Run `make test-all` before committing (the schema
+   suite does not run under plain `make test`).
+4. When the code is complete, announce it and run `/cc:auto-review`. That
+   skill runs the local reviews, has you triage the findings, stops at a
+   push gate, opens the PR, and drives the Copilot feedback rounds to
+   merge-ready. It is the canonical definition of the review and PR cycle;
+   do not hand-run those steps here.
+
+A human reads the PR against the issue's definition of done and merges it.
+Claude never merges.
+
+## Surprises
+
+You may encounter an environment, tool, dependency, or constraint that the
+user never mentioned and that changes your approach. Examples: an unexpected
+conda environment, a missing credential, a second uv project. When that
+happens, STOP and ask before proceeding. Do not work around the surprise
+silently.
+
+## Communication
+
+- Do not use analogies or metaphors.
+- Lead with the outcome in one sentence.
+- Keep status updates to one line.
+- Flag your assumptions explicitly.
+
+## GitHub API discipline
+
+- Never enumerate a full project board, and never paginate more than two
+  pages to find one item.
+- Never fetch issues or pull requests in a loop. Use a single search or
+  list call with filters instead.
+- If you get a rate-limit response, STOP and tell the user. Do not retry.
 
 ## Git Discipline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,10 +107,10 @@ Validate at trust boundaries only, and trust everything inside them.
 1. Create a GitHub issue for every change, with a definition-of-done
    checklist. The issue is the record the result is checked against.
 2. Create a feature branch `noopdog/{issue#}-short-description`.
-3. Implement with tests. Run `make test-all` before committing. It is the
-   root-level aggregator that runs both the root suite and the schema
-   suite. Plain `make test` runs the root suite only, so it is not
-   sufficient before pushing.
+3. Implement with tests. Run `make test-all` from the repo root before
+   committing. It is the root-level aggregator that runs both the root
+   suite and the schema suite. Plain `make test` runs the root suite only,
+   so it is not sufficient before pushing.
 4. When the code is complete, announce it and run `/cc:auto-review`. That
    skill runs the local reviews, has you triage the findings, stops at a
    push gate, opens the PR, and drives the Copilot feedback rounds to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,8 +143,17 @@ silently.
 
 ## Git Discipline
 
-- **Never amend commits** — use separate commits for each fix round. Amending rewrites history and requires force pushes, which loses review context.
-- **Never force push** — each push should add commits, not rewrite them.
+- **Never amend commits.** Use a separate commit for each fix round.
+  Amending rewrites commits a reviewer already read, which loses the
+  review context. This is the behavior to avoid; adding commits is how
+  review history stays intact.
+- **Never force push `main`.**
+- **On a feature branch, prefer adding commits over force pushing**, so
+  review history is preserved. Force pushing is allowed only for the
+  structural rebase a stacked pull request needs: when the branch it was
+  based on merges, rebase onto the new `main` and push with
+  `--force-with-lease`. This moves the branch onto a new base; it does not
+  rewrite reviewed commits, which is why it is fine and amending is not.
 
 ## Code Change Discipline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Validate at trust boundaries only, and trust everything inside them.
 ## Workflow
 
 1. Create a GitHub issue for every change, with a definition-of-done
-   checklist. The issue is the record the result is checked against.
+   checklist. The issue is the record that the result is checked against.
 2. Create a feature branch `noopdog/{issue#}-short-description`.
 3. Implement with tests. Run `make test-all` from the repo root before
    committing. It is the root-level aggregator that runs both the root

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,10 @@ Validate at trust boundaries only, and trust everything inside them.
 1. Create a GitHub issue for every change, with a definition-of-done
    checklist. The issue is the record the result is checked against.
 2. Create a feature branch `noopdog/{issue#}-short-description`.
-3. Implement with tests. Run `make test-all` before committing (the schema
-   suite does not run under plain `make test`).
+3. Implement with tests. Run `make test-all` before committing. It is the
+   root-level aggregator that runs both the root suite and the schema
+   suite. Plain `make test` runs the root suite only, so it is not
+   sufficient before pushing.
 4. When the code is complete, announce it and run `/cc:auto-review`. That
    skill runs the local reviews, has you triage the findings, stops at a
    push gate, opens the PR, and drives the Copilot feedback rounds to
@@ -152,8 +154,11 @@ silently.
   review history is preserved. Force pushing is allowed only for the
   structural rebase a stacked pull request needs: when the branch it was
   based on merges, rebase onto the new `main` and push with
-  `--force-with-lease`. This moves the branch onto a new base; it does not
-  rewrite reviewed commits, which is why it is fine and amending is not.
+  `--force-with-lease`. A rebase does rewrite commit SHAs, so re-request
+  review afterward if the branch was already reviewed. The reason it is
+  allowed and amending is not: it replays the same reviewed changes onto a
+  new base, rather than altering the content of a commit that is under
+  review.
 
 ## Code Change Discipline
 


### PR DESCRIPTION
Closes #173

## What changed
- **CLAUDE.md** gains the shared team sections it lacked: team roster, error handling philosophy, surprises rule, communication, and GitHub API discipline. The error-handling section cites this repo's own #169/#170 (removal of the `classification_rules.yaml` legacy redirect) as its worked example. All existing meta-disco content (Design Principles, Docstring & Comment Accuracy, Code Change Discipline, the two-uv-project notes) is preserved.
- **Workflow** section now defers the review and PR cycle to `/cc:auto-review` instead of hand-listing the steps, since the skill is now the canonical definition. Steps 1-3 (issue, branch, tests) are kept, and `make test` was corrected to `make test-all` per the schema-suite note.
- **Git Discipline** reconciled with stacked PRs: amends stay banned (they rewrite reviewed history), `main` force-push is banned, and feature-branch `--force-with-lease` is allowed only for the structural stacked-PR rebase.
- **.claude/settings.json** (new, checked in) enables `cc@cc-claude-tools` and `pyright-lsp`, so teammates are prompted to install both when they open the repo. TypeScript LSP is omitted because this repo is Python. `settings.local.json` stays gitignored as the personal opt-out.

## Why
Seed the shared team standards here ahead of the refactor that will pilot `/cc:auto-review` in this repo, so the refactor runs on an already-configured repo.

## Assumptions I made
- Dropped typescript-lsp (Python-only repo).
- The force-push resolution follows Dave's decision: support stacked PRs, ban amends and main force-push, discourage-but-allow on feature branches.
- The existing "you are always authorized to fetch and resolve CP threads without asking" latitude is now covered by the auto-review skill's reply-and-resolve step.

## How to verify
- [ ] CLAUDE.md reads coherently top to bottom; no existing section was dropped
- [ ] Git Discipline no longer contradicts the stacked-PR rebase in /cc:auto-review
- [ ] Open a fresh Claude Code session in this repo after merge and confirm the prompt to install cc + pyright-lsp
- [ ] `.claude/settings.local.json` remains gitignored

## Repo-settings actions (cannot ride in this PR)
- [ ] @NoopDog: enable Copilot review-on-push
- [ ] @NoopDog: confirm branch protection requires PRs on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)