### PR TITLE
Migrate open() to pathlib and enforce PTH (#176)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ ignore = [
     #     these families is already live and protects new code. Fixes are made
     #     in the burn-down PRs, with tests, not by a blanket `ruff --fix` here:
     #     several of these autofixes change behavior or strip re-export noqas. ---
-    "PTH123",                                          # pathlib migration (#176)
     "B904", "B905", "RUF012", "RUF013",                # correctness (#177)
     # readability (#178)
     "SIM102", "SIM108", "SIM115", "SIM118", "SIM300",

--- a/scripts/classify_auxiliary_genomic.py
+++ b/scripts/classify_auxiliary_genomic.py
@@ -21,7 +21,7 @@ AUXILIARY_EXTENSIONS = {".fast5", ".pod5", ".fast5.tar", ".fast5.tar.gz", ".pvar
 def classify_auxiliary_genomic(metadata_path: Path, output_path: Path):
     """Classify auxiliary genomic files using RuleEngine."""
 
-    with open(metadata_path) as f:
+    with metadata_path.open() as f:
         data = json.load(f)
 
     files = data if isinstance(data, list) else data.get("files", data.get("results", []))
@@ -119,7 +119,7 @@ def classify_auxiliary_genomic(metadata_path: Path, output_path: Path):
 
     # Save results
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w") as f:
+    with output_path.open("w") as f:
         json.dump(
             {
                 "metadata": {

--- a/scripts/classify_bed_files.py
+++ b/scripts/classify_bed_files.py
@@ -38,7 +38,7 @@ def load_bed_reference_evidence() -> dict[str, dict]:
             continue
         for evi_file in subdir.iterdir():
             try:
-                with open(evi_file) as fh:
+                with evi_file.open() as fh:
                     evi = json.load(fh)
                 md5 = evi.get("md5sum")
                 if md5:
@@ -52,7 +52,7 @@ def load_bed_reference_evidence() -> dict[str, dict]:
 def classify_bed_files(metadata_path: Path, output_path: Path):
     """Classify BED files using RuleEngine + coordinate-based reference evidence."""
 
-    with open(metadata_path) as f:
+    with metadata_path.open() as f:
         data = json.load(f)
 
     files = data if isinstance(data, list) else data.get("files", data.get("results", []))
@@ -143,7 +143,7 @@ def classify_bed_files(metadata_path: Path, output_path: Path):
 
     # Save results
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w") as f:
+    with output_path.open("w") as f:
         json.dump(
             {
                 "metadata": {

--- a/scripts/classify_hprc_files.py
+++ b/scripts/classify_hprc_files.py
@@ -266,41 +266,41 @@ def main():
     if "sequencing" in catalogs_to_run:
         catalog_path = args.catalog_dir / "sequencing-data.json"
         if catalog_path.exists():
-            with open(catalog_path) as f:
+            with catalog_path.open() as f:
                 catalog = json.load(f)
             results = classify_sequencing_data(catalog, args.evidence_base, limit=args.limit)
             all_results["sequencing"] = results
-            with open(output_dir / "sequencing_classifications.json", "w") as f:
+            with (output_dir / "sequencing_classifications.json").open("w") as f:
                 json.dump({"classifications": results, "metadata": {"total": len(results)}}, f, indent=2)
 
     if "assemblies" in catalogs_to_run:
         catalog_path = args.catalog_dir / "assemblies.json"
         if catalog_path.exists():
-            with open(catalog_path) as f:
+            with catalog_path.open() as f:
                 catalog = json.load(f)
             results = classify_assemblies(catalog, args.evidence_base, limit=args.limit)
             all_results["assemblies"] = results
-            with open(output_dir / "assembly_classifications.json", "w") as f:
+            with (output_dir / "assembly_classifications.json").open("w") as f:
                 json.dump({"classifications": results, "metadata": {"total": len(results)}}, f, indent=2)
 
     if "alignments" in catalogs_to_run:
         catalog_path = args.catalog_dir / "alignments.json"
         if catalog_path.exists():
-            with open(catalog_path) as f:
+            with catalog_path.open() as f:
                 catalog = json.load(f)
             results = classify_filename_only(catalog, "alignments")
             all_results["alignments"] = results
-            with open(output_dir / "alignment_classifications.json", "w") as f:
+            with (output_dir / "alignment_classifications.json").open("w") as f:
                 json.dump({"classifications": results, "metadata": {"total": len(results)}}, f, indent=2)
 
     if "annotations" in catalogs_to_run:
         catalog_path = args.catalog_dir / "annotations.json"
         if catalog_path.exists():
-            with open(catalog_path) as f:
+            with catalog_path.open() as f:
                 catalog = json.load(f)
             results = classify_filename_only(catalog, "annotations")
             all_results["annotations"] = results
-            with open(output_dir / "annotation_classifications.json", "w") as f:
+            with (output_dir / "annotation_classifications.json").open("w") as f:
                 json.dump({"classifications": results, "metadata": {"total": len(results)}}, f, indent=2)
 
     # Summary

--- a/scripts/classify_images.py
+++ b/scripts/classify_images.py
@@ -18,7 +18,7 @@ from meta_disco.rule_engine import RuleEngine
 def classify_images(metadata_path: Path, output_path: Path):
     """Classify image files using RuleEngine."""
 
-    with open(metadata_path) as f:
+    with metadata_path.open() as f:
         data = json.load(f)
 
     files = data if isinstance(data, list) else data.get("files", data.get("results", []))
@@ -92,7 +92,7 @@ def classify_images(metadata_path: Path, output_path: Path):
 
     # Save results
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w") as f:
+    with output_path.open("w") as f:
         json.dump(
             {
                 "metadata": {

--- a/scripts/classify_index_files.py
+++ b/scripts/classify_index_files.py
@@ -69,7 +69,7 @@ def load_classifications(*paths: Path) -> dict[str, dict]:
     for path in paths:
         if not path.is_file():
             continue
-        with open(path) as f:
+        with path.open() as f:
             data = json.load(f)
         for c in data.get("classifications", []):
             md5 = c.get("md5sum")
@@ -94,7 +94,7 @@ def propagate_to_index_files(
     """Propagate metadata from parent files to index files."""
 
     # Load source metadata
-    with open(metadata_path) as f:
+    with metadata_path.open() as f:
         data = json.load(f)
 
     files = data if isinstance(data, list) else data.get("files", data.get("results", []))
@@ -308,7 +308,7 @@ def propagate_to_index_files(
             }
         )
 
-    with open(output_path, "w") as f:
+    with output_path.open("w") as f:
         json.dump(
             {
                 "metadata": {

--- a/scripts/classify_remaining_files.py
+++ b/scripts/classify_remaining_files.py
@@ -25,7 +25,7 @@ def load_already_classified(classification_paths: list[Path]) -> set[str]:
     for path in classification_paths:
         if not path.is_file():
             continue
-        with open(path) as f:
+        with path.open() as f:
             data = json.load(f)
         for r in data.get("classifications", data.get("results", [])):
             name = r.get("file_name", "")
@@ -37,7 +37,7 @@ def load_already_classified(classification_paths: list[Path]) -> set[str]:
 def classify_remaining(metadata_path: Path, output_path: Path, classification_paths: list[Path]):
     """Classify files not handled by other classifiers."""
 
-    with open(metadata_path) as f:
+    with metadata_path.open() as f:
         data = json.load(f)
 
     files = data if isinstance(data, list) else data.get("files", data.get("results", []))
@@ -84,7 +84,7 @@ def classify_remaining(metadata_path: Path, output_path: Path, classification_pa
         print(f"  .{ext}: {count:,}")
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w") as out:
+    with output_path.open("w") as out:
         json.dump(
             {
                 "metadata": {

--- a/scripts/download_anvil_metadata.py
+++ b/scripts/download_anvil_metadata.py
@@ -75,7 +75,7 @@ def load_checkpoint(output_dir: Path) -> tuple[int, int, list | None]:
     """Load checkpoint if it exists. Returns (page_num, total_fetched, search_after)."""
     checkpoint_path = output_dir / "checkpoint.json"
     if checkpoint_path.exists():
-        with open(checkpoint_path) as f:
+        with checkpoint_path.open() as f:
             data = json.load(f)
         return data["page"], data["total_fetched"], data.get("search_after")
     return 0, 0, None
@@ -84,7 +84,7 @@ def load_checkpoint(output_dir: Path) -> tuple[int, int, list | None]:
 def save_checkpoint(output_dir: Path, page: int, total_fetched: int, search_after: list | None):
     """Save checkpoint for resume."""
     checkpoint_path = output_dir / "checkpoint.json"
-    with open(checkpoint_path, "w") as f:
+    with checkpoint_path.open("w") as f:
         json.dump(
             {
                 "page": page,
@@ -107,11 +107,11 @@ def download_all_metadata(output_dir: Path, delay: float = DEFAULT_DELAY, max_pa
     if page_num > 0:
         print(f"Resuming from checkpoint: page {page_num}, {total_fetched:,} files already downloaded")
         # Open in append mode
-        ndjson_file = open(ndjson_path, "a")
+        ndjson_file = ndjson_path.open("a")
     else:
         print("Starting fresh download...")
         # Open in write mode (truncate)
-        ndjson_file = open(ndjson_path, "w")
+        ndjson_file = ndjson_path.open("w")
 
     try:
         # Get total count
@@ -202,7 +202,7 @@ def download_all_metadata(output_dir: Path, delay: float = DEFAULT_DELAY, max_pa
         # Create final JSON with metadata
         print("Creating final JSON file with metadata...")
         files = []
-        with open(ndjson_path) as f:
+        with ndjson_path.open() as f:
             for line in f:
                 if line.strip():
                     files.append(json.loads(line))
@@ -216,7 +216,7 @@ def download_all_metadata(output_dir: Path, delay: float = DEFAULT_DELAY, max_pa
             "files": files,
         }
         json_path = output_dir / "anvil_files_metadata.json"
-        with open(json_path, "w") as f:
+        with json_path.open("w") as f:
             json.dump(final_output, f)
         print(f"Saved {json_path}")
 

--- a/scripts/fetch_bed_headers.py
+++ b/scripts/fetch_bed_headers.py
@@ -39,7 +39,7 @@ def load_cached_evidence(md5sum: str) -> dict | None:
     path = get_evidence_path(md5sum)
     if path.exists():
         try:
-            with open(path) as f:
+            with path.open() as f:
                 return json.load(f)
         except (json.JSONDecodeError, IOError):
             return None
@@ -59,7 +59,7 @@ def save_evidence(md5sum: str, file_name: str, evidence: dict):
         }
     )
 
-    with open(path, "w") as f:
+    with path.open("w") as f:
         json.dump(evidence, f, indent=2)
 
 
@@ -242,7 +242,7 @@ def process_bed_files(
         resume: Use cached evidence
         workers: Parallel workers
     """
-    with open(input_path) as f:
+    with input_path.open() as f:
         data = json.load(f)
     files = data if isinstance(data, list) else data.get("files", data)
 
@@ -335,7 +335,7 @@ def process_bed_files(
 
     # Save results
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w") as f:
+    with output_path.open("w") as f:
         json.dump(
             {
                 "metadata": {

--- a/scripts/generate_classification_report.py
+++ b/scripts/generate_classification_report.py
@@ -42,7 +42,7 @@ FORMAT_CATEGORY_RULES = [
 
 def load_source_metadata(path: Path) -> list[dict]:
     """Load source metadata file."""
-    with open(path) as f:
+    with path.open() as f:
         data = json.load(f)
     return data if isinstance(data, list) else data.get("files", data.get("results", []))
 
@@ -64,7 +64,7 @@ def load_classifications(output_dir: Path) -> dict[str, list[dict]]:
     for name, filename in files_to_load.items():
         path = output_dir / filename
         if path.exists():
-            with open(path) as f:
+            with path.open() as f:
                 data = json.load(f)
             classifications[name] = data.get("classifications", [])
         else:

--- a/scripts/generate_coverage_report.py
+++ b/scripts/generate_coverage_report.py
@@ -66,7 +66,7 @@ def load_records(run_dir: Path) -> list[dict]:
         path = run_dir / fname
         if not path.is_file():
             continue
-        with open(path) as f:
+        with path.open() as f:
             data = json.load(f)
         for r in data.get("classifications", data.get("results", [])):
             cls = r.get("classifications", r)
@@ -206,7 +206,7 @@ def main():
     metadata_path = Path("data/anvil/anvil_files_metadata.ndjson")
     dataset_counts = Counter()
     if metadata_path.is_file():
-        with open(metadata_path) as f:
+        with metadata_path.open() as f:
             for line in f:
                 r = json.loads(line)
                 dataset_counts[r.get("dataset_title") or "unknown"] += 1
@@ -222,7 +222,7 @@ def main():
         )
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    with open(args.output, "w") as out:
+    with args.output.open("w") as out:
         out.write("# AnVIL Classification Coverage Report\n\n")
         out.write(f"Classification run: **{run_time}**\n\n")
 

--- a/scripts/generate_validation_report.py
+++ b/scripts/generate_validation_report.py
@@ -66,7 +66,7 @@ def load_our_classifications(run_dir: Path) -> tuple[dict, dict]:
         path = run_dir / fname
         if not path.is_file():
             continue
-        with open(path) as f:
+        with path.open() as f:
             data = json.load(f)
         for r in data.get("classifications", data.get("results", [])):
             rec = {}
@@ -196,7 +196,7 @@ def compare_anvil(our_by_md5: dict, metadata_path: Path) -> dict:
     dataset_counts = Counter()
     metadata_coverage = Counter()
     truth_records = []
-    with open(metadata_path) as f:
+    with metadata_path.open() as f:
         for line in f:
             r = json.loads(line)
             total_files += 1
@@ -253,7 +253,7 @@ def load_hprc_results(hprc_results_path: Path) -> dict:
     if not hprc_results_path.is_file():
         return {"matched": 0, "unmatched": 0, "dimensions": {}}
 
-    with open(hprc_results_path) as f:
+    with hprc_results_path.open() as f:
         data = json.load(f)
 
     # Handle both old format (results.total_validated) and new format (dimensions.*)
@@ -572,7 +572,7 @@ def main():
 
     # Generate markdown report
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    with open(args.output, "w") as out:
+    with args.output.open("w") as out:
         out.write("# Validation Report\n\n")
         out.write("Comparing meta-disco rule engine classifications against external ground truth.\n")
         out.write(f"Classification run: **{run_time}**\n\n")

--- a/scripts/run_batch_classification.py
+++ b/scripts/run_batch_classification.py
@@ -18,13 +18,13 @@ def load_metadata(input_path: Path) -> list[dict]:
     """Load metadata from JSON or NDJSON file."""
     if input_path.suffix == ".ndjson":
         files = []
-        with open(input_path) as f:
+        with input_path.open() as f:
             for line in f:
                 if line.strip():
                     files.append(json.loads(line))
         return files
     else:
-        with open(input_path) as f:
+        with input_path.open() as f:
             data = json.load(f)
         return data.get("files", data)
 
@@ -127,7 +127,7 @@ def save_results(results: list[dict], stats: dict, output_dir: Path):
 
     # Save full results as JSON
     json_path = output_dir / f"classification_results_{timestamp}.json"
-    with open(json_path, "w") as f:
+    with json_path.open("w") as f:
         json.dump(
             {
                 "metadata": {
@@ -145,7 +145,7 @@ def save_results(results: list[dict], stats: dict, output_dir: Path):
     # Save as TSV for easy viewing
     tsv_path = output_dir / f"classification_results_{timestamp}.tsv"
     if results:
-        with open(tsv_path, "w", newline="") as f:
+        with tsv_path.open("w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=results[0].keys(), delimiter="\t")
             writer.writeheader()
             writer.writerows(results)
@@ -153,7 +153,7 @@ def save_results(results: list[dict], stats: dict, output_dir: Path):
 
     # Save stats summary
     stats_path = output_dir / f"classification_stats_{timestamp}.json"
-    with open(stats_path, "w") as f:
+    with stats_path.open("w") as f:
         json.dump(stats, f, indent=2)
     print(f"Saved stats to {stats_path}")
 

--- a/scripts/validate_1000g_samples.py
+++ b/scripts/validate_1000g_samples.py
@@ -148,7 +148,7 @@ def validate_against_igsr(
     # Load classifications from all input files
     for input_path in input_paths:
         print(f"Loading classifications from {input_path}...", flush=True)
-        with open(input_path) as f:
+        with input_path.open() as f:
             data = json.load(f)
         classifications = data.get("classifications", data)
         all_classifications.extend(classifications)
@@ -351,7 +351,7 @@ def validate_against_igsr(
 
     # Save results
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w") as f:
+    with output_path.open("w") as f:
         json.dump(
             {
                 "metadata": {

--- a/scripts/validate_against_hprc.py
+++ b/scripts/validate_against_hprc.py
@@ -41,7 +41,7 @@ def load_catalog(name: str, catalog_dir: Path | None, fetch: bool) -> list[dict]
     if catalog_dir and not fetch:
         path = catalog_dir / f"{name}.json"
         if path.exists():
-            with open(path) as f:
+            with path.open() as f:
                 data = json.load(f)
             print(f"  {name}: {len(data):,} records (cached)")
             return data
@@ -183,7 +183,7 @@ def validate_against_hprc(
             print(f"  Skipping {input_path} (not found)")
             continue
         print(f"Loading {input_path}...", flush=True)
-        with open(input_path) as f:
+        with input_path.open() as f:
             data = json.load(f)
         classifications = data.get("classifications", data)
         if isinstance(classifications, list):
@@ -310,7 +310,7 @@ def validate_against_hprc(
 
     # Save results
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w") as f:
+    with output_path.open("w") as f:
         json.dump(
             {
                 "metadata": {

--- a/scripts/validate_ena_accessions.py
+++ b/scripts/validate_ena_accessions.py
@@ -55,7 +55,7 @@ def validate_against_ena(
 
     # Load classifications
     print(f"Loading classifications from {input_path}...")
-    with open(input_path) as f:
+    with input_path.open() as f:
         data = json.load(f)
 
     classifications = data.get("classifications", data)
@@ -252,7 +252,7 @@ def validate_against_ena(
 
     # Save results
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w") as f:
+    with output_path.open("w") as f:
         json.dump(
             {
                 "metadata": {

--- a/scripts/validate_reference_assemblies.py
+++ b/scripts/validate_reference_assemblies.py
@@ -192,7 +192,7 @@ def validate_classified_files(sample_size: int = 0) -> dict:
     # Load VCF classifications
     print("\nLoading VCF classifications...", flush=True)
     try:
-        with open("output/anvil/vcf_classifications.json") as f:
+        with Path("output/anvil/vcf_classifications.json").open() as f:
             data = json.load(f)
         vcf_files = data.get("classifications", data)
         results["vcf"]["total"] = len(vcf_files)
@@ -208,7 +208,7 @@ def validate_classified_files(sample_size: int = 0) -> dict:
     # Load BAM classifications
     print("Loading BAM classifications...", flush=True)
     try:
-        with open("output/anvil/bam_classifications.json") as f:
+        with Path("output/anvil/bam_classifications.json").open() as f:
             data = json.load(f)
         bam_files = data.get("classifications", data)
         results["bam"]["total"] = len(bam_files)
@@ -299,7 +299,7 @@ def main():
 
     # Save results
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    with open(args.output, "w") as f:
+    with args.output.open("w") as f:
         json.dump(
             {
                 "mapping_validation": mapping_results,

--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -63,7 +63,7 @@ def load_cached_evidence(evidence_dir: Path, md5sum: str) -> dict | None:
     path = get_evidence_path(evidence_dir, md5sum)
     if path.exists():
         try:
-            with open(path) as f:
+            with path.open() as f:
                 return json.load(f)
         except (json.JSONDecodeError, IOError):
             return None
@@ -74,7 +74,7 @@ def save_evidence(evidence_dir: Path, md5sum: str, evidence: dict) -> None:
     """Save evidence dict to cache."""
     path = get_evidence_path(evidence_dir, md5sum)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
+    with path.open("w") as f:
         json.dump(evidence, f, indent=2)
 
 

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -37,7 +37,7 @@ def load_records(input_path: Path) -> list:
     ``files`` (or legacy ``results``) list. Shared by ``ClassifyPipeline`` and the
     ``validate_metadata`` gate so the envelope handling lives in one place.
     """
-    with open(input_path) as f:
+    with input_path.open() as f:
         if input_path.suffix == ".ndjson":
             return [json.loads(line) for line in f if line.strip()]
         data = json.load(f)
@@ -147,7 +147,7 @@ class NdjsonWriter:
     def __init__(self, output_path: Path):
         self.path = output_path.with_suffix(".ndjson")
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self._fh = open(self.path, "w")
+        self._fh = self.path.open("w")
         self._count = 0
 
     def write(self, record: dict):
@@ -320,7 +320,7 @@ class ClassifyPipeline:
         if not self.skip_complete or not self.output_path.exists():
             return False
         try:
-            with open(self.output_path) as f:
+            with self.output_path.open() as f:
                 existing = json.load(f)
             existing_count = len(existing.get("classifications", []))
             if existing.get("metadata", {}).get("complete") and existing_count >= len(records):
@@ -548,13 +548,13 @@ class ClassifyPipeline:
         ndjson = self.output_path.with_suffix(".ndjson")
         classifications = []
         if ndjson.exists():
-            with open(ndjson) as f:
+            with ndjson.open() as f:
                 for line in f:
                     if line.strip():
                         classifications.append(json.loads(line))
 
         self.output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(self.output_path, "w") as f:
+        with self.output_path.open("w") as f:
             json.dump(
                 {
                     "metadata": {

--- a/tests/test_index_propagation.py
+++ b/tests/test_index_propagation.py
@@ -260,7 +260,7 @@ class TestLoadClassifications:
         propagate_to_index_files(metadata_file, [bed_cls_file], output_file)
 
         # Verify the CSI index inherited from the BED parent
-        with open(output_file) as f:
+        with output_file.open() as f:
             output = json.load(f)
         index_cls = output["classifications"]
         assert len(index_cls) == 1
@@ -323,7 +323,7 @@ class TestLoadClassifications:
         )
         output_file = tmp_path / "out.json"
         propagate_to_index_files(metadata_file, [vcf_cls], output_file)
-        with open(output_file) as f:
+        with output_file.open() as f:
             output = json.load(f)
         assert len(output["classifications"]) == 1
         cls = output["classifications"][0]["classifications"]
@@ -378,7 +378,7 @@ class TestLoadClassifications:
         )
         output_file = tmp_path / "out.json"
         propagate_to_index_files(metadata_file, [bam_cls], output_file)
-        with open(output_file) as f:
+        with output_file.open() as f:
             output = json.load(f)
         assert len(output["classifications"]) == 1
         cls = output["classifications"][0]["classifications"]
@@ -408,7 +408,7 @@ class TestLoadClassifications:
         empty_cls.write_text(json.dumps({"classifications": []}))
         output_file = tmp_path / "out.json"
         propagate_to_index_files(metadata_file, [empty_cls], output_file)
-        with open(output_file) as f:
+        with output_file.open() as f:
             output = json.load(f)
         assert len(output["classifications"]) == 0
         assert len(output["unmatched_files"]) == 1
@@ -445,7 +445,7 @@ class TestLoadClassifications:
         empty_cls.write_text(json.dumps({"classifications": []}))
         output_file = tmp_path / "out.json"
         propagate_to_index_files(metadata_file, [empty_cls], output_file)
-        with open(output_file) as f:
+        with output_file.open() as f:
             output = json.load(f)
         # Parent filename matched but md5 not in classifications → not_classified
         assert len(output["classifications"]) == 1

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -140,7 +140,7 @@ class TestPipelineRun:
         assert len(results) == 2  # Only .test files, not .bam
         assert output.exists()
 
-        with open(output) as f:
+        with output.open() as f:
             data = json.load(f)
         assert data["metadata"]["successful"] == 2
         assert data["metadata"]["complete"] is True
@@ -172,7 +172,7 @@ class TestPipelineRun:
         results = pipeline.run()
         assert len(results) == 0
 
-        with open(output) as f:
+        with output.open() as f:
             data = json.load(f)
         assert data["metadata"]["failed"] == 2
 

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -117,7 +117,7 @@ class TestThenStatus:
         import yaml
 
         path = tmp_path / "rules.yaml"
-        with open(path, "w", encoding="utf-8") as f:
+        with path.open("w", encoding="utf-8") as f:
             yaml.safe_dump_all(
                 [
                     {"extension_map": {".foo": "foo"}},

--- a/tests/test_rule_vocabulary.py
+++ b/tests/test_rule_vocabulary.py
@@ -162,7 +162,7 @@ def test_assay_type_condition_values_in_vocabulary():
 def test_assay_condition_check_rejects_bogus_platform(tmp_path):
     """The assay-condition drift check catches a typo'd enum-backed value (#113)."""
     path = tmp_path / "rules.yaml"
-    with open(path, "w", encoding="utf-8") as f:
+    with path.open("w", encoding="utf-8") as f:
         yaml.safe_dump_all(
             [
                 {"extension_map": {}},
@@ -188,7 +188,7 @@ def test_assay_condition_check_rejects_bogus_platform(tmp_path):
 def _write_assay_rules_file(tmp_path, assay_rule):
     """Write a rules file whose fourth document holds a single assay_type_rule."""
     path = tmp_path / "rules.yaml"
-    with open(path, "w", encoding="utf-8") as f:
+    with path.open("w", encoding="utf-8") as f:
         yaml.safe_dump_all(
             [
                 {"extension_map": {}},
@@ -298,7 +298,7 @@ def test_value_in_vocabulary_rejects_all_statuses():
 def _write_rules_file(tmp_path, rule):
     """Write a minimal two-document rules file containing a single rule."""
     path = tmp_path / "rules.yaml"
-    with open(path, "w", encoding="utf-8") as f:
+    with path.open("w", encoding="utf-8") as f:
         yaml.safe_dump_all([{"extension_map": {}}, {"rules": [rule]}], f)
     return path
 


### PR DESCRIPTION
Closes #176

## What changed
- Removed `PTH123` from the burn-down ignore list in `pyproject.toml`, so the `PTH` (flake8-use-pathlib) rule family is now fully enforced.
- Converted all **73** flagged builtin `open()` calls to `Path.open()` across `src/` (7), `scripts/` (55), and `tests/` (11).
  - **71 sites**: the argument was already a `Path`, so they became `x.open(...)` directly — no redundant `Path()` re-wrapping.
  - **2 sites** (`scripts/validate_reference_assemblies.py`): string literals became `Path("...").open()`.
- Modes, `encoding=`, and `newline=` kwargs preserved verbatim; `with`-statement vs. assignment structure preserved.

## Why
`PTH` is already in the repo's ruff `select` list but `PTH123` sat on the burn-down ignore list from the lint adoption (#175). This clears that entry so the rule protects the whole codebase and new `open()` calls can't regress. pathlib is the modern idiom and removes a class of path-as-string mistakes.

## Assumptions I made
- **Scope is narrower than the issue estimated — worth knowing.** #176 anticipated `PTH100/110/118/120` (os.path `abspath`/`exists`/`join`/`dirname`) too, but the codebase had **zero** violations of those and they were never on the ignore list. `PTH123` (`open()`) was the entire real surface. Verified with `ruff check --select PTH`.
- **`.open()` not `.read_text()`.** I used the minimal faithful conversion (`open(p)` → `p.open()`), not a further refactor to `read_text`/`write_text`, keeping this a pure, reviewable PTH migration.
- **Every converted arg is a `Path` at runtime.** Confirmed three ways: pyright/Pylance type diagnostics report zero issues on all 22 changed files; the argparse `args.output` sites are declared `type=Path`; and pre-existing unchanged code already calls `Path`-only methods (`.parent.mkdir()`, `.with_name()`) on those same variables.

## How to verify
Definition of done from #176, mapped to steps:
- [x] **PTH123 removed from the ignore list** — see `pyproject.toml` diff. (PTH100/110/118/120 were never present; noted above.)
- [x] **`os.path.*` and `open()` replaced with pathlib where flagged** — 73 conversions in the diff; `open()` was the only flagged construct.
- [x] **`make test-all` passes** — run it; expect 588 root + 10 schema passing.
- [x] **`make lint` green with PTH enforced** — run `make lint`; PTH123 no longer ignored.

To check locally:
```
git checkout noopdog/176-pathlib-migration
make lint          # -> All checks passed! (PTH enforced)
uv run ruff check src/ scripts/ tests/ --select PTH --ignore E501   # -> All checks passed!
make test-all      # -> 588 + 10 passing
make format-check  # -> all formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)