### PR TITLE
Add GitHub Actions CI to enforce lint/format/type/tests on PRs (#180)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+# Continuous integration: enforce the same lint/format/type/test gates on every
+# PR that were previously local-only make targets (issue #180).
+#
+# CI is a thin wrapper over the Makefile so the checks never drift from what a
+# developer runs locally:
+#   make lint-all     -> ruff check (root + schema) + pyright
+#   make format-check -> ruff format --check (root)
+#   make test-all     -> pytest (root + schema, two independent uv projects)
+#
+# Python is pinned to 3.10 — the project's requires-python floor and the
+# [tool.pyright] pythonVersion — so CI exercises the minimum we claim to support.
+#
+# NOTE FOR WHOEVER ADDS release-please (or the shared clevercanary/.github
+# workflows, see issue #180): give release-please a GitHub App token or PAT, not
+# the default GITHUB_TOKEN. Events raised by GITHUB_TOKEN do not trigger further
+# workflow runs (GitHub loop-prevention), so release-please's release PR would
+# never trigger this CI. If this CI is a *required* status check, that release PR
+# would sit at "Expected — waiting for status" forever and could never merge.
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel a superseded run when new commits land on the same PR/branch.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv (with Python 3.10)
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.10"
+          enable-cache: true
+
+      # Two independent uv projects (root + schema/), each with its own lockfile.
+      - name: Sync root project
+        run: uv sync --locked
+      - name: Sync schema project
+        run: uv sync --locked --directory schema
+
+      - name: Lint + type check (ruff check + pyright)
+        run: make lint-all
+      - name: Format check (ruff format --check)
+        run: make format-check
+      - name: Tests (root + schema)
+        run: make test-all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,10 @@ reportOptionalSubscript = "warning"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    # End-to-end eval tests that read real fetched headers from the local
+    # evidence cache (data/evidence/anvil/, gitignored). tests/conftest.py
+    # auto-skips them when that cache is absent — e.g. in CI, where a miss would
+    # otherwise fall through to a live S3 + samtools fetch. See issue #180.
+    "e2e: needs the local evidence cache; auto-skipped when it is absent",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+# tests/conftest.py
+
+from pathlib import Path
+
+import pytest
+
+# The @pytest.mark.e2e eval tests classify by MD5 through the script functions,
+# which read real fetched headers from the evidence cache ClassifyPipeline writes
+# under data/evidence/anvil/ (evidence_base default in pipeline.py; gitignored).
+# Without that cache a lookup misses and falls through to a live S3 + samtools
+# fetch of the real (hundreds-of-GB) files — unavailable in CI. We mirror the
+# code's own CWD-relative default so the gate is present exactly when the code
+# would find the cache: run these where it exists, skip them where it does not.
+_EVIDENCE_CACHE = Path("data/evidence/anvil")
+
+
+def pytest_collection_modifyitems(items):
+    """Skip e2e-marked tests when the local evidence cache is absent (e.g. CI).
+
+    pytest injects only the hook arguments a plugin declares, so we request just
+    `items` and omit the unused `session`/`config`.
+    """
+    if _EVIDENCE_CACHE.is_dir():
+        return
+    skip_e2e = pytest.mark.skip(
+        reason=f"evidence cache {_EVIDENCE_CACHE}/ absent; e2e eval tests are local-only (issue #180)"
+    )
+    for item in items:
+        if "e2e" in item.keywords:
+            item.add_marker(skip_e2e)

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -9,7 +9,6 @@ For rule-engine-only classifiers (BED, images, auxiliary), the input
 is a FileInfo and the output is an ExtendedClassificationResult.
 """
 
-import json
 import sys
 from pathlib import Path
 
@@ -65,6 +64,7 @@ def assert_output_format(record):
 # =============================================================================
 
 
+@pytest.mark.e2e
 class TestBamE2E:
     """End-to-end BAM classification from cached headers."""
 
@@ -167,6 +167,7 @@ class TestBamE2E:
 # =============================================================================
 
 
+@pytest.mark.e2e
 class TestVcfE2E:
     """End-to-end VCF classification from cached headers."""
 
@@ -218,6 +219,7 @@ class TestVcfE2E:
 # =============================================================================
 
 
+@pytest.mark.e2e
 class TestFastqE2E:
     """End-to-end FASTQ classification from cached read names."""
 
@@ -716,6 +718,7 @@ class TestGfaSegmentTagParsing:
 # =============================================================================
 
 
+@pytest.mark.e2e
 class TestFastaE2E:
     """End-to-end FASTA classification from cached contig names."""
 


### PR DESCRIPTION
## What changed
Adds `.github/workflows/ci.yml` — the repo's first GitHub Actions CI. One job on `ubuntu-latest`, Python 3.10, triggered on `pull_request → main` and `push → main`. It runs the checks that were previously local-only make targets:

- `make lint-all` → ruff check (root + schema) + pyright
- `make format-check` → ruff format --check (root)
- `make test-all` → pytest (root + schema, two independent uv projects)

Before the checks, it installs uv via `astral-sh/setup-uv@v7`, pins Python 3.10, and runs `uv sync --locked` for both the root and `schema/` projects.

## Why
Issue #180: checks ran only locally and were not enforced on PRs; the shared standard requires CI enforcement. CI is written as a thin wrapper over the existing make targets so the enforced checks never drift from what a developer runs locally.

## Assumptions I made
- **Reuse make targets over inlining raw commands** (your call in planning): steps invoke `make lint-all/format-check/test-all` rather than duplicating `uv run ruff …` etc., so there's a single source of truth.
- **Python 3.10** — the `requires-python` floor and `[tool.pyright] pythonVersion`. CI exercises the minimum version we claim to support.
- **Action pins = latest floating majors** (`checkout@v7`, `setup-uv@v7`), API-verified to exist. setup-uv publishes `v8` only as exact patches (no `v8` floating tag), so v7 is its newest floating major; it still exposes the `python-version` + `enable-cache` inputs used here.
- **`uv sync --locked` is intentional**, not redundant with the make targets' auto-sync: it enforces lockfile currency and isolates install failures from check failures. Lockfiles are current today, so `--locked` passes.
- **No network/classification steps.** All `classify-*` targets need network header fetches; CI runs only the hermetic lint/format/type/test gates.
- **release-please token caveat is documented in a header comment**, not implemented here (no release-please in the repo yet): whoever adds it must give it an App/PAT token, because `GITHUB_TOKEN`-authored PRs don't trigger this CI and would stall on a required check.
- **Branch protection is not set by this PR** — it's a repo admin setting. Dave will mark the `checks` job required after the first green run (DoD item 2).
- **Pre-existing gap, not addressed here:** `format-check` covers root only; `schema/` Python is ruff-*lint*-checked but not *format*-checked. Out of scope for #180; file a follow-up if desired.

## How to verify
Definition of done from #180:

- [x] **Workflow runs ruff check, ruff format --check, pyright, make test-all on every PR** — verify the `CI` check runs on this very PR and passes. Locally, the same commands pass: `make lint-all` (0 errors), `make format-check` (all formatted), `make test-all` (588 root + 10 schema tests pass). To reproduce a failure gate: introduce a lint/format/type error or a failing test on a branch, open a PR, and confirm CI goes red.
- [ ] **Branch protection requires it before merge** — human/admin step: after this PR's CI is green, go to Settings → Branches → `main` and mark the `checks` status check required. (Not doable from the workflow file.)
- [ ] **Migrate to the shared reusable workflow once clevercanary/.github exists** — deferred by the issue itself until that repo exists; left as a future follow-up.

Closes #180
