### PR TITLE
Silence uv VIRTUAL_ENV mismatch warning in schema sub-make (#193)

### DIFF
--- a/schema/Makefile
+++ b/schema/Makefile
@@ -1,5 +1,12 @@
 # Makefile for meta-disco schema validation component
 
+# This is a separate uv project (its own schema/.venv with linkml, #164). When
+# invoked with the root project's venv activated — e.g. `make test-all` from the
+# repo root — the inherited VIRTUAL_ENV points at ../.venv and every `uv run`
+# below warns that it does not match schema/.venv before ignoring it. Drop it
+# from the recipe environment so uv silently resolves this project's own env.
+unexport VIRTUAL_ENV
+
 # The canonical schemas are package data of the root meta_disco package; this
 # tooling project references them from there (issue #164).
 SCHEMA = ../src/meta_disco/schema/classification.yaml


### PR DESCRIPTION
**Closes #193.**

## What changed

One line at the top of `schema/Makefile`: `unexport VIRTUAL_ENV` (with an explanatory comment).

## Why

`schema/` is a separate uv project with its own `schema/.venv` (it has linkml, #164). When its targets run with the root project's venv activated — e.g. `make test-all` / `make lint-all` from the repo root — the inherited `VIRTUAL_ENV=../.venv` doesn't match `schema/.venv`, so every `uv run` in `schema/Makefile` prints:

```
warning: `VIRTUAL_ENV=/…/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
```

`unexport VIRTUAL_ENV` drops the variable from the recipe environment, so uv silently resolves this project's own env. Because it's declared at the Makefile top level, it covers every schema recipe (`test`, `lint`, `gen`, `gen-metadata`, `validate`).

## Assumptions I made

- **`unexport` over `--active`:** `--active` would force schema to use the *activated root* env, which lacks linkml — wrong. Unsetting lets uv fall back to the schema project's own env, which is correct. The warning only ever appeared because the root env was activated; uv was already ignoring it and using the right env — this just removes the noise.
- **GNU Make:** `unexport` is a GNU Make directive. The repo already depends on GNU Make (`$(MAKE)`), and macOS ships GNU Make, so this is consistent.
- **CI is unaffected:** CI never activates a venv (no `VIRTUAL_ENV` to mismatch) and syncs the schema project via `uv sync --directory schema`, not through this Makefile. This is purely local-dev ergonomics.
- **No test added:** this is build tooling with no unit-test surface; verification is the observable "0 warnings, correct env, gate still green."

## How to verify

Definition of done: `make test-all` / `make lint-all` no longer print the `VIRTUAL_ENV` mismatch warning, and the schema suite still runs in the correct env.

1. With the root venv activated (`echo $VIRTUAL_ENV` → `…/meta-disco/.venv`), run `make test-all` → **no `VIRTUAL_ENV` warning**; schema suite reports `10 passed`.
2. `make lint-all` → no warning; `All checks passed` + pyright `0 errors, 0 warnings`.
3. `make -C schema test` directly → no warning; `10 passed` (confirms it uses `schema/.venv` with linkml, not the root env).
4. Sanity: `grep -c 'does not match' <(make -C schema test 2>&1)` → `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
