### PR TITLE
Pyright burn-down PR2: None-handling at trust boundaries (#189)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,6 @@ exclude = ["src/meta_disco/schema/metadata_model.py", "**/__pycache__"]
 #     the Ruff burn-down. See #189 for the live per-rule site list. ---
 reportPossiblyUnboundVariable = "warning"
 reportArgumentType = "warning"
-reportReturnType = "warning"
-reportOptionalMemberAccess = "warning"
 reportOperatorIssue = "warning"
 reportOptionalSubscript = "warning"
 

--- a/src/meta_disco/metadata_schema.py
+++ b/src/meta_disco/metadata_schema.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from pydantic import ConfigDict, ValidationError
+from pydantic_core import ErrorDetails
 
 from .models import CLASSIFICATION_FIELDS, NOT_CLASSIFIED, build_field_entry
 from .schema.metadata_model import AnvilFileMetadataRecord
@@ -120,7 +121,7 @@ _TYPE_DESCRIPTIONS = {
 }
 
 
-def _format_error(err: dict) -> str:
+def _format_error(err: ErrorDetails) -> str:
     """Render one pydantic error dict as a value-independent ``"<field>: <why>"``.
 
     For every error type this schema can raise, the description comes from

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -12,7 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
-from typing import NamedTuple
+from typing import NamedTuple, TypeGuard
 
 from .fetchers import FetchError
 from .header_classifier import classify_without_content
@@ -300,7 +300,7 @@ class ClassifyPipeline:
 
         return [r for r in records if matches(r)]
 
-    def _is_cached(self, md5sum) -> bool:
+    def _is_cached(self, md5sum) -> TypeGuard[str]:
         """Check if evidence is cached (cheap file-existence check, no JSON parse).
 
         Only a well-formed md5 (lowercase-hex, 32 chars) can key real cached
@@ -335,7 +335,7 @@ class ClassifyPipeline:
         """Print how many files are already cached. Returns set of cached MD5s."""
         name = self.config.name.upper()
         print(f"Found {len(records)} {name} files with MD5 for header inspection")
-        cached_md5s = {r.get("file_md5sum") for r in records if self._is_cached(r.get("file_md5sum"))}
+        cached_md5s = {md5 for r in records if self._is_cached(md5 := r.get("file_md5sum"))}
         print(f"  Already cached: {len(cached_md5s)}")
         print(f"  Remaining to fetch: {len(records) - len(cached_md5s)}")
         return cached_md5s
@@ -374,6 +374,10 @@ class ClassifyPipeline:
         # The fields the fetch/classify path consumes — keep this set in sync with
         # metadata_schema.CLASSIFIER_RELEVANT_FIELDS (which decides what blocks).
         md5 = record.get("file_md5sum")
+        # Guaranteed a valid md5 string: file_md5sum is classifier-relevant, so the
+        # blocking-reasons guard above diverted the record if it were missing or
+        # mistyped. This asserts that contract post-condition for _fetch_and_classify.
+        assert isinstance(md5, str)
         file_name = record.get("file_name") or ""
         file_size = record.get("file_size")
         file_format = record.get("file_format") or ""

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -280,7 +280,9 @@ def evaluate_claims(claims: list[dict]) -> dict:
     # Assertive declarations disagree — check tiers
     max_tier = max(c.get("tier", 0) for c in assertive_claims)
     top_tier_claims = [c for c in assertive_claims if c.get("tier", 0) == max_tier]
-    top_tier_decls = {_claim_declaration(c) for c in top_tier_claims}
+    # Declarations are non-None here (real_claims already dropped None ones); the
+    # explicit filter restates that so the set is set[str] and sorted() type-checks.
+    top_tier_decls = {d for c in top_tier_claims if (d := _claim_declaration(c)) is not None}
 
     # NOT_APPLICABLE is a terminal declaration — it wins over real values
     # at the same tier without triggering a conflict (e.g., text_stats

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -198,7 +198,9 @@ class RuleLoader:
         # a plain filesystem Path. _is_default tailors that message: a missing bundled
         # resource means a broken install, a missing explicit path is the caller's.
         self._is_default = rules_path is None
-        self.rules_path = None if self._is_default else Path(rules_path)
+        # Narrow on rules_path directly (not self._is_default, which pyright can't
+        # correlate with rules_path's None-ness) so the Path() call type-checks.
+        self.rules_path = None if rules_path is None else Path(rules_path)
         self._rules: UnifiedRules | None = None
 
     def load(self) -> UnifiedRules:
@@ -215,9 +217,14 @@ class RuleLoader:
             return self._rules
 
         try:
-            if self._is_default:
-                self.rules_path = default_rules_resource()
-            text = self.rules_path.read_text(encoding="utf-8")
+            # rules_path is None only for the default (unresolved) case; resolve it
+            # to the bundled resource here. Binding to a local lets pyright narrow
+            # away None for the read_text() call below.
+            resource = self.rules_path
+            if resource is None:
+                resource = default_rules_resource()
+                self.rules_path = resource
+            text = resource.read_text(encoding="utf-8")
         except (FileNotFoundError, KeyError, ModuleNotFoundError) as e:
             # KeyError: a zip-backed resource (zipapp / un-unpacked wheel) reports a
             # missing entry that way rather than as FileNotFoundError. ModuleNotFoundError:


### PR DESCRIPTION
Part of #189 (Pyright burn-down). This is **PR2 of 3**; #189 stays open until PR3 clears the remaining test-only + control-flow warnings.

## What changed

Cleared the **six production-code** pyright warnings in the None-handling group, and removed `reportReturnType` + `reportOptionalMemberAccess` from the `[tool.pyright]` burn-down list (they now fail the gate as errors). No runtime behavior changes — every fix restates an existing invariant or annotates a boundary.

| Site | Rule | Fix |
|------|------|-----|
| `metadata_schema.py:124` | `reportArgumentType` | Annotate `_format_error(err: ErrorDetails)` — the exact element type `exc.errors()` returns (`from pydantic_core import ErrorDetails`). |
| `rule_loader.py:203` | `reportArgumentType` | Narrow on `rules_path is None` directly (pyright can't correlate `self._is_default` with the arg's None-ness) so `Path(rules_path)` type-checks. |
| `rule_loader.py:223-227` | `reportOptionalMemberAccess` | Bind a local `resource`, resolve the default in the `is None` branch, call `read_text()` on the narrowed local. **Removes the rule.** |
| `rule_engine.py:285` | `reportArgumentType` | Restate the non-None declaration invariant with a filter comprehension so `top_tier_decls` is `set[str]` and `sorted()` type-checks. |
| `pipeline.py:303,338` | `reportReturnType` | `_is_cached -> TypeGuard[str]` (True only after `isinstance` + `_MD5_RE` match) + walrus in `_print_cache_stats` → `set[str]`. **Removes the rule.** |
| `pipeline.py:380` | `reportArgumentType` | `assert isinstance(md5, str)` as the contract post-condition after the `classification_blocking_reasons` boundary guard. |

`reportArgumentType` stays on the burn-down list — its last site, `test_evals.py:212`, lands in PR3.

## Why

`make lint-all` runs pyright; the burn-down downgraded standard-mode rules to `warning` so the gate stays green while sites are fixed incrementally (#189, mirroring the Ruff burn-down). Each fix here promotes a rule back toward `error`.

## Assumptions I made

- **`assert isinstance(md5, str)` over `typing.cast`** (raised in review): the `classification_blocking_reasons` guard above is the trust boundary — it diverts any record with a missing/mistyped `file_md5sum` before this line. The assert states that post-condition. Chosen over `cast` because there is no `python -O` in the build (verified), so it throws loudly *at the boundary* per CLAUDE.md ("let the code throw… a stack trace at the real call site enables the fix"), rather than letting a regressed `None` crash deep in a fetcher. It is not a defensive default/coercion/catch-and-continue. The deeper fix (a typed record so `md5` is `str` by construction) is tracked separately in #172.
- **`_is_cached -> TypeGuard[str]` is behavior-neutral**: TypeGuard is static-only; the runtime still returns `bool`. Tests asserting `_is_cached(...) is True/False` are unaffected.
- **`_is_default` retained**: the `except` block reads it *after* `rules_path` may have been reassigned to the resolved resource, so `self.rules_path is None` would misroute the error message there.
- **The `rule_engine` None-filter can never fire** at runtime (`real_claims` already dropped None declarations upstream); it exists only to produce `set[str]`.

## How to verify

Maps to #189's definition of done for this group:

1. `make lint-all` (or `uv run pyright`) → **0 errors**. The 9 remaining warnings are exactly PR3 scope: `download_anvil_metadata.py` possibly-unbound ×3, `test_evals.py` ×4, `test_header_classifier.py:492`, `test_pipeline.py:539`.
2. `grep -E 'reportReturnType|reportOptionalMemberAccess' pyproject.toml` → **no matches** (both removed); `reportArgumentType` still present (PR3).
3. `make test-all` → 588 root + 10 schema tests pass (run locally with the evidence cache; e2e auto-skip in CI).
4. `make lint && make format-check` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)