### PR TITLE
Adopt shared Ruff rule set with a burn-down ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,14 +38,37 @@ line-length = 120
 extend-exclude = ["src/meta_disco/schema/metadata_model.py"]
 
 [tool.ruff.lint]
+# Shared Clever Canary rule set (cc-claude-tools templates/pyproject.ruff.template.toml).
 select = [
-    "F",     # pyflakes (unused imports, undefined names, etc.)
-    "E",     # pycodestyle errors
-    "W",     # pycodestyle warnings
-    "I",     # isort (import ordering)
+    "E", "W",   # pycodestyle
+    "F",        # pyflakes: unused imports and variables, undefined names
+    "I",        # isort: import ordering
+    "UP",       # pyupgrade: modern syntax for the target version
+    "B",        # flake8-bugbear: real bug patterns
+    "SIM",      # flake8-simplify
+    "C4",       # flake8-comprehensions
+    "PIE",      # flake8-pie
+    "RET",      # flake8-return
+    "PTH",      # flake8-use-pathlib
+    "RUF",      # Ruff's own rules
 ]
 ignore = [
-    "E501",  # line too long (we use line-length=120 but don't enforce strictly)
+    "E501",  # line length: the formatter targets 120 best-effort, not hard-capped
+    # Formatter-incompatible rules; the formatter is the single authority on layout.
+    "E111", "E114", "E117", "W191",
+    # --- Burn-down list: rules turned on but not yet cleaned up. Each has an
+    #     open issue; remove the codes as each issue lands. Every OTHER rule in
+    #     these families is already live and protects new code. Fixes are made
+    #     in the burn-down PRs, with tests, not by a blanket `ruff --fix` here:
+    #     several of these autofixes change behavior or strip re-export noqas. ---
+    "PTH123",                                          # pathlib migration (#176)
+    "B904", "B905", "RUF012", "RUF013",                # correctness (#177)
+    # readability (#178)
+    "SIM102", "SIM108", "SIM115", "SIM118", "SIM300",
+    "RET501", "RET504", "RET505", "RET508",
+    "PIE810", "C416", "C420", "B007",
+    "UP024", "UP033", "UP035",
+    "RUF015", "RUF022", "RUF043", "RUF059", "RUF100",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,9 @@ select = [
     "RUF",      # Ruff's own rules
 ]
 ignore = [
-    "E501",  # line length: the formatter targets 120 best-effort, not hard-capped
-    # Formatter-incompatible rules; the formatter is the single authority on layout.
+    "E501",  # line length: not hard-capped; the formatter (arrives in #181) targets 120 best-effort
+    # Rules that conflict with the ruff formatter (arrives in #181), ignored
+    # now so they never fight the formatter once it is the layout authority.
     "E111", "E114", "E117", "W191",
     # --- Burn-down list: rules turned on but not yet cleaned up. Each has an
     #     open issue; remove the codes as each issue lands. Every OTHER rule in


### PR DESCRIPTION
Closes #175

## What changed
Widened `[tool.ruff.lint].select` in pyproject.toml to the shared Clever Canary rule set (adds UP, B, SIM, C4, PIE, RET, PTH, RUF to the existing E/W/F/I) plus the formatter-incompatible ignores (E111/E114/E117/W191). The 152 existing violations are parked in a **burn-down ignore list**, each code tagged with its cleanup issue. Pure config: no source files change.

## Why
Adopt the mechanical enforcement floor from cc-claude-tools. The burn-down approach means `make lint` is green today, every un-violated rule in each family already protects new code, and the existing debt is cleaned up in reviewable themed PRs (#176 pathlib, #177 correctness, #178 readability).

## Assumptions I made
- **No `ruff --fix` in this PR, deliberately.** The autofixes broke things in testing: a partial-select `--fix` made RUF100 strip a `# noqa: F401 — re-exported for backward compat` and F401 then deleted the re-exports `infer_illumina_instrument_model` / `parse_ont_read_name` (broke test_header_classifier on import); another "safe" fix changed FASTA classification control flow (broke 14 evals). So fixes happen in the burn-down PRs, with tests.
- line-length stays 120 (repo override of the template's 100).
- ruff format is deferred to #181 (a ~50-file one-time reformat deserves its own PR).
- Actions CI is deferred to #180 (this repo has none; enforcement is `make lint` for now).

## How to verify
- [ ] `make lint` is green
- [ ] `make test-all` is green (run in a checkout that has the gitignored output/ cache — a fresh git worktree lacks it, so its FASTA evals fail independent of this change)
- [ ] pyproject select includes UP, B, SIM, C4, PIE, RET, PTH, RUF; ignore list carries the burn-down codes tagged with #176-178
- [ ] No source files are modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)