### PR TITLE
Burn down correctness rules B904/B905/RUF012/RUF013 (#177)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ ignore = [
     #     these families is already live and protects new code. Fixes are made
     #     in the burn-down PRs, with tests, not by a blanket `ruff --fix` here:
     #     several of these autofixes change behavior or strip re-export noqas. ---
-    "B904", "B905", "RUF012", "RUF013",                # correctness (#177)
     # readability (#178)
     "SIM102", "SIM108", "SIM115", "SIM118", "SIM300",
     "RET501", "RET504", "RET505", "RET508",

--- a/scripts/generate_classification_report.py
+++ b/scripts/generate_classification_report.py
@@ -150,7 +150,7 @@ def generate_report(source_path: Path, output_dir: Path, report_path: Path):
     ax1.set_title(f"Input Files by Category\n(Total: {total_files:,})", fontweight="bold")
 
     # Add legend
-    legend_labels = [f"{label}: {s:,}" for label, s in zip(labels, sizes)]
+    legend_labels = [f"{label}: {s:,}" for label, s in zip(labels, sizes, strict=True)]
     ax1.legend(wedges, legend_labels, loc="center left", bbox_to_anchor=(1, 0.5), fontsize=8)
 
     # === Panel 2: Classification Coverage (horizontal bar) ===

--- a/scripts/generate_coverage_report.py
+++ b/scripts/generate_coverage_report.py
@@ -185,7 +185,7 @@ def main():
         run_dir = args.run_dir or find_latest_run(Path("output/anvil"))
     except FileNotFoundError as exc:
         print(exc, file=sys.stderr)
-        raise SystemExit(1)
+        raise SystemExit(1) from None
     print(f"Loading from: {run_dir}")
 
     records = load_records(run_dir)

--- a/scripts/generate_validation_report.py
+++ b/scripts/generate_validation_report.py
@@ -540,7 +540,7 @@ def main():
         run_dir = args.run_dir or find_latest_run(Path("output/anvil"))
     except FileNotFoundError as exc:
         print(exc, file=sys.stderr)
-        raise SystemExit(1)
+        raise SystemExit(1) from None
     print(f"Loading classifications from: {run_dir}")
 
     our_by_md5, _ = load_our_classifications(run_dir)

--- a/scripts/rerun_all_classifications.py
+++ b/scripts/rerun_all_classifications.py
@@ -47,7 +47,7 @@ def build_parallel_jobs(metadata: Path, output_dir: Path) -> list[tuple]:
     return jobs
 
 
-def run_script(script_name: str, output_path: Path, extra_args: list[str] = None):
+def run_script(script_name: str, output_path: Path, extra_args: list[str] | None = None):
     """Run a classification script."""
     cmd = [sys.executable, f"scripts/{script_name}", "--output", str(output_path)]
     if extra_args:

--- a/scripts/validate_against_hprc.py
+++ b/scripts/validate_against_hprc.py
@@ -374,7 +374,7 @@ def main():
         except FileNotFoundError as exc:
             print(exc, file=sys.stderr)
             print("Run 'make classify-hprc' first.", file=sys.stderr)
-            raise SystemExit(1)
+            raise SystemExit(1) from None
         print(f"Using HPRC run directory: {hprc_run_dir}")
         input_paths = [f for f in sorted(hprc_run_dir.glob("*_classifications.json"))]
 

--- a/scripts/validate_ena_accessions.py
+++ b/scripts/validate_ena_accessions.py
@@ -40,7 +40,7 @@ def fetch_ena_metadata(acc: str) -> dict | None:
             return None
         headers = lines[0].split("\t")
         values = lines[1].split("\t")
-        return dict(zip(headers, values))
+        return dict(zip(headers, values, strict=True))
     except (requests.RequestException, ValueError):
         return None
 

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from importlib.resources import files
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import yaml
 
@@ -89,7 +89,7 @@ class UnifiedRules:
     reference_contig_lengths: dict[str, dict[str, int]]
 
     # Compound extensions in priority order (longest first)
-    COMPOUND_EXTENSIONS = [
+    COMPOUND_EXTENSIONS: ClassVar[list[str]] = [
         ".g.vcf.gz",  # Must come before .vcf.gz
         ".gvcf.gz",
         ".vcf.gz",
@@ -141,14 +141,14 @@ class UnifiedRules:
 class RuleLoader:
     """Loader for unified classification rules."""
 
-    VALID_SCOPES = {"extension", "filename", "header", "vcf_header", "fastq_header", "file_size"}
-    VALID_TIERS = {1, 2, 3}
+    VALID_SCOPES: ClassVar[set[str]] = {"extension", "filename", "header", "vcf_header", "fastq_header", "file_size"}
+    VALID_TIERS: ClassVar[set[int]] = {1, 2, 3}
 
     # Condition keys the engine interprets. Keep in sync with
     # rule_engine.RuleEngine._rule_matches() and its _match_* helpers — a key not
     # listed here is silently ignored at match time, so an unrecognized key is
     # almost always a typo (e.g. "filename_patern").
-    VALID_WHEN_KEYS = {
+    VALID_WHEN_KEYS: ClassVar[set[str]] = {
         "always",
         "extensions",
         "filename_pattern",
@@ -171,19 +171,19 @@ class RuleLoader:
     # fields (real-value effects) plus the reserved `status` key, whose value is a
     # sub-map of {field: status} for fields a rule declares non-classified (#133).
     # A key not listed here would never be applied, so it is treated as an error.
-    THEN_STATUS_KEY = "status"
-    VALID_THEN_KEYS = set(CLASSIFICATION_FIELDS) | {THEN_STATUS_KEY}
+    THEN_STATUS_KEY: ClassVar[str] = "status"
+    VALID_THEN_KEYS: ClassVar[set[str]] = set(CLASSIFICATION_FIELDS) | {THEN_STATUS_KEY}
 
     # Statuses a rule may author in a `then.status` sub-map. `classified` is
     # implied by a real value and `conflict` is engine-derived, so neither may be
     # written by a rule (mirrors schema_vocab's antecedent/emitted split).
-    AUTHORABLE_STATUSES = {NOT_APPLICABLE, NOT_CLASSIFIED}
+    AUTHORABLE_STATUSES: ClassVar[set[str]] = {NOT_APPLICABLE, NOT_CLASSIFIED}
 
     # assay_type_rules condition keys that infer_assay_type() treats as iterables
     # (`x not in platform_in`, `any(r in ... for r in matched_rules_any)`). A
     # scalar string here silently becomes a per-character membership test, so it
     # must be a list. Keep in sync with rule_engine.RuleEngine.infer_assay_type().
-    LIST_VALUED_ASSAY_CONDITIONS = {"platform_in", "matched_rules_any"}
+    LIST_VALUED_ASSAY_CONDITIONS: ClassVar[set[str]] = {"platform_in", "matched_rules_any"}
 
     def __init__(self, rules_path: str | Path | None = None):
         """Initialize the rule loader.


### PR DESCRIPTION
Closes #177

## What changed
Removed `B904`, `B905`, `RUF012`, `RUF013` from the ruff burn-down ignore list and fixed all 12 flagged sites with intent:

- **RUF012 (6)** — annotated class-level constants in `src/meta_disco/rule_loader.py` as `ClassVar[...]`. I annotated *all* constants in `RuleLoader` plus `COMPOUND_EXTENSIONS` on the `UnifiedRules` dataclass, not only the 6 flagged mutable literals, so no sibling constant is left inconsistent.
- **B904 (3)** — the CLI `print(exc, file=sys.stderr); raise SystemExit(1)` pattern now uses `raise SystemExit(1) from None`. The error is already reported cleanly, so the chained traceback is deliberately suppressed.
- **B905 (2)** — added `strict=True` to two `zip()` calls.
- **RUF013 (1)** — `extra_args: list[str] = None` → `list[str] | None = None`.

## Why
These four codes are correctness-adjacent and were parked on the burn-down list from the lint adoption (#175). Clearing them enforces the rules across the codebase so new violations can't regress, and each fix removes a real latent issue (unchained exceptions, silently-truncating zips, implicit Optional, shared mutable class state).

## Assumptions I made
- **`strict=True` is safe and intentional at both `zip` sites.** In `generate_classification_report.py`, `labels` and `sizes` are `list(d.keys())`/`list(d.values())` of the *same* dict — always equal length, so `strict=True` documents the invariant and can never spuriously raise. In `validate_ena_accessions.py`, the `zip` parses a TSV header/value row from an **ENA network response** (a trust boundary); a ragged row now raises `ValueError`, which the existing `except (requests.RequestException, ValueError): return None` already handles — a deliberate reject-malformed-input choice over silently truncating to the shorter row.
- **`ClassVar` is runtime-inert.** On the `UnifiedRules` dataclass, `COMPOUND_EXTENSIONS` was already a non-field (unannotated); `ClassVar` keeps it a non-field, so `__init__` and attribute access are unchanged. On `RuleLoader` (a plain class) the annotations are typing-only.
- **`from None` is display-only** — `SystemExit(1)` still propagates with the same exit code; only the traceback chain is suppressed.

## How to verify
Definition of done from #177:
- [x] **B904, B905, RUF012, RUF013 removed from the ignore list** — see `pyproject.toml` diff.
- [x] **Each fixed with intent, not just silenced** — see the per-code rationale above and the diff.
- [x] **`make test-all` passes** — expect 588 root + 10 schema.

Local check:
```
git checkout noopdog/177-correctness-burndown
uv run ruff check src/ scripts/ tests/ --select B904,B905,RUF012,RUF013 --ignore E501   # -> All checks passed!
make lint          # -> All checks passed! (four codes now enforced)
make test-all      # -> 588 + 10 passing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)