### PR TITLE
Migrate schema/ to pathlib, fixing 26 ruff errors (#190)

### DIFF
--- a/schema/scripts/validate_outputs.py
+++ b/schema/scripts/validate_outputs.py
@@ -1,8 +1,8 @@
 # scripts/validate_outputs.py
 
 import logging
-import os
 import sys
+from pathlib import Path
 
 import yaml
 from linkml.validator import Validator
@@ -12,20 +12,20 @@ logging.basicConfig(level=logging.ERROR)
 
 def validate_instance(instance_file: str, schema_file: str) -> bool:
     try:
-        if not os.path.exists(instance_file):
+        if not Path(instance_file).exists():
             print(f"File not found: {instance_file}")
             return False
 
         # Callers can pass an explicit schema path now, so a wrong one would
         # otherwise fall into the broad handler as a generic "Exception during
         # validation" — check it here for a clear message.
-        if not os.path.exists(schema_file):
+        if not Path(schema_file).exists():
             print(f"Schema not found: {schema_file}")
             return False
 
         # Load the YAML file contents first
         try:
-            with open(instance_file, 'r') as f:
+            with Path(instance_file).open() as f:
                 instance_data = yaml.safe_load(f)
         except yaml.YAMLError as e:
             print(f"❌ {instance_file}: INVALID (YAML parsing error)")
@@ -44,11 +44,10 @@ def validate_instance(instance_file: str, schema_file: str) -> bool:
         if not report.results:
             print(f"✅ {instance_file}: VALID")
             return True
-        else:
-            print(f"❌ {instance_file}: INVALID")
-            for result in report.results:
-                print(f"  - {result.severity}: {result.message}")
-            return False
+        print(f"❌ {instance_file}: INVALID")
+        for result in report.results:
+            print(f"  - {result.severity}: {result.message}")
+        return False
 
     except Exception as e:
         logging.error(f"Exception during validation of {instance_file}", exc_info=True)
@@ -70,8 +69,9 @@ def main():
     if len(sys.argv) >= 3:
         schema_path = sys.argv[2]
     else:
-        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        schema_path = os.path.join(repo_root, "src/meta_disco/schema/classification.yaml")
+        # parents[2] of schema/scripts/validate_outputs.py is the repo root.
+        repo_root = Path(__file__).resolve().parents[2]
+        schema_path = str(repo_root / "src/meta_disco/schema/classification.yaml")
 
     result = validate_instance(instance_path, schema_path)
     sys.exit(0 if result else 1)  # Exit with 0 (success) or 1 (failure)

--- a/schema/scripts/validate_outputs.py
+++ b/schema/scripts/validate_outputs.py
@@ -12,14 +12,14 @@ logging.basicConfig(level=logging.ERROR)
 
 def validate_instance(instance_file: str, schema_file: str) -> bool:
     try:
-        if not Path(instance_file).exists():
+        if not Path(instance_file).is_file():
             print(f"File not found: {instance_file}")
             return False
 
         # Callers can pass an explicit schema path now, so a wrong one would
         # otherwise fall into the broad handler as a generic "Exception during
         # validation" — check it here for a clear message.
-        if not Path(schema_file).exists():
+        if not Path(schema_file).is_file():
             print(f"Schema not found: {schema_file}")
             return False
 

--- a/schema/tests/test_metadata_model_drift.py
+++ b/schema/tests/test_metadata_model_drift.py
@@ -8,24 +8,22 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
-_SCHEMA_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SCHEMA_ROOT = Path(__file__).resolve().parent.parent
 # The path `make gen-metadata` passes to gen-pydantic, verbatim, so the embedded
 # `source_file` line in the output matches the committed file byte-for-byte.
 _REL_SCHEMA = "../src/meta_disco/schema/metadata.yaml"
-_COMMITTED_MODEL = os.path.join(
-    _SCHEMA_ROOT, "..", "src", "meta_disco", "schema", "metadata_model.py"
-)
+_COMMITTED_MODEL = _SCHEMA_ROOT.parent / "src" / "meta_disco" / "schema" / "metadata_model.py"
 
 
 # The gen-pydantic console script from the same venv as the test interpreter (the
 # schema env, which has linkml) — hermetic, and exactly what `make gen-metadata` runs.
 # On Windows the console script is gen-pydantic.exe.
-_GEN_PYDANTIC = os.path.join(
-    os.path.dirname(sys.executable),
-    "gen-pydantic.exe" if os.name == "nt" else "gen-pydantic",
+_GEN_PYDANTIC = Path(sys.executable).parent / (
+    "gen-pydantic.exe" if os.name == "nt" else "gen-pydantic"
 )
 
 
@@ -33,7 +31,7 @@ def test_committed_model_matches_schema():
     # This needs the schema env's linkml (gen-pydantic). Skip cleanly if run under an
     # interpreter without it (e.g. an explicit `pytest schema/tests` in the root env),
     # so it degrades to a skip rather than a FileNotFoundError.
-    if not os.path.exists(_GEN_PYDANTIC):
+    if not _GEN_PYDANTIC.exists():
         pytest.skip("gen-pydantic not found; run under the schema uv env (make test-schema)")
     # Run from the schema/ dir with the same relative path `make gen-metadata` uses,
     # so the regenerated text (including the embedded source_file) is comparable
@@ -43,7 +41,7 @@ def test_committed_model_matches_schema():
         cwd=_SCHEMA_ROOT, capture_output=True, text=True,
     )
     assert result.returncode == 0, result.stderr
-    with open(_COMMITTED_MODEL) as f:
+    with _COMMITTED_MODEL.open() as f:
         committed = f.read()
     # Byte-for-byte: the comparison is reproducible because schema/uv.lock pins the
     # linkml version (the generated header carries linkml's metamodel_version). If a

--- a/schema/tests/test_metadata_model_drift.py
+++ b/schema/tests/test_metadata_model_drift.py
@@ -31,7 +31,7 @@ def test_committed_model_matches_schema():
     # This needs the schema env's linkml (gen-pydantic). Skip cleanly if run under an
     # interpreter without it (e.g. an explicit `pytest schema/tests` in the root env),
     # so it degrades to a skip rather than a FileNotFoundError.
-    if not _GEN_PYDANTIC.exists():
+    if not _GEN_PYDANTIC.is_file():
         pytest.skip("gen-pydantic not found; run under the schema uv env (make test-schema)")
     # Run from the schema/ dir with the same relative path `make gen-metadata` uses,
     # so the regenerated text (including the embedded source_file) is comparable

--- a/schema/tests/test_validation.py
+++ b/schema/tests/test_validation.py
@@ -1,14 +1,12 @@
 # tests/test_validation.py
 
-import os
 import subprocess
 import sys
+from pathlib import Path
 
-_VALIDATE = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-    "scripts/validate_outputs.py",
-)
-_DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_data")
+_HERE = Path(__file__).resolve().parent
+_VALIDATE = _HERE.parent / "scripts" / "validate_outputs.py"
+_DATA = _HERE / "test_data"
 
 
 def _run(instance):
