### PR TITLE
Burn down readability rules SIM/RET/PIE/C4/UP/RUF (#178)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,11 @@ ignore = [
     #     these families is already live and protects new code. Fixes are made
     #     in the burn-down PRs, with tests, not by a blanket `ruff --fix` here:
     #     several of these autofixes change behavior or strip re-export noqas. ---
-    # readability (#178)
-    "SIM102", "SIM108", "SIM115", "SIM118", "SIM300",
-    "RET501", "RET504", "RET505", "RET508",
-    "PIE810", "C416", "C420", "B007",
-    "UP024", "UP033", "UP035",
-    "RUF015", "RUF022", "RUF043", "RUF059", "RUF100",
+    # RUF022 kept ignored on purpose (#178): both __all__ lists use intentional,
+    # non-alphabetical ordering that RUF022's sort would degrade — src/meta_disco/
+    # __init__.py groups exports by source module, and validators/__init__.py has
+    # explicit comment-grouped sections (# Contig length validators, etc.).
+    "RUF022",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/scripts/classify_bed_files.py
+++ b/scripts/classify_bed_files.py
@@ -43,7 +43,7 @@ def load_bed_reference_evidence() -> dict[str, dict]:
                 md5 = evi.get("md5sum")
                 if md5:
                     evidence[md5] = evi
-            except (json.JSONDecodeError, IOError):
+            except (OSError, json.JSONDecodeError):
                 continue
 
     return evidence
@@ -63,7 +63,7 @@ def classify_bed_files(metadata_path: Path, output_path: Path):
     for f in files:
         name = f.get("file_name", "")
         fmt = f.get("file_format", "")
-        if name.endswith(".bed") or name.endswith(".bed.gz") or fmt in [".bed", ".bed.gz"]:
+        if name.endswith((".bed", ".bed.gz")) or fmt in [".bed", ".bed.gz"]:
             bed_files.append(f)
 
     print(f"Found {len(bed_files):,} BED files")

--- a/scripts/classify_hprc_files.py
+++ b/scripts/classify_hprc_files.py
@@ -75,7 +75,7 @@ def classify_sequencing_data(
 
         classifications = None
 
-        if fn.endswith(".bam") or fn.endswith(".cram"):
+        if fn.endswith((".bam", ".cram")):
             raw_data = fetch_bam_header(
                 bam_evidence,
                 key,
@@ -90,7 +90,7 @@ def classify_sequencing_data(
                     file_size=file_size,
                     file_format=".cram" if fn.endswith(".cram") else ".bam",
                 )
-        elif fn.endswith(".fastq.gz") or fn.endswith(".fastq"):
+        elif fn.endswith((".fastq.gz", ".fastq")):
             raw_data = fetch_fastq_reads(
                 fastq_evidence,
                 key,

--- a/scripts/classify_images.py
+++ b/scripts/classify_images.py
@@ -35,7 +35,7 @@ def classify_images(metadata_path: Path, output_path: Path):
 
         # Check if this is an image file
         is_image = False
-        for ext in stats.keys():
+        for ext in stats:
             if fmt == ext or name_lower.endswith(ext):
                 is_image = True
                 stats[ext]["total"] = stats[ext].get("total", 0) + 1

--- a/scripts/classify_index_files.py
+++ b/scripts/classify_index_files.py
@@ -138,7 +138,7 @@ def propagate_to_index_files(
 
             # Check if this is an index file
             index_ext = None
-            for ext in INDEX_TO_PARENT.keys():
+            for ext in INDEX_TO_PARENT:
                 if fmt == ext or name.endswith(ext):
                     index_ext = ext
                     break
@@ -218,7 +218,7 @@ def propagate_to_index_files(
     modality_all = 0
     ref_all = 0
 
-    for ext in INDEX_TO_PARENT.keys():
+    for ext in INDEX_TO_PARENT:
         s = stats[ext]
         if s["total"] > 0:
             match_pct = s["matched"] / s["total"] * 100
@@ -370,10 +370,7 @@ def main():
     args = parser.parse_args()
 
     # Build list of classification paths (deduplicated)
-    if args.classifications:
-        cls_paths = list(dict.fromkeys(args.classifications))
-    else:
-        cls_paths = [args.bam, args.vcf]
+    cls_paths = list(dict.fromkeys(args.classifications)) if args.classifications else [args.bam, args.vcf]
 
     propagate_to_index_files(
         args.metadata,

--- a/scripts/fetch_bed_headers.py
+++ b/scripts/fetch_bed_headers.py
@@ -41,7 +41,7 @@ def load_cached_evidence(md5sum: str) -> dict | None:
         try:
             with path.open() as f:
                 return json.load(f)
-        except (json.JSONDecodeError, IOError):
+        except (OSError, json.JSONDecodeError):
             return None
     return None
 
@@ -85,10 +85,7 @@ def fetch_bed_signals(md5sum: str, is_gzipped: bool = True, file_size: int | Non
     """
     # Adaptive fetch size: small files get fetched whole, large ones get 10MB
     # HTTP Range end offset is inclusive, so bytes=0-N fetches N+1 bytes
-    if file_size and file_size <= 10_000_000:
-        fetch_bytes = file_size - 1
-    else:
-        fetch_bytes = 10_485_759  # 10MB (inclusive end)
+    fetch_bytes = file_size - 1 if file_size and file_size <= 10_000_000 else 10_485_759  # 10MB (inclusive end)
 
     url = f"{S3_MIRROR_URL}/{md5sum}.md5"
 
@@ -151,7 +148,7 @@ def extract_bed_signals(lines: list[str]) -> dict:
 
     for line in lines:
         line = line.strip()
-        if not line or line.startswith("#") or line.startswith("track") or line.startswith("browser"):
+        if not line or line.startswith(("#", "track", "browser")):
             continue
 
         parts = line.split("\t")

--- a/scripts/generate_classification_report.py
+++ b/scripts/generate_classification_report.py
@@ -144,7 +144,7 @@ def generate_report(source_path: Path, output_dir: Path, report_path: Path):
     labels = list(categories_for_pie.keys())
     sizes = list(categories_for_pie.values())
 
-    wedges, texts, autotexts = ax1.pie(
+    wedges, _texts, _autotexts = ax1.pie(
         sizes, labels=None, autopct=lambda p: f"{p:.1f}%" if p > 3 else "", colors=colors[: len(sizes)], startangle=90
     )
     ax1.set_title(f"Input Files by Category\n(Total: {total_files:,})", fontweight="bold")
@@ -279,10 +279,7 @@ def generate_report(source_path: Path, output_dir: Path, report_path: Path):
                 dtype = "alignments"
             elif source == "VCF":
                 vtype = item.get("variant_type", "")
-                if vtype in ["structural", "cnv"]:
-                    dtype = "structural_variants"
-                else:
-                    dtype = "variant_calls"
+                dtype = "structural_variants" if vtype in ["structural", "cnv"] else "variant_calls"
             elif source == "FASTQ":
                 dtype = "reads"
             elif source == "Images":

--- a/scripts/generate_coverage_report.py
+++ b/scripts/generate_coverage_report.py
@@ -102,12 +102,11 @@ def _normalize_reason(reason: str) -> str:
         r"Parent file marks \1 not applicable",
         reason,
     )
-    reason = re.sub(
+    return re.sub(
         r"Inherited from parent file: .+",
         "Inherited from parent file",
         reason,
     )
-    return reason
 
 
 def get_nc_reasons(records: list[dict], field_name: str) -> dict[str, Counter]:

--- a/scripts/rerun_all_classifications.py
+++ b/scripts/rerun_all_classifications.py
@@ -100,7 +100,7 @@ def main():
     with ThreadPoolExecutor(max_workers=len(parallel_jobs)) as executor:
         futures = {executor.submit(run_script, name, path, extra): name for name, path, extra in parallel_jobs}
         for future in as_completed(futures):
-            script_name, ok = future.result()
+            _script_name, ok = future.result()
             success &= ok
 
     # Phase 2: Index classification (inherits from parent file classifications)

--- a/scripts/run_batch_classification.py
+++ b/scripts/run_batch_classification.py
@@ -23,10 +23,9 @@ def load_metadata(input_path: Path) -> list[dict]:
                 if line.strip():
                     files.append(json.loads(line))
         return files
-    else:
-        with input_path.open() as f:
-            data = json.load(f)
-        return data.get("files", data)
+    with input_path.open() as f:
+        data = json.load(f)
+    return data.get("files", data)
 
 
 def run_classification(files: list[dict], engine: RuleEngine) -> list[dict]:

--- a/scripts/validate_1000g_samples.py
+++ b/scripts/validate_1000g_samples.py
@@ -206,7 +206,7 @@ def validate_against_igsr(
     # Fetch all sample metadata in parallel
     print("Fetching IGSR metadata...", flush=True)
     with ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = {executor.submit(fetch_sample, sid): sid for sid in sample_files.keys()}
+        futures = {executor.submit(fetch_sample, sid): sid for sid in sample_files}
 
         for future in as_completed(futures):
             completed_samples += 1
@@ -276,7 +276,7 @@ def validate_against_igsr(
                     if our_modality == exp_mod:
                         modality_match = True
                         break
-                    elif our_modality.startswith(exp_mod.split(".")[0]) or exp_mod.startswith(our_modality):
+                    if our_modality.startswith(exp_mod.split(".")[0]) or exp_mod.startswith(our_modality):
                         modality_partial = True
 
             if modality_match:

--- a/scripts/validate_against_hprc.py
+++ b/scripts/validate_against_hprc.py
@@ -376,7 +376,7 @@ def main():
             print("Run 'make classify-hprc' first.", file=sys.stderr)
             raise SystemExit(1) from None
         print(f"Using HPRC run directory: {hprc_run_dir}")
-        input_paths = [f for f in sorted(hprc_run_dir.glob("*_classifications.json"))]
+        input_paths = sorted(hprc_run_dir.glob("*_classifications.json"))
 
     validate_against_hprc(input_paths, args.output, args.catalog_dir, args.fetch, args.limit)
 

--- a/scripts/validate_reference_assemblies.py
+++ b/scripts/validate_reference_assemblies.py
@@ -136,7 +136,7 @@ def validate_internal_mappings() -> dict:
     # CHM13 - validate against known T2T values
     # Source: https://www.ncbi.nlm.nih.gov/assembly/GCF_009914755.1
     print("\nValidating CHM13 against T2T consortium values...", flush=True)
-    _chm13_official = {  # noqa: F841
+    _chm13_official = {
         "1": 248387328,  # Note: slight difference from our value
         "2": 242696752,
         "3": 201105948,

--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -65,7 +65,7 @@ def load_cached_evidence(evidence_dir: Path, md5sum: str) -> dict | None:
         try:
             with path.open() as f:
                 return json.load(f)
-        except (json.JSONDecodeError, IOError):
+        except (OSError, json.JSONDecodeError):
             return None
     return None
 
@@ -258,9 +258,8 @@ def fetch_vcf_header(
         for line in text.split("\n"):
             if line.startswith("#"):
                 header_lines.append(line)
-            elif line.strip():
-                if len(variant_lines) < 100:
-                    variant_lines.append(line)
+            elif line.strip() and len(variant_lines) < 100:
+                variant_lines.append(line)
 
         if header_lines:
             header_text = "\n".join(header_lines)

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -12,12 +12,12 @@ import re
 from dataclasses import replace
 
 from .models import CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED, build_field_entry
-from .validators.read_name_parsers import (  # noqa: F401 — re-exported for backward compat
+from .validators.read_name_parsers import (
     detect_paired_end_indicators,
     extract_archive_accession,
-    infer_illumina_instrument_model,
+    infer_illumina_instrument_model,  # noqa: F401  re-exported for backward compat
     parse_illumina_read_name,
-    parse_ont_read_name,
+    parse_ont_read_name,  # noqa: F401  re-exported for backward compat
     parse_pacbio_read_name,
 )
 
@@ -796,15 +796,14 @@ def _infer_bed_reference(signals: dict) -> tuple[str | None, str]:
     if len(candidates) == 1:
         rationale = f"Only {candidates[0]} not ruled out. {'; '.join(evidence_details)}"
         return candidates[0], rationale
-    elif len(candidates) == 0:
+    if len(candidates) == 0:
         return None, f"All references ruled out: {'; '.join(evidence_details)}"
-    else:
-        # More than one reference is still consistent with these coordinates —
-        # the file's coordinates don't reach into regions where the candidates'
-        # chromosome lengths differ, so we genuinely can't tell them apart. Return
-        # "can't tell" (None) rather than guessing a closest match: an undefined
-        # coordinate result must not override a filename-based reference.
-        return None, (f"Cannot distinguish between {', '.join(candidates)} — coordinates fit multiple references")
+    # More than one reference is still consistent with these coordinates —
+    # the file's coordinates don't reach into regions where the candidates'
+    # chromosome lengths differ, so we genuinely can't tell them apart. Return
+    # "can't tell" (None) rather than guessing a closest match: an undefined
+    # coordinate result must not override a filename-based reference.
+    return None, (f"Cannot distinguish between {', '.join(candidates)} — coordinates fit multiple references")
 
 
 def classify_from_bed_signals(

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -379,7 +379,7 @@ class ClassifyPipeline:
         file_format = record.get("file_format") or ""
 
         has_gz_ext = any(ext.endswith(".gz") for ext in self.config.extensions)
-        is_gzipped = file_name.endswith(".gz") or file_format.endswith(".gz") if has_gz_ext else True
+        is_gzipped = (file_name.endswith(".gz") or file_format.endswith(".gz")) if has_gz_ext else True
 
         was_cached = self.resume and self._is_cached(md5)
 

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -7,11 +7,12 @@ which carries extension filters, fetcher, classifier, and summary printer.
 
 import json
 import re
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
-from typing import Callable, NamedTuple
+from typing import NamedTuple
 
 from .fetchers import FetchError
 from .header_classifier import classify_without_content
@@ -326,7 +327,7 @@ class ClassifyPipeline:
             if existing.get("metadata", {}).get("complete") and existing_count >= len(records):
                 print(f"Output already complete with {existing_count} classifications. Skipping.")
                 return True
-        except (json.JSONDecodeError, IOError):
+        except (OSError, json.JSONDecodeError):
             pass
         return False
 
@@ -378,10 +379,7 @@ class ClassifyPipeline:
         file_format = record.get("file_format") or ""
 
         has_gz_ext = any(ext.endswith(".gz") for ext in self.config.extensions)
-        if has_gz_ext:
-            is_gzipped = file_name.endswith(".gz") or file_format.endswith(".gz")
-        else:
-            is_gzipped = True
+        is_gzipped = file_name.endswith(".gz") or file_format.endswith(".gz") if has_gz_ext else True
 
         was_cached = self.resume and self._is_cached(md5)
 

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -72,7 +72,7 @@ class ExtendedClassificationResult:
     # above hold a real value or None only — the sentinel (not_applicable /
     # not_classified) lives here, never in a value slot. Defaults to
     # not_classified (no statement made) until a value or status is set.
-    field_status: dict[str, str] = field(default_factory=lambda: {fld: NOT_CLASSIFIED for fld in CLASSIFICATION_FIELDS})
+    field_status: dict[str, str] = field(default_factory=lambda: dict.fromkeys(CLASSIFICATION_FIELDS, NOT_CLASSIFIED))
 
     def set_field(self, fld: str, value: str | None = None, status: str | None = None) -> None:
         """Set a dimension's value and status coherently.
@@ -337,10 +337,7 @@ class RuleEngine:
             ExtendedClassificationResult with classification and metadata
         """
         # Convert to ExtendedFileInfo if needed
-        if isinstance(file_info, FileInfo):
-            ext_info = ExtendedFileInfo.from_file_info(file_info)
-        else:
-            ext_info = file_info
+        ext_info = ExtendedFileInfo.from_file_info(file_info) if isinstance(file_info, FileInfo) else file_info
 
         # Extract extension
         extension = self.rules.extract_extension(ext_info.filename)
@@ -408,14 +405,12 @@ class RuleEngine:
             return True
 
         # Check extension filter
-        if "extensions" in when:
-            if file_info.file_format not in [e.lower() for e in when["extensions"]]:
-                return False
+        if "extensions" in when and file_info.file_format not in [e.lower() for e in when["extensions"]]:
+            return False
 
         # Check filename pattern
-        if pattern := when.get("filename_pattern"):
-            if not re.search(pattern, file_info.filename, re.IGNORECASE):
-                return False
+        if (pattern := when.get("filename_pattern")) and not re.search(pattern, file_info.filename, re.IGNORECASE):
+            return False
 
         # Check dataset pattern
         if pattern := when.get("dataset_pattern"):
@@ -425,13 +420,15 @@ class RuleEngine:
                 return False
 
         # Check file size constraints
-        if min_gb := when.get("file_size_min_gb"):
-            if file_info.file_size_gb is None or file_info.file_size_gb < min_gb:
-                return False
+        if (min_gb := when.get("file_size_min_gb")) and (
+            file_info.file_size_gb is None or file_info.file_size_gb < min_gb
+        ):
+            return False
 
-        if max_gb := when.get("file_size_max_gb"):
-            if file_info.file_size_gb is None or file_info.file_size_gb > max_gb:
-                return False
+        if (max_gb := when.get("file_size_max_gb")) and (
+            file_info.file_size_gb is None or file_info.file_size_gb > max_gb
+        ):
+            return False
 
         # Check platform constraint — check claims since fields aren't set until evaluation
         if platform := when.get("platform"):
@@ -440,9 +437,8 @@ class RuleEngine:
                 return False
 
         # Check file format constraint
-        if file_format := when.get("file_format"):
-            if file_info.file_format != file_format:
-                return False
+        if (file_format := when.get("file_format")) and file_info.file_format != file_format:
+            return False
 
         # Check modality_not_set — true unless data_modality already has a
         # definitive declaration (a real value or an explicit not_applicable; a
@@ -467,24 +463,27 @@ class RuleEngine:
                 return False
 
         # Check header section (tier 3) — skip if checking for absence
-        if rule.scope == "header" and when.get("header_section") and not when.get("header_absent"):
-            if not self._match_bam_header(when, file_info):
-                return False
+        if (
+            rule.scope == "header"
+            and when.get("header_section")
+            and not when.get("header_absent")
+            and not self._match_bam_header(when, file_info)
+        ):
+            return False
 
         # Check VCF header (tier 3)
-        if rule.scope == "vcf_header" and when.get("vcf_header_type"):
-            if not self._match_vcf_header(when, file_info):
-                return False
+        if rule.scope == "vcf_header" and when.get("vcf_header_type") and not self._match_vcf_header(when, file_info):
+            return False
 
         # Check FASTQ header (tier 3)
-        if rule.scope == "fastq_header" and when.get("fastq_pattern"):
-            if not self._match_fastq_header(when, file_info):
-                return False
+        if rule.scope == "fastq_header" and when.get("fastq_pattern") and not self._match_fastq_header(when, file_info):
+            return False
 
-        # Check header absence (for unaligned detection)
-        if when.get("header_absent"):
-            if not self._check_header_absent(when, file_info):
-                return False
+        # Check header absence (for unaligned detection). Kept as a guard clause
+        # (if ... : return False) to match the preceding checks rather than folding
+        # into `return not (...)`, which reads worse in this run of guards.
+        if when.get("header_absent") and not self._check_header_absent(when, file_info):  # noqa: SIM103
+            return False
 
         return True
 
@@ -592,9 +591,10 @@ class RuleEngine:
             conditions = assay_rule.conditions
 
             # Check matched_rules_any condition
-            if matched_any := conditions.get("matched_rules_any"):
-                if not any(r in result.rules_matched for r in matched_any):
-                    continue
+            if (matched_any := conditions.get("matched_rules_any")) and not any(
+                r in result.rules_matched for r in matched_any
+            ):
+                continue
 
             # Check data_modality_contains condition
             if modality_contains := conditions.get("data_modality_contains"):
@@ -604,39 +604,36 @@ class RuleEngine:
                     continue
 
             # Check data_modality exact match condition
-            if modality := conditions.get("data_modality"):
-                if result.data_modality != modality:
-                    continue
+            if (modality := conditions.get("data_modality")) and result.data_modality != modality:
+                continue
 
             # Check platform condition
-            if platform := conditions.get("platform"):
-                if result.platform != platform:
-                    continue
+            if (platform := conditions.get("platform")) and result.platform != platform:
+                continue
 
             # Check platform_in condition
-            if platform_in := conditions.get("platform_in"):
-                if result.platform not in platform_in:
-                    continue
+            if (platform_in := conditions.get("platform_in")) and result.platform not in platform_in:
+                continue
 
             # Check file_format condition
-            if file_format := conditions.get("file_format"):
-                if file_info.file_format != file_format:
-                    continue
+            if (file_format := conditions.get("file_format")) and file_info.file_format != file_format:
+                continue
 
             # Check file_format_not condition
-            if file_format_not := conditions.get("file_format_not"):
-                if file_info.file_format == file_format_not:
-                    continue
+            if (file_format_not := conditions.get("file_format_not")) and file_info.file_format == file_format_not:
+                continue
 
             # Check file_size_gb_gt condition
-            if size_gt := conditions.get("file_size_gb_gt"):
-                if file_info.file_size_gb is None or file_info.file_size_gb <= size_gt:
-                    continue
+            if (size_gt := conditions.get("file_size_gb_gt")) and (
+                file_info.file_size_gb is None or file_info.file_size_gb <= size_gt
+            ):
+                continue
 
             # Check file_size_gb_lt condition
-            if size_lt := conditions.get("file_size_gb_lt"):
-                if file_info.file_size_gb is None or file_info.file_size_gb >= size_lt:
-                    continue
+            if (size_lt := conditions.get("file_size_gb_lt")) and (
+                file_info.file_size_gb is None or file_info.file_size_gb >= size_lt
+            ):
+                continue
 
             # All conditions passed — apply and record evidence
             result.set_field("assay_type", assay_rule.assay_type)

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -499,6 +499,5 @@ def reload_rules(rules_path: str | Path | None = None) -> UnifiedRules:
     if rules_path is None:
         _default_loader = RuleLoader()
         return _default_loader.load()
-    else:
-        loader = RuleLoader(rules_path)
-        return loader.load()
+    loader = RuleLoader(rules_path)
+    return loader.load()

--- a/src/meta_disco/schema_vocab.py
+++ b/src/meta_disco/schema_vocab.py
@@ -9,7 +9,7 @@ checkout. The rule engine's emitted values are validated against these enums (se
 The ``schema/`` project is the LinkML tooling that maintains and validates it.
 """
 
-from functools import lru_cache
+from functools import cache
 from importlib.resources import files
 
 import yaml
@@ -63,7 +63,7 @@ def default_schema_path():
     return files(f"{__package__}.schema") / "classification.yaml"
 
 
-@lru_cache(maxsize=None)
+@cache
 def _load_enums() -> dict[str, frozenset[str]]:
     """Load all enums from the schema as ``{enum_name: {permissible values}}``."""
     resource = None

--- a/src/meta_disco/validators/header_extractors.py
+++ b/src/meta_disco/validators/header_extractors.py
@@ -172,13 +172,13 @@ def has_sam_section(header: SAMHeader, section: str) -> bool:
     """
     if section == "@HD":
         return header.hd is not None
-    elif section == "@SQ":
+    if section == "@SQ":
         return header.sq is not None and len(header.sq) > 0
-    elif section == "@RG":
+    if section == "@RG":
         return header.rg is not None and len(header.rg) > 0
-    elif section == "@PG":
+    if section == "@PG":
         return header.pg is not None and len(header.pg) > 0
-    elif section == "@CO":
+    if section == "@CO":
         return header.co is not None and len(header.co) > 0
     return False
 
@@ -293,12 +293,12 @@ def match_vcf_header_pattern(header: VCFHeader, header_type: str, pattern: str) 
 
     if header_type == "##reference" and header.reference:
         return bool(compiled.search(header.reference))
-    elif header_type == "##source" and header.source:
+    if header_type == "##source" and header.source:
         return bool(compiled.search(header.source))
-    elif header_type == "##contig" and header.contigs:
+    if header_type == "##contig" and header.contigs:
         for contig in header.contigs:
             # Check all fields in the contig line
-            for key, value in contig.items():
+            for _key, value in contig.items():
                 if compiled.search(str(value)):
                     return True
     elif header_type == "##INFO" and header.info_fields:

--- a/tests/test_header_classifier.py
+++ b/tests/test_header_classifier.py
@@ -63,7 +63,7 @@ class TestExtractArchiveAccession:
 
     def test_ddbj_accession(self):
         """Extract DDBJ (DRR) accession."""
-        accession, source, remainder = extract_archive_accession("@DRR000001.1 some_data")
+        accession, source, _remainder = extract_archive_accession("@DRR000001.1 some_data")
         assert accession == "DRR000001"
         assert source == "DDBJ"
 

--- a/tests/test_output_shape.py
+++ b/tests/test_output_shape.py
@@ -259,7 +259,7 @@ def test_output_structural_contract(output):
             )
             assert isinstance(entry["evidence"], list)
             for ev in entry["evidence"]:
-                assert EVIDENCE_KEYS <= set(ev), f"{ftype}.{field} evidence: {set(ev)}"
+                assert set(ev) >= EVIDENCE_KEYS, f"{ftype}.{field} evidence: {set(ev)}"
 
 
 def test_output_values_in_vocabulary(output):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -589,7 +589,7 @@ class TestFileTypeConfigs:
         def _explode(evidence_dir, md5, **kwargs):
             if md5 == boom_md5:
                 raise TypeError("a bug in the parser, not a fetch failure")
-            return None  # silent drop, no cause
+            return  # silent drop, no cause
 
         config = dataclasses.replace(FILE_TYPE_REGISTRY["gfa"], fetcher=_explode)
         input_path = tmp_path / "in.json"

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -402,7 +402,7 @@ class TestConflictingClassificationFields:
         not the value slot) and the structured competing_values field."""
         result = engine.classify_extended(FileInfo(filename="CHM13.hg38.gff3.gz"))
         evidence = result.field_evidence.get("reference_assembly", [])
-        conflict = [e for e in evidence if "conflicting_" in e["rule_id"]][0]
+        conflict = next(e for e in evidence if "conflicting_" in e["rule_id"])
         assert conflict["status"] == NOT_CLASSIFIED
         assert "value" not in conflict
         assert set(conflict["competing_values"]) == {"GRCh38", "CHM13"}
@@ -411,7 +411,7 @@ class TestConflictingClassificationFields:
         """Every evidence entry should include the value that was set."""
         result = engine.classify_extended(FileInfo(filename="sample.GRCh38.bed"))
         evidence = result.field_evidence.get("reference_assembly", [])
-        ref_entry = [e for e in evidence if e["rule_id"] == "filename_ref_grch38"][0]
+        ref_entry = next(e for e in evidence if e["rule_id"] == "filename_ref_grch38")
         assert ref_entry["value"] == "GRCh38"
 
 

--- a/tests/test_rule_vocabulary.py
+++ b/tests/test_rule_vocabulary.py
@@ -366,7 +366,7 @@ def test_loader_rejects_unknown_then_status_field(tmp_path):
             "then": {"status": {"data_modalty": "not_applicable"}},  # typo
         },
     )
-    with pytest.raises(ValueError, match="unknown 'then.status' field"):
+    with pytest.raises(ValueError, match=r"unknown 'then\.status' field"):
         RuleLoader(path).load()
 
 
@@ -384,7 +384,7 @@ def test_loader_rejects_non_authorable_then_status_value(tmp_path, bad_status):
             "then": {"status": {"data_modality": bad_status}},
         },
     )
-    with pytest.raises(ValueError, match="'then.status' values must be one of"):
+    with pytest.raises(ValueError, match=r"'then\.status' values must be one of"):
         RuleLoader(path).load()
 
 
@@ -419,7 +419,7 @@ def test_loader_rejects_non_mapping_then_status(tmp_path, bad_status_block):
             "then": {"status": bad_status_block},
         },
     )
-    with pytest.raises(ValueError, match="'then.status' must be a mapping"):
+    with pytest.raises(ValueError, match=r"'then\.status' must be a mapping"):
         RuleLoader(path).load()
 
 

--- a/tests/test_validate_metadata_script.py
+++ b/tests/test_validate_metadata_script.py
@@ -8,9 +8,9 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-import validate_metadata  # noqa: E402
+import validate_metadata
 
-from tests.metadata_fixtures import valid_record as _valid  # noqa: E402
+from tests.metadata_fixtures import valid_record as _valid
 
 
 def _write(path, records, key="files"):


### PR DESCRIPTION
Closes #178

## What changed
Removed **19** readability codes from the ruff burn-down ignore list and fixed all ~64 flagged sites; kept **1** code ignored with a documented rationale. Also dropped the already-clean SIM115 from the ignore list.

**Fixed & enforced:** SIM102 (nested-guard collapses), SIM108 (if/else→ternary), SIM118 (`key in d.keys()`→`key in d`), SIM300 (yoda), RET501/504/505/508, PIE810 (tuple `startswith`/`endswith`), C416/C420, B007, UP024 (`IOError`→`OSError`), UP033 (`@lru_cache(maxsize=None)`→`@cache`), UP035 (`collections.abc` import), RUF015 (`next(iter(...))`), RUF043 (escape literal `.` in pytest `match=` patterns), RUF059, RUF100.

**Kept ignored (permanent, rationale in pyproject):** RUF022 — both `__all__` lists use intentional ordering (`src/meta_disco/__init__.py` groups by source module; `validators/__init__.py` has explicit `# Contig length validators` / `# Header extractors` comment sections) that alphabetical sorting would degrade.

## Why
Clears the last of the three burn-down blocks from #175's ignore list so the SIM/RET/PIE/C4/UP/RUF readability families are enforced across the codebase and new violations can't regress.

## Assumptions I made
- **SIM102 in `rule_engine.py` was hand-collapsed (10 sites).** ruff won't autofix these because they move a walrus binding into a compound `and`; the collapse is behavior-identical by short-circuit. The 3 genuinely-nested guards (dataset_pattern, platform, modality/reference_not_set) were correctly left nested by ruff and stay nested.
- **Re-export noqa restored precisely.** The RUF100 autofix stripped a statement-level `# noqa: F401 re-exported for backward compat` from `header_classifier.py`, exposing F401 on two re-exported parsers. I restored it as **per-line** noqas on just those two names (RUF100-safe, and more precise than the original blanket form — the other 4 imports are used and now unguarded). These two re-exports have **no in-repo importers today** — a candidate for future removal, preserved here to keep #178 scoped to style.
- **One SIM103 kept via noqa** (`rule_engine.py`): the final guard stays `if ...: return False` to match the run of preceding guard clauses rather than fold into `return not (...)`.

## How to verify
Definition of done from #178:
- [x] **Each code fixed & removed from ignore, or kept with a permanent-ignore rationale** — 19 fixed, RUF022 kept (see pyproject comment).
- [x] **No temporary burn-down entries remain** — only RUF022 (a permanent decision) stays in the readability section.
- [x] **`make test-all` passes** — 588 root + 10 schema.

Local check:
```
git checkout noopdog/178-readability-burndown
make lint          # -> All checks passed! (19 codes now enforced)
make format-check  # -> all formatted
make test-all      # -> 588 + 10 passing
```

**Classification output is unchanged** (verified): the offline `classify_auxiliary_genomic` produces byte-identical results (21,266 records, exact match) before and after this PR, confirming the `rule_engine.py` guard rewrites change no behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)