@@ -16,7 +14,7 @@ def _run(instance):
     # than `uv run` — keeps the test hermetic and off an external uv binary, and
     # avoids nesting a uv invocation inside the uv run that already launched pytest.
     return subprocess.run(
-        [sys.executable, _VALIDATE, os.path.join(_DATA, instance)],
+        [sys.executable, _VALIDATE, _DATA / instance],
         capture_output=True, text=True,
     )
 


### PR DESCRIPTION
Closes #190

## What changed
Migrated the three `schema/` files that used `os.path` to `pathlib.Path`, clearing all 26 ruff errors that `make lint-schema` reported on `main` (24× `PTH`, plus `UP015` and `RET505`):

- **`schema/scripts/validate_outputs.py`** — `Path(...).exists()` / `Path(...).open()`; the default schema path (bare-CLI branch) is now `Path(__file__).resolve().parents[2] / "src/meta_disco/schema/classification.yaml"`, wrapped in `str(...)`. Also dropped an `else`-after-`return` (`RET505`) and a redundant `"r"` open mode (`UP015`).
- **`schema/tests/test_metadata_model_drift.py`** — module-level path constants rebuilt on `Path`; kept `import os` (still used for `os.name`).
- **`schema/tests/test_validation.py`** — path constants on `Path`; dropped now-unused `import os`.

No config change.

## Why
`schema/` has no `[tool.ruff]` block, so `make lint-schema` resolves config upward to the **root** `pyproject.toml` — the shared Clever Canary rule set with `PTH` enabled. The schema code predated that standard and hadn't been migrated, so `make lint-schema` (and therefore `make lint-all`) was red for a reason unrelated to the #179 Pyright adoption. This is the schema half of the lint burn-down; fixing it makes `make lint-all` green end-to-end, which a fully-enforcing CI (#180) needs.

## Assumptions I made
- **Inheriting the root ruff config is intended**, not an accident to paper over — one shared standard across both uv projects. So the right fix is to migrate the code, not to add a `[tool.ruff]` block that would fork the standard for `schema/`. (If the team actually wants `schema/` on a *different*, narrower rule set, that's a separate decision — this PR does not make it.)
- **`schema_path` should stay a `str`.** The function is annotated `schema_file: str`, the sibling branch `schema_path = sys.argv[2]` yields a `str`, and it flows to linkml's `Validator(schema=...)`. Wrapping the `Path` in `str(...)` keeps both branches the same type.
- **`resolve()` in place of `abspath()` is acceptable** (it follows symlinks; `abspath` did not). The byte-for-byte model-drift comparison does not depend on it — that comes from the unchanged relative `_REL_SCHEMA` string gen-pydantic embeds. Flagged in review and accepted as the more-correct idiom.
- **Per-file path derivation is the right altitude.** The three files anchor to different roots at different tree depths and two must stay hermetic (they spawn subprocesses); a shared path module would be over-engineering. Left as-is.

## How to verify
Definition of done from #190:
- [x] **Triage the 26 `schema/` ruff findings** — all 26 are `PTH`/`UP015`/`RET505` in 3 files (see What changed).
- [x] **Fix or justifiably ignore each so `make lint-schema` is green** — fixed by pathlib migration; none ignored.
- [x] **`make lint-all` green end to end** — verified below.

Steps a reviewer can run from the repo root:

1. `make lint-schema` → **All checks passed!** (was `Found 26 errors.` on `main`)
2. `make lint-all` → green end-to-end: ruff root clean, pyright `0 errors, 23 warnings` (the #189 burn-down warnings, expected), ruff schema **All checks passed!**
3. `make test-all` → **598 passed** (588 root + 10 schema); the schema suite exercises the migrated path constants directly (`test_validation.py` shells out to `validate_outputs.py`, `test_metadata_model_drift.py` opens `_COMMITTED_MODEL`).
4. Smoke the CLI script's own path logic (from `schema/`):
   - `uv run python scripts/validate_outputs.py tests/test_data/valid_file.yaml` → `✅ … VALID` (exercises the new `parents[2]` **default** schema-path branch)
   - `uv run python scripts/validate_outputs.py tests/test_data/valid_file.yaml /no/such.yaml` → `Schema not found: /no/such.yaml` (exercises the `Path(schema_file).exists()` guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)