### PR TITLE
Parse AnVIL records into a typed model at the load boundary (#172)

### DIFF
--- a/docs/plans/172-typed-record-boundary.md
+++ b/docs/plans/172-typed-record-boundary.md
@@ -1,6 +1,6 @@
 # Plan — #172: Parse AnVIL records into a typed model at the load boundary
 
-> **As shipped (see PR #201):** this is the original plan; two details changed
+> **As shipped (see PR #201):** this is the original plan; three details changed
 > during implementation. (1) The invalid stream is a single `InvalidRecord`
 > dataclass carrying the coerced identity fields *and* the reasons — the separate
 > `LenientIdentityView` the plan describes was merged into it during `/simplify`,

--- a/docs/plans/172-typed-record-boundary.md
+++ b/docs/plans/172-typed-record-boundary.md
@@ -1,5 +1,15 @@
 # Plan — #172: Parse AnVIL records into a typed model at the load boundary
 
+> **As shipped (see PR #201):** this is the original plan; two details changed
+> during implementation. (1) The invalid stream is a single `InvalidRecord`
+> dataclass carrying the coerced identity fields *and* the reasons — the separate
+> `LenientIdentityView` the plan describes was merged into it during `/simplify`,
+> so there is no `(LenientIdentityView, reasons)` tuple. (2) `ClassifierRecord.file_size`
+> is `int` (a missing/null `file_size` is classifier-relevant and diverts), not
+> `int | None`. (3) `_process_single_record` takes the `ClassifierRecord | InvalidRecord`
+> union and dispatches on it, rather than handling only the valid stream. The
+> sections below retain the original wording.
+
 **Outcome:** the pipeline stops passing raw `dict`s around and re-deriving field
 safety at every consumer. Records become typed at the boundary — a valid record's
 classifier fields are `str`/`int` by construction — so the scattered

--- a/docs/plans/172-typed-record-boundary.md
+++ b/docs/plans/172-typed-record-boundary.md
@@ -1,0 +1,159 @@
+# Plan — #172: Parse AnVIL records into a typed model at the load boundary
+
+**Outcome:** the pipeline stops passing raw `dict`s around and re-deriving field
+safety at every consumer. Records become typed at the boundary — a valid record's
+classifier fields are `str`/`int` by construction — so the scattered
+`str(... or "")` guards added in #171 can be deleted.
+
+## Background
+
+#171 (issue #161) added input-metadata validation, then discovered a recurring
+corner case: we validate a record with the Pydantic model and *throw the model
+away, keeping the dict*. Every consumer then re-guards field type. `x or ""` guards
+`None` but not type, so a drifted non-string (`file_size` as `"123"`, a non-string
+`file_name`) slips into `.endswith` / slicing / the output row. #171 patched each
+site with a targeted `str(... or "")` coercion. The five current guard sites:
+
+- `pipeline.py:297-298` — `_filter_records` routing (`str()` before `.endswith`)
+- `pipeline.py:430,433` — `_build_record` output echo (`str()` on name/format)
+- `pipeline.py:472-477` — `update_progress` label (`str()` before slicing)
+- `pipeline.py:313` — `_is_cached` md5 type/format guard
+- `pipeline.py:380` — `assert isinstance(md5, str)` post-condition assert
+
+Root cause is one thing: *parse, don't validate* — construct a typed record at the
+boundary and pass that.
+
+## The one design decision to confirm first
+
+The issue's proposal says "valid → the typed model instance." But today's divert
+criterion is **narrower than full strict validation**:
+`classification_blocking_reasons` (metadata_schema.py:92) diverts a record to
+`validation_failed` **only** when a *classifier-relevant* field
+(`file_md5sum`, `file_name`, `file_size`, `file_format`) is invalid. A record that
+fails the full strict contract on a non-classifier field (e.g. `drs_uri`,
+`is_supplementary`) **still classifies today** — #161 deliberately marks only what
+it genuinely cannot classify and leaves the rest to the whole-corpus gate.
+
+So "valid == constructs the full strict `_ValidatedRecord`" would **change
+behavior**: records bad only on a provenance field would newly divert to
+`validation_failed`. That contradicts #161.
+
+**Recommendation — a strict "classifier view", not the full model.** Keep
+`classification_blocking_reasons` as the split criterion (behavior unchanged).
+Model only what the classifier actually reads. Rejected alternative: use the full
+`_ValidatedRecord` as the valid stream — simpler typing but silently widens the
+divert set, contradicting #161. This is the only choice that affects the whole
+shape; the rest of the plan assumes the classifier-view approach.
+
+## Design
+
+Split at the load boundary (in `run()`, after `_filter_records`) into two streams,
+each carrying a typed view instead of a raw dict:
+
+1. **Valid** (no blocking reasons) → a `ClassifierRecord`: a small typed record
+   over the classifier-relevant fields as strict types, plus the pass-through
+   identity fields `_build_record` echoes (`file_md5sum`, `dataset_title`,
+   `entry_id`). Because it is built only from a record that already passed
+   `classification_blocking_reasons`, its `file_name`/`file_format` are `str`,
+   `file_size` is `int | None`, `file_md5sum` is a valid md5 `str` — no guards.
+
+2. **Invalid** (has blocking reasons) → carried as `(view, reasons)` where `view`
+   is a `LenientIdentityView`: a dataclass whose `__post_init__` coerces
+   (`file_name = str(file_name or "")`, etc.). The coercion lives in one
+   constructor instead of at every echo site. This view is used only to build the
+   `validation_failed` output row and the progress label.
+
+Both views expose the same identity attributes (`file_name`, `file_format`,
+`file_md5sum`, `file_size`, `dataset_title`, `entry_id`) so `_build_record` and the
+progress label read `.attr` uniformly regardless of stream.
+
+### `_filter_records` runs before the split
+
+Routing (extension match) precedes parsing, so `_filter_records` still receives raw
+dicts and non-dict elements. Per the issue, it either reads through a lenient view
+or keeps its guard. **Recommendation:** keep its `str(... or "")` guard as-is — it
+is the routing boundary and must tolerate a non-dict/garbage element that never
+becomes either typed view. Document that this one guard is intentionally retained;
+remove the other four.
+
+## Implementation steps
+
+1. **Add the typed views.** In a new `src/meta_disco/records.py` (or extend
+   `metadata_schema.py`):
+   - `ClassifierRecord` — frozen dataclass (or pydantic model) with the four
+     classifier fields + identity pass-throughs. A `from_valid(record: dict)`
+     constructor; may `assert` the post-conditions the blocking check guarantees.
+   - `LenientIdentityView` — dataclass with `__post_init__` coercion of
+     `file_name`/`file_format` to `str`.
+   - Decide together whether both share a small `Protocol`/base exposing the
+     identity attrs, so `_build_record` is stream-agnostic.
+
+2. **Split in `run()`** (pipeline.py:202): after `_filter_records`, partition into
+   `valid: list[ClassifierRecord]` and `invalid: list[tuple[LenientIdentityView,
+   list[str]]]` using `classification_blocking_reasons`. Thread both into
+   `_run_parallel` (adjust its signature / a combined work-list that preserves the
+   pre-classify ordering and the cache-stats/limit/skip-cached steps, which
+   currently operate on `records`).
+
+3. **Rework `_process_single_record`** to take a `ClassifierRecord` (valid path
+   only). Drop the in-function `classification_blocking_reasons` call and the
+   `assert isinstance(md5, str)` (now guaranteed by the type). Read typed attrs.
+   The invalid stream no longer flows through here — its `validation_failed` row is
+   built directly from the `LenientIdentityView` + reasons.
+
+4. **Rework `_build_record`** to accept a view (typed or lenient) and read typed
+   attrs. Remove the `str(record.get(...) or "")` coercions and the docstring
+   paragraph that calls whole-row normalization "#172's job" (this *is* that job).
+
+5. **Rework `update_progress` / `_run_parallel`** to take the view's `file_name`
+   (already a `str`); drop the `str(file_name or "")[:45]` coercion, keep the
+   `[:45]` slice.
+
+6. **`_is_cached`** — md5 reaching it on the valid path is a valid md5 by
+   construction. Decide whether to keep the `isinstance/_MD5_RE` guard (it is also
+   called from `_print_cache_stats` over raw `r.get("file_md5sum")` at
+   pipeline.py:338, before the split). Likely keep it, since that call site still
+   sees raw dicts — or move cache-stats to run on the typed valid stream and then
+   the guard can go. Resolve during implementation; note whichever in the docstring.
+
+7. **Keep `_filter_records`'s guard** (routing boundary, see above). Remove the
+   other four #171 guards (steps 3–5).
+
+8. **Fix the stale doc reference.** `src/meta_disco/schema/classification.yaml:19`
+   says pipeline-Pydantic adoption is "a planned follow-up (#33)". #33 is closed and
+   was about enum coverage, not pipeline adoption. Repoint to #172 (or drop the line
+   once this lands). Grep for any other `#33` pipeline-adoption references.
+
+## Tests
+
+- `tests/test_pipeline.py` — add/extend: a drifted-but-classifier-relevant record
+  diverts to `validation_failed` (unchanged behavior); a record drifted only on a
+  non-classifier field (`drs_uri`) **still classifies** (guards the #161 behavior
+  the classifier-view design preserves); a valid record produces the same output
+  row as before (byte-for-byte on the echoed identity fields).
+- Unit tests for `ClassifierRecord.from_valid` and `LenientIdentityView` coercion
+  (null/non-string name/format → `str`).
+- Confirm no regression in `tests/test_metadata_schema.py` (validate_record /
+  blocking-reasons semantics unchanged — only the pipeline's *use* of them moves).
+- `make test-all` from repo root before pushing (root + schema suites).
+
+## Out of scope
+
+- The `validate_metadata` gate's `OSError` handling (an I/O boundary, not a
+  field-type issue) — noted in the issue.
+- Modeling the fastq scalar-hint extras inside `classifications` (#134 follow-up).
+- Changing what counts as a blocking violation — the divert *set* stays identical.
+
+## Definition of done
+
+- [ ] `ClassifierRecord` + `LenientIdentityView` typed views exist and are the only
+      things passed past the load boundary.
+- [ ] Valid/invalid split uses `classification_blocking_reasons`; divert behavior is
+      unchanged (non-classifier-field drift still classifies — test proves it).
+- [ ] The four #171 guards (steps 3–5) and the md5 `assert` are removed;
+      `_filter_records`'s routing guard is retained and documented as intentional.
+- [ ] `classification.yaml:19` stale #33 reference repointed to #172 (or removed).
+- [ ] Docstrings updated to match new behavior (`_build_record`, `_is_cached`,
+      `_process_single_record`); no docstring still claims normalization is "#172's
+      job".
+- [ ] `make test-all` green; new tests cover both streams and the #161 behavior.

--- a/docs/plans/172-typed-record-boundary.md
+++ b/docs/plans/172-typed-record-boundary.md
@@ -22,13 +22,13 @@ corner case: we validate a record with the Pydantic model and *throw the model
 away, keeping the dict*. Every consumer then re-guards field type. `x or ""` guards
 `None` but not type, so a drifted non-string (`file_size` as `"123"`, a non-string
 `file_name`) slips into `.endswith` / slicing / the output row. #171 patched each
-site with a targeted `str(... or "")` coercion. The five current guard sites:
+site with a targeted `str(... or "")` coercion. The five guard sites at plan time:
 
-- `pipeline.py:297-298` — `_filter_records` routing (`str()` before `.endswith`)
-- `pipeline.py:430,433` — `_build_record` output echo (`str()` on name/format)
-- `pipeline.py:472-477` — `update_progress` label (`str()` before slicing)
-- `pipeline.py:313` — `_is_cached` md5 type/format guard
-- `pipeline.py:380` — `assert isinstance(md5, str)` post-condition assert
+- `_filter_records` routing (`str()` before `.endswith`)
+- `_build_record` output echo (`str()` on name/format)
+- `update_progress` label (`str()` before slicing)
+- `_is_cached` md5 type/format guard
+- `_process_single_record`'s `assert isinstance(md5, str)` post-condition assert
 
 Root cause is one thing: *parse, don't validate* — construct a typed record at the
 boundary and pass that.
@@ -37,7 +37,7 @@ boundary and pass that.
 
 The issue's proposal says "valid → the typed model instance." But today's divert
 criterion is **narrower than full strict validation**:
-`classification_blocking_reasons` (metadata_schema.py:92) diverts a record to
+`classification_blocking_reasons` (metadata_schema.py) diverts a record to
 `validation_failed` **only** when a *classifier-relevant* field
 (`file_md5sum`, `file_name`, `file_size`, `file_format`) is invalid. A record that
 fails the full strict contract on a non-classifier field (e.g. `drs_uri`,
@@ -98,7 +98,7 @@ remove the other four.
    - Decide together whether both share a small `Protocol`/base exposing the
      identity attrs, so `_build_record` is stream-agnostic.
 
-2. **Split in `run()`** (pipeline.py:202): after `_filter_records`, partition into
+2. **Split in `run()`** (pipeline.py): after `_filter_records`, partition into
    `valid: list[ClassifierRecord]` and `invalid: list[tuple[LenientIdentityView,
    list[str]]]` using `classification_blocking_reasons`. Thread both into
    `_run_parallel` (adjust its signature / a combined work-list that preserves the
@@ -121,15 +121,15 @@ remove the other four.
 
 6. **`_is_cached`** — md5 reaching it on the valid path is a valid md5 by
    construction. Decide whether to keep the `isinstance/_MD5_RE` guard (it is also
-   called from `_print_cache_stats` over raw `r.get("file_md5sum")` at
-   pipeline.py:338, before the split). Likely keep it, since that call site still
+   called from `_print_cache_stats` over raw `r.get("file_md5sum")`, before the
+   split). Likely keep it, since that call site still
    sees raw dicts — or move cache-stats to run on the typed valid stream and then
    the guard can go. Resolve during implementation; note whichever in the docstring.
 
 7. **Keep `_filter_records`'s guard** (routing boundary, see above). Remove the
    other four #171 guards (steps 3–5).
 
-8. **Fix the stale doc reference.** `src/meta_disco/schema/classification.yaml:19`
+8. **Fix the stale doc reference.** `src/meta_disco/schema/classification.yaml`
    says pipeline-Pydantic adoption is "a planned follow-up (#33)". #33 is closed and
    was about enum coverage, not pipeline adoption. Repoint to #172 (or drop the line
    once this lands). Grep for any other `#33` pipeline-adoption references.
@@ -162,7 +162,7 @@ remove the other four.
       unchanged (non-classifier-field drift still classifies — test proves it).
 - [ ] The four #171 guards (steps 3–5) and the md5 `assert` are removed;
       `_filter_records`'s routing guard is retained and documented as intentional.
-- [ ] `classification.yaml:19` stale #33 reference repointed to #172 (or removed).
+- [ ] `classification.yaml` stale #33 reference repointed to #172 (or removed).
 - [ ] Docstrings updated to match new behavior (`_build_record`, `_is_cached`,
       `_process_single_record`); no docstring still claims normalization is "#172's
       job".

--- a/src/meta_disco/metadata_schema.py
+++ b/src/meta_disco/metadata_schema.py
@@ -43,9 +43,9 @@ _RECORD_LOC = "<record>"
 # stop this record from classifying (issue #161 review: the run marks only what it
 # genuinely cannot classify, the whole-corpus gate flags the rest).
 #
-# Keep in sync with the fields ClassifyPipeline._process_single_record reads and
-# passes to _fetch_and_classify. A field the run consumes but omitted here would
-# let a record bad on that field fetch instead of divert to validation_failed.
+# Keep in sync with the fields ClassifierRecord exposes to the fetch/classify path
+# (records.py). A field the run consumes but omitted here would let a record bad on
+# that field build a ClassifierRecord and fetch, instead of divert to validation_failed.
 CLASSIFIER_RELEVANT_FIELDS = frozenset(
     {
         "file_md5sum",

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -509,9 +509,7 @@ class ClassifyPipeline:
                     update_progress(outcome, item.file_name)
             else:
                 with ThreadPoolExecutor(max_workers=self.workers) as executor:
-                    future_to_item = {
-                        executor.submit(self._process_single_record, item): item for item in work
-                    }
+                    future_to_item = {executor.submit(self._process_single_record, item): item for item in work}
                     for future in as_completed(future_to_item):
                         item = future_to_item[future]
                         try:

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -342,10 +342,11 @@ class ClassifyPipeline:
 
         Only a well-formed md5 (lowercase-hex, 32 chars) can key real cached
         evidence, and ``get_evidence_path`` builds a filesystem path from the md5
-        (``md5sum[:2]`` / ``{md5sum}.json``). A null, non-string, or non-md5 value
-        therefore returns False — it cannot be cached, and this keeps the check safe
-        for a record headed to ``validation_failed`` (md5 is classifier-relevant), so
-        it never depends on what ``_filter_records`` admits.
+        (``md5sum[:2]`` / ``{md5sum}.json``). The type/format guard makes that path
+        construction safe regardless of the caller: today every caller passes a
+        ``ClassifierRecord``'s md5 (a valid md5 by construction), but the guard means
+        a null, non-string, or non-md5 value simply returns False rather than
+        building a bogus path.
         """
         if not isinstance(md5sum, str) or not _MD5_RE.match(md5sum):
             return False
@@ -371,15 +372,17 @@ class ClassifyPipeline:
     def _print_cache_stats(self, work: list[ClassifierRecord | InvalidRecord]) -> set[str]:
         """Print how many files are already cached. Returns set of cached MD5s.
 
-        Reads ``file_md5sum`` off both streams: a ``ClassifierRecord``'s is a valid
-        md5 by construction, an ``InvalidRecord``'s is the raw (possibly non-string)
-        value — which is why ``_is_cached`` keeps its own type/format guard.
+        Counts only the classifiable stream: an ``InvalidRecord`` is never fetched or
+        header-inspected, so including it would inflate "files with MD5" and
+        "Remaining to fetch". Every counted md5 is a ``ClassifierRecord``'s, a valid
+        md5 by construction.
         """
         name = self.config.name.upper()
-        print(f"Found {len(work)} {name} files with MD5 for header inspection")
-        cached_md5s = {w.file_md5sum for w in work if self._is_cached(w.file_md5sum)}
+        classifiable = [w for w in work if isinstance(w, ClassifierRecord)]
+        print(f"Found {len(classifiable)} {name} files with MD5 for header inspection")
+        cached_md5s = {w.file_md5sum for w in classifiable if self._is_cached(w.file_md5sum)}
         print(f"  Already cached: {len(cached_md5s)}")
-        print(f"  Remaining to fetch: {len(work) - len(cached_md5s)}")
+        print(f"  Remaining to fetch: {len(classifiable) - len(cached_md5s)}")
         return cached_md5s
 
     def _process_single_record(self, item: ClassifierRecord | InvalidRecord) -> RecordOutcome:

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -20,6 +20,7 @@ from .metadata_schema import (
     classification_blocking_reasons,
     validation_failed_classifications,
 )
+from .records import ClassifierRecord, InvalidRecord
 
 # A well-formed md5: lowercase hex, 32 chars — the same shape the input contract
 # (metadata.yaml file_md5sum) requires. Only such a value can key real cached
@@ -200,7 +201,13 @@ class ClassifyPipeline:
         self.skip_cached = skip_cached
 
     def run(self) -> list[dict]:
-        """Execute the full pipeline: load -> filter -> fetch+classify -> write."""
+        """Execute the full pipeline: load -> filter -> parse -> fetch+classify -> write.
+
+        After routing, records are parsed into typed work items at the load boundary
+        (#172): a ``ClassifierRecord`` per valid record and an ``InvalidRecord`` per
+        record whose classifier-relevant fields violate the input contract (#161).
+        Everything downstream reads typed attributes, not raw ``dict`` keys.
+        """
         records = self._load_input()
         records = self._filter_records(records)
 
@@ -208,24 +215,28 @@ class ClassifyPipeline:
             print(f"No {self.config.name.upper()} files found matching extensions {self.config.extensions}")
             return []
 
+        # Skip-complete only needs the record count, so it runs before parsing: on an
+        # already-complete resume run this returns without validating any record.
         if self._should_skip_complete(records):
             return []
 
-        cached_md5s = self._print_cache_stats(records)
+        work = self._partition_records(records)
+
+        cached_md5s = self._print_cache_stats(work)
 
         if self.skip_cached and cached_md5s:
-            records = [r for r in records if r.get("file_md5sum") not in cached_md5s]
-            print(f"  Skipping cached files, processing only {len(records)} new files")
+            work = [w for w in work if w.file_md5sum not in cached_md5s]
+            print(f"  Skipping cached files, processing only {len(work)} new files")
 
         if self.limit:
-            records = records[: self.limit]
+            work = work[: self.limit]
             print(f"Processing first {self.limit} files")
 
-        if not records:
+        if not work:
             return []
 
         self.evidence_dir.mkdir(parents=True, exist_ok=True)
-        classifications = self._run_parallel(records)
+        classifications = self._run_parallel(work)
 
         if self.config.summary_printer:
             self.config.summary_printer(classifications)
@@ -300,6 +311,28 @@ class ClassifyPipeline:
 
         return [r for r in records if matches(r)]
 
+    def _partition_records(self, records: list[dict]) -> list[ClassifierRecord | InvalidRecord]:
+        """Parse routed records into typed work items at the load boundary (#172).
+
+        Each record becomes either a ``ClassifierRecord`` (no classifier-relevant
+        contract violation — it will be fetched and classified) or an
+        ``InvalidRecord`` (a classifier-relevant field violates the input contract —
+        diverted straight to a ``validation_failed`` row, never fetched, per #161).
+        The split criterion is ``classification_blocking_reasons``, so a record that
+        violates the contract only on a field the classifier never reads is *not*
+        diverted here; that drift is surfaced by the whole-corpus ``validate_metadata``
+        gate. Input order is preserved so the combined work list keeps the ordering
+        the progress and ``limit`` steps assume.
+        """
+        work: list[ClassifierRecord | InvalidRecord] = []
+        for record in records:
+            reasons = classification_blocking_reasons(record)
+            if reasons:
+                work.append(InvalidRecord.from_record(record, reasons))
+            else:
+                work.append(ClassifierRecord.from_record(record))
+        return work
+
     def _is_cached(self, md5sum) -> TypeGuard[str]:
         """Check if evidence is cached (cheap file-existence check, no JSON parse).
 
@@ -331,29 +364,37 @@ class ClassifyPipeline:
             pass
         return False
 
-    def _print_cache_stats(self, records: list[dict]) -> set[str]:
-        """Print how many files are already cached. Returns set of cached MD5s."""
+    def _print_cache_stats(self, work: list[ClassifierRecord | InvalidRecord]) -> set[str]:
+        """Print how many files are already cached. Returns set of cached MD5s.
+
+        Reads ``file_md5sum`` off both streams: a ``ClassifierRecord``'s is a valid
+        md5 by construction, an ``InvalidRecord``'s is the raw (possibly non-string)
+        value — which is why ``_is_cached`` keeps its own type/format guard.
+        """
         name = self.config.name.upper()
-        print(f"Found {len(records)} {name} files with MD5 for header inspection")
-        cached_md5s = {md5 for r in records if self._is_cached(md5 := r.get("file_md5sum"))}
+        print(f"Found {len(work)} {name} files with MD5 for header inspection")
+        cached_md5s = {w.file_md5sum for w in work if self._is_cached(w.file_md5sum)}
         print(f"  Already cached: {len(cached_md5s)}")
-        print(f"  Remaining to fetch: {len(records) - len(cached_md5s)}")
+        print(f"  Remaining to fetch: {len(work) - len(cached_md5s)}")
         return cached_md5s
 
-    def _process_single_record(self, record: dict) -> RecordOutcome:
-        """Fetch, classify, and build output for one record.
+    def _process_single_record(self, item: ClassifierRecord | InvalidRecord) -> RecordOutcome:
+        """Fetch, classify, and build output for one parsed work item.
 
-        Scope: this runs on records ``_filter_records`` routed to this file type by
-        extension (md5 is *not* a routing condition). A record whose *classifier-
-        relevant* fields — including ``file_md5sum`` — violate the input-metadata
-        contract (issue #161) is neither fetched nor classified: it is built with
-        every dimension ``not_classified`` and the blocking reasons as evidence, and
+        An ``InvalidRecord`` (a classifier-relevant field violated the input
+        contract, issue #161) is neither fetched nor classified: it is built with
+        every dimension ``not_classified`` and its blocking reasons as evidence, and
         flagged ``validation_failed`` so the run tallies it. It is still written — a
         missing row is indistinguishable from a file that was never seen (issue
-        #155). A contract violation on a field the classifier does not read does
-        *not* divert the record; that drift is surfaced by the whole-corpus
-        ``validate_metadata`` gate, not here (as are records ``_filter_records``
-        does not route: a non-matching extension, a ``skip`` flag, or a non-dict).
+        #155). The valid/invalid split happened at the load boundary
+        (``_partition_records``); a record that violates the contract only on a field
+        the classifier does not read was never diverted, and drift on records
+        ``_filter_records`` did not route is surfaced by the whole-corpus
+        ``validate_metadata`` gate, not here.
+
+        A ``ClassifierRecord`` reads typed attributes — ``file_md5sum`` is a valid
+        md5 ``str``, ``file_name``/``file_format`` are ``str``, ``file_size`` an
+        ``int`` — by construction, so this path carries no per-field type guards.
 
         ``content_unreadable`` is reported explicitly rather than sniffed out of
         the output: ``classify_without_content`` annotates only the dimensions
@@ -361,39 +402,27 @@ class ClassifyPipeline:
         ``content_fields`` is empty would leave no ``fetch_failed`` evidence at
         all. Detection must not depend on evidence that a config may not emit.
         """
-        reasons = classification_blocking_reasons(record)
-        if reasons:
-            classifications = validation_failed_classifications(reasons)
+        if isinstance(item, InvalidRecord):
+            classifications = validation_failed_classifications(item.reasons)
             return RecordOutcome(
-                self._build_record(record, classifications),
+                self._build_record(item, classifications),
                 was_cached=False,
                 content_unreadable=False,
                 validation_failed=True,
             )
 
-        # The fields the fetch/classify path consumes — keep this set in sync with
-        # metadata_schema.CLASSIFIER_RELEVANT_FIELDS (which decides what blocks).
-        md5 = record.get("file_md5sum")
-        # Guaranteed a valid md5 string: file_md5sum is classifier-relevant, so the
-        # blocking-reasons guard above diverted the record if it were missing or
-        # mistyped. This asserts that contract post-condition for _fetch_and_classify.
-        assert isinstance(md5, str)
-        file_name = record.get("file_name") or ""
-        file_size = record.get("file_size")
-        file_format = record.get("file_format") or ""
-
         has_gz_ext = any(ext.endswith(".gz") for ext in self.config.extensions)
-        is_gzipped = (file_name.endswith(".gz") or file_format.endswith(".gz")) if has_gz_ext else True
+        is_gzipped = (item.file_name.endswith(".gz") or item.file_format.endswith(".gz")) if has_gz_ext else True
 
-        was_cached = self.resume and self._is_cached(md5)
+        was_cached = self.resume and self._is_cached(item.file_md5sum)
 
         classifications, content_unreadable = _fetch_and_classify(
             self.config,
             self.evidence_dir,
-            md5,
-            file_name=file_name,
-            file_size=file_size,
-            file_format=file_format,
+            item.file_md5sum,
+            file_name=item.file_name,
+            file_size=item.file_size,
+            file_format=item.file_format,
             is_gzipped=is_gzipped,
             use_cache=self.resume,
         )
@@ -411,32 +440,32 @@ class ClassifyPipeline:
             was_cached = False
 
         return RecordOutcome(
-            self._build_record(record, classifications), was_cached, content_unreadable, validation_failed=False
+            self._build_record(item, classifications), was_cached, content_unreadable, validation_failed=False
         )
 
     @staticmethod
-    def _build_record(record: dict, classifications: dict) -> dict:
+    def _build_record(item: ClassifierRecord | InvalidRecord, classifications: dict) -> dict:
         """Wrap a classifications dict in the output record envelope.
 
-        ``file_name``/``file_format`` are coerced to ``str`` because on the
-        ``validation_failed`` path they are echoed from a record whose fields may
-        have drifted to non-string types, and downstream consumers do string
-        operations on these two (path building, extension checks). The other echoed
-        identity fields (``md5sum``/``file_size``/``dataset_title``/``entry_id``) are
-        passed through as-is — a drifted ``validation_failed`` row can still carry
-        their raw types; normalizing the whole row by construction is #172's job.
+        Reads identity off the typed work item (a ``ClassifierRecord`` on the success
+        path, an ``InvalidRecord`` on the ``validation_failed`` path). Both guarantee
+        ``file_name``/``file_format`` are ``str`` — the two fields downstream
+        consumers do string operations on (path building, extension checks) — so no
+        coercion happens here. The other identity fields are echoed as the item
+        carries them: typed on the success path, the raw (possibly drifted) values on
+        the ``validation_failed`` path.
         """
         return {
-            "file_name": str(record.get("file_name") or ""),
-            "md5sum": record.get("file_md5sum"),
-            "file_size": record.get("file_size"),
-            "file_format": str(record.get("file_format") or ""),
-            "dataset_title": record.get("dataset_title"),
+            "file_name": item.file_name,
+            "md5sum": item.file_md5sum,
+            "file_size": item.file_size,
+            "file_format": item.file_format,
+            "dataset_title": item.dataset_title,
             "classifications": classifications,
-            "entry_id": record.get("entry_id"),
+            "entry_id": item.entry_id,
         }
 
-    def _run_parallel(self, records: list[dict]) -> list[dict]:
+    def _run_parallel(self, work: list[ClassifierRecord | InvalidRecord]) -> list[dict]:
         """ThreadPoolExecutor with progress tracking, returns classifications."""
         successful = 0
         dropped = 0  # fetcher returned None: no cause given
@@ -446,13 +475,13 @@ class ClassifyPipeline:
         processed = 0
         unreadable = 0
         lock = Lock()
-        total = len(records)
+        total = len(work)
 
         print(f"Using {self.workers} parallel workers")
 
         with NdjsonWriter(self.output_path) as writer:
 
-            def update_progress(outcome: RecordOutcome, file_name):
+            def update_progress(outcome: RecordOutcome, file_name: str):
                 nonlocal successful, dropped, from_cache, processed, unreadable, invalid
                 with lock:
                     processed += 1
@@ -469,30 +498,27 @@ class ClassifyPipeline:
                     else:
                         dropped += 1
                     cache_indicator = "[cached] " if outcome.was_cached else ""
-                    # str(... or ""): a record may carry a null file_name (present-but-
-                    # null → None) or a non-string one (drift, e.g. an int). This print
-                    # is the crash site — a raise here aborts the sequential run, and in
-                    # the parallel path lands in the executor's `except Exception`,
-                    # discarding a record (often a validation_failed one) already written.
-                    label = str(file_name or "")[:45]
+                    # file_name is a str on both work streams (ClassifierRecord types it,
+                    # InvalidRecord coerces it), so the slice cannot raise.
+                    label = file_name[:45]
                     print(f"\r[{processed}/{total}] {cache_indicator}{label:<52}", end="", flush=True)
 
             if self.workers == 1:
-                for record in records:
-                    outcome = self._process_single_record(record)
-                    update_progress(outcome, record.get("file_name") or "")
+                for item in work:
+                    outcome = self._process_single_record(item)
+                    update_progress(outcome, item.file_name)
             else:
                 with ThreadPoolExecutor(max_workers=self.workers) as executor:
-                    future_to_record = {
-                        executor.submit(self._process_single_record, record): record for record in records
+                    future_to_item = {
+                        executor.submit(self._process_single_record, item): item for item in work
                     }
-                    for future in as_completed(future_to_record):
-                        record = future_to_record[future]
+                    for future in as_completed(future_to_item):
+                        item = future_to_item[future]
                         try:
                             outcome = future.result()
-                            update_progress(outcome, record.get("file_name") or "")
+                            update_progress(outcome, item.file_name)
                         except Exception as e:
-                            print(f"\nError processing {record.get('file_name')}: {e}")
+                            print(f"\nError processing {item.file_name}: {e}")
                             with lock:
                                 processed += 1
                                 errored += 1

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -225,7 +225,11 @@ class ClassifyPipeline:
         cached_md5s = self._print_cache_stats(work)
 
         if self.skip_cached and cached_md5s:
-            work = [w for w in work if w.file_md5sum not in cached_md5s]
+            # Only classifiable records can be cached, so only they are skip-filtered.
+            # An InvalidRecord is never fetched or cached and must still be written as
+            # validation_failed (#155/#161); it is kept unconditionally, which also
+            # avoids hashing its raw (possibly unhashable) file_md5sum against the set.
+            work = [w for w in work if isinstance(w, InvalidRecord) or w.file_md5sum not in cached_md5s]
             print(f"  Skipping cached files, processing only {len(work)} new files")
 
         if self.limit:

--- a/src/meta_disco/records.py
+++ b/src/meta_disco/records.py
@@ -32,6 +32,17 @@ from dataclasses import dataclass
 from typing import Any
 
 
+def _coerce_identity(value: Any) -> str:
+    """Stringify a drifted identity value for echo; null (``None``) becomes ``""``.
+
+    Distinguishes null from a falsy-but-present value on purpose: a ``str(value or
+    "")`` would collapse ``0``/``False`` to ``""`` and lose the drifted value, so a
+    ``file_name`` of ``0`` here becomes ``"0"``, not ``""``. Only genuine ``None``
+    (absent/null) maps to the empty string.
+    """
+    return "" if value is None else str(value)
+
+
 @dataclass(frozen=True)
 class ClassifierRecord:
     """A filtered record whose classifier-relevant fields passed the input contract.
@@ -102,14 +113,15 @@ class InvalidRecord:
     def from_record(cls, record: dict, reasons: list[str]) -> InvalidRecord:
         """Build from a raw record whose classifier-relevant fields may be drifted.
 
-        ``str(... or "")``: ``file_name``/``file_format`` may be null (present-but-
-        None) or a drifted non-string (an int); coercing them here — the sole
-        coercion site the #171 point fixes are replaced by — means neither can raise
-        in the downstream path/extension operations or the progress-label slice.
+        ``file_name``/``file_format`` may be null (present-but-None) or a drifted
+        non-string (an int); ``_coerce_identity`` maps null to ``""`` and stringifies
+        any other value — the sole coercion site the #171 point fixes are replaced
+        by — so neither can raise in the downstream path/extension operations or the
+        progress-label slice.
         """
         return cls(
-            file_name=str(record.get("file_name") or ""),
-            file_format=str(record.get("file_format") or ""),
+            file_name=_coerce_identity(record.get("file_name")),
+            file_format=_coerce_identity(record.get("file_format")),
             file_md5sum=record.get("file_md5sum"),
             file_size=record.get("file_size"),
             dataset_title=record.get("dataset_title"),

--- a/src/meta_disco/records.py
+++ b/src/meta_disco/records.py
@@ -1,0 +1,118 @@
+"""Typed record views passed past the pipeline's load boundary (#172).
+
+The pipeline used to pass raw ``dict``s downstream and re-derive field safety at
+every consumer, because it validated a record against the Pydantic contract and
+then threw the model away and kept the dict (#171's scattered ``str(... or "")``
+guards were point fixes for that one root cause). Instead, ``run()`` splits the
+filtered records into two typed streams at the boundary:
+
+* **valid** (no classifier-relevant contract violation) -> :class:`ClassifierRecord`,
+  whose classifier-relevant fields are ``str``/``int`` by construction, so the
+  fetch/classify path reads typed attributes with no per-field guards.
+* **invalid** (a classifier-relevant field violates the input contract, the drift
+  #161 exists to catch) -> :class:`InvalidRecord`, which coerces the echoed string
+  identity fields in one constructor and carries the blocking reasons for the
+  ``validation_failed`` row.
+
+The split criterion is ``classification_blocking_reasons`` (unchanged from #161):
+a record that violates the full contract only on a field the classifier never
+reads (e.g. ``drs_uri``) is *not* diverted — it still classifies, and the
+whole-corpus ``validate_metadata`` gate reports that drift. So the "valid" stream
+is modeled over exactly the classifier-relevant fields, not the full contract.
+
+Both classes expose the same six identity attributes (``file_name``,
+``file_format``, ``file_md5sum``, ``file_size``, ``dataset_title``, ``entry_id``),
+so ``_build_record`` and the work-list steps read them uniformly regardless of
+stream.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ClassifierRecord:
+    """A filtered record whose classifier-relevant fields passed the input contract.
+
+    Built only from a record with no ``classification_blocking_reasons``, so
+    ``file_name``/``file_format`` are ``str``, ``file_size`` is a non-negative
+    ``int``, and ``file_md5sum`` is a well-formed md5 ``str`` — all by construction.
+    That post-condition is what lets the fetch/classify path drop the per-field
+    guards #171 added.
+
+    ``dataset_title``/``entry_id`` are *not* classifier-relevant, so a record with
+    either drifted still reaches the valid stream. They are echoed into the output
+    row untouched — typed ``Any`` and passed through as-is, exactly as the raw-dict
+    path did.
+    """
+
+    file_name: str
+    file_format: str
+    file_size: int
+    file_md5sum: str
+    dataset_title: Any
+    entry_id: Any
+
+    @classmethod
+    def from_record(cls, record: dict) -> ClassifierRecord:
+        """Build from a raw record already known to have no blocking reasons.
+
+        The four classifier-relevant fields are read by subscript, not ``.get(...)
+        or ""``: the caller's blocking check guarantees each is present and
+        well-typed, so a missing/mistyped value here is a bug in the caller, not
+        input to defend against (CLAUDE.md error-handling philosophy). A ``KeyError``
+        or wrong type surfacing here means the split routed a record it should not
+        have.
+        """
+        return cls(
+            file_name=record["file_name"],
+            file_format=record["file_format"],
+            file_size=record["file_size"],
+            file_md5sum=record["file_md5sum"],
+            dataset_title=record.get("dataset_title"),
+            entry_id=record.get("entry_id"),
+        )
+
+
+@dataclass(frozen=True)
+class InvalidRecord:
+    """A filtered record whose classifier-relevant fields violate the input contract.
+
+    Diverted at the load boundary and never fetched or classified (#161): it carries
+    the identity fields for the ``validation_failed`` output row and progress label,
+    plus the blocking ``reasons`` used as that row's evidence. Like
+    ``ClassifierRecord`` it exposes all six identity attributes ready to echo —
+    ``file_name``/``file_format`` are coerced to ``str`` in :meth:`from_record`
+    (the two fields downstream does string operations on), the rest are echoed as
+    the record carried them, since a ``validation_failed`` row may carry their
+    drifted (non-string) types.
+    """
+
+    file_name: str
+    file_format: str
+    file_md5sum: Any
+    file_size: Any
+    dataset_title: Any
+    entry_id: Any
+    reasons: list[str]
+
+    @classmethod
+    def from_record(cls, record: dict, reasons: list[str]) -> InvalidRecord:
+        """Build from a raw record whose classifier-relevant fields may be drifted.
+
+        ``str(... or "")``: ``file_name``/``file_format`` may be null (present-but-
+        None) or a drifted non-string (an int); coercing them here — the sole
+        coercion site the #171 point fixes are replaced by — means neither can raise
+        in the downstream path/extension operations or the progress-label slice.
+        """
+        return cls(
+            file_name=str(record.get("file_name") or ""),
+            file_format=str(record.get("file_format") or ""),
+            file_md5sum=record.get("file_md5sum"),
+            file_size=record.get("file_size"),
+            dataset_title=record.get("dataset_title"),
+            entry_id=record.get("entry_id"),
+            reasons=reasons,
+        )

--- a/src/meta_disco/schema/classification.yaml
+++ b/src/meta_disco/schema/classification.yaml
@@ -16,7 +16,8 @@ description: >-
   (schema/tests/test_output_validation.py, run closed=False, so any unmodeled key is
   tolerated; in practice the pipeline's only such extras are the fastq scalar hints
   inside `classifications` — modeling them is a #134 follow-up).
-  Adopting the generated Pydantic records in the pipeline is a planned follow-up (#33).
+  Adopting typed records in the pipeline is done: `run()` parses each routed record
+  into a typed view at the load boundary (`src/meta_disco/records.py`, #172).
 
 prefixes:
   linkml: https://w3id.org/linkml/

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from meta_disco.pipeline import ClassifyPipeline, FileTypeConfig, NdjsonWriter
+from meta_disco.records import ClassifierRecord, InvalidRecord
 from tests.metadata_fixtures import valid_record as _valid_record
 
 # --- Test fixtures ---
@@ -279,10 +280,34 @@ class TestPipelineRun:
         reasons = [e["reason"] for e in results[0]["classifications"]["data_modality"]["evidence"]]
         assert any("file_md5sum" in r for r in reasons)
 
-    def test_build_record_coerces_file_name_and_format_to_str(self):
-        # A validation_failed row echoes identity from a possibly-drifted record;
-        # the output types must stay stable for downstream consumers.
-        out = ClassifyPipeline._build_record({"file_name": 123, "file_format": None, "file_md5sum": "x"}, {})
+    def test_partition_routes_by_classifier_relevant_fields(self, tmp_path):
+        """The load-boundary split (#172) preserves #161's divert rule: a contract
+        violation only on a field the classifier never reads (drs_uri) still yields a
+        ClassifierRecord and classifies; a violation on a classifier-relevant field
+        (file_size) yields an InvalidRecord diverted to validation_failed."""
+        pipeline = ClassifyPipeline(
+            _make_config(),
+            tmp_path / "in.json",
+            tmp_path / "out.json",
+            evidence_base=tmp_path / "evidence",
+        )
+        good = _valid_record(file_name="a.test", file_format=".test")
+        non_classifier_drift = _valid_record(file_name="b.test", file_format=".test", drs_uri=123)
+        classifier_drift = _valid_record(file_name="c.test", file_format=".test", file_size="big")
+
+        work = pipeline._partition_records([good, non_classifier_drift, classifier_drift])
+
+        assert isinstance(work[0], ClassifierRecord)
+        assert isinstance(work[1], ClassifierRecord)  # drs_uri drift is not blocking
+        assert isinstance(work[2], InvalidRecord)  # file_size drift is blocking
+        assert any("file_size" in reason for reason in work[2].reasons)
+
+    def test_build_record_echoes_typed_item_identity(self):
+        # _build_record reads identity off the typed work item. On the
+        # validation_failed path that is an InvalidRecord, which has already coerced
+        # file_name/file_format to str, so the output types stay stable.
+        item = InvalidRecord.from_record({"file_name": 123, "file_format": None, "file_md5sum": "x"}, [])
+        out = ClassifyPipeline._build_record(item, {})
         assert out["file_name"] == "123"
         assert out["file_format"] == ""
         assert isinstance(out["file_name"], str) and isinstance(out["file_format"], str)
@@ -358,7 +383,7 @@ class TestPipelineRun:
         assert pipeline._is_cached(md5) is True
 
         outcome = pipeline._process_single_record(
-            _valid_record(file_md5sum=md5, file_name="x.test", file_format=".test")
+            ClassifierRecord.from_record(_valid_record(file_md5sum=md5, file_name="x.test", file_format=".test"))
         )
         assert outcome.result is None
         assert outcome.was_cached is False
@@ -531,7 +556,9 @@ class TestFileTypeConfigs:
         stale.parent.mkdir(parents=True, exist_ok=True)
         stale.write_text("{ not json")
 
-        out, was_cached, content_unreadable, _validation_failed = pipeline._process_single_record(record)
+        out, was_cached, content_unreadable, _validation_failed = pipeline._process_single_record(
+            ClassifierRecord.from_record(record)
+        )
 
         assert content_unreadable is True
         assert was_cached is False, "a fetch that reached the network is not a cache hit"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -280,6 +280,40 @@ class TestPipelineRun:
         reasons = [e["reason"] for e in results[0]["classifications"]["data_modality"]["evidence"]]
         assert any("file_md5sum" in r for r in reasons)
 
+    def test_skip_cached_keeps_invalid_records_and_tolerates_unhashable_md5(self, tmp_path):
+        """skip_cached must not drop validation_failed records (they are never cached)
+        and must not crash on an InvalidRecord whose md5 drifted to an unhashable
+        type — only classifiable records are skip-filtered against the cached set."""
+        from meta_disco.fetchers import get_evidence_path
+
+        cached_md5 = "a" * 32
+        valid = _valid_record(file_md5sum=cached_md5, file_name="v.test", file_format=".test")
+        # Blocking drift (non-int file_size) + an unhashable md5 (a list).
+        invalid = _valid_record(file_name="i.test", file_format=".test", file_size="big", file_md5sum=["x"])
+        input_path = tmp_path / "in.json"
+        input_path.write_text(json.dumps({"results": [valid, invalid]}))
+
+        pipeline = ClassifyPipeline(
+            _make_config(),
+            input_path,
+            tmp_path / "out.json",
+            evidence_base=tmp_path / "evidence",
+            resume=True,
+            skip_cached=True,
+            workers=1,
+        )
+        ev = get_evidence_path(pipeline.evidence_dir, cached_md5)
+        ev.parent.mkdir(parents=True, exist_ok=True)
+        ev.write_text("{}")
+
+        results = pipeline.run()  # must not raise on the unhashable md5
+
+        names = [r["file_name"] for r in results]
+        assert "v.test" not in names  # cached classifiable record is skipped
+        assert "i.test" in names  # validation_failed record is still written
+        meta = json.loads((tmp_path / "out.json").read_text())["metadata"]
+        assert meta["validation_failed"] == 1
+
     def test_partition_routes_by_classifier_relevant_fields(self, tmp_path):
         """The load-boundary split (#172) preserves #161's divert rule: a contract
         violation only on a field the classifier never reads (drs_uri) still yields a

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,0 +1,60 @@
+"""Tests for the typed record views the pipeline parses at its load boundary (#172)."""
+
+import pytest
+
+from meta_disco.records import ClassifierRecord, InvalidRecord
+from tests.metadata_fixtures import valid_record
+
+
+class TestClassifierRecord:
+    def test_from_record_exposes_typed_classifier_fields(self):
+        rec = valid_record(file_name="a.bam", file_format=".bam", file_size=42, file_md5sum="a" * 32)
+        cr = ClassifierRecord.from_record(rec)
+        assert cr.file_name == "a.bam"
+        assert cr.file_format == ".bam"
+        assert cr.file_size == 42
+        assert cr.file_md5sum == "a" * 32
+
+    def test_passes_through_non_classifier_identity(self):
+        cr = ClassifierRecord.from_record(valid_record(entry_id="e9", dataset_title="T"))
+        assert cr.entry_id == "e9"
+        assert cr.dataset_title == "T"
+
+    def test_missing_optional_identity_is_none(self):
+        rec = valid_record()
+        del rec["dataset_title"]
+        del rec["entry_id"]
+        cr = ClassifierRecord.from_record(rec)
+        assert cr.dataset_title is None
+        assert cr.entry_id is None
+
+
+class TestInvalidRecord:
+    @pytest.mark.parametrize("raw,expected", [(None, ""), (123, "123"), ("x.bam", "x.bam"), ("", "")])
+    def test_coerces_file_name_to_str(self, raw, expected):
+        inv = InvalidRecord.from_record({"file_name": raw}, [])
+        assert inv.file_name == expected
+        assert isinstance(inv.file_name, str)
+
+    @pytest.mark.parametrize("raw,expected", [(None, ""), (0, ""), (".bam", ".bam")])
+    def test_coerces_file_format_to_str(self, raw, expected):
+        inv = InvalidRecord.from_record({"file_format": raw}, [])
+        assert inv.file_format == expected
+        assert isinstance(inv.file_format, str)
+
+    def test_passes_other_identity_fields_through_raw(self):
+        # md5/size/title/entry_id are echoed as-is on the validation_failed path —
+        # a drifted row may carry their raw (non-string) types.
+        inv = InvalidRecord.from_record(
+            {"file_md5sum": 5, "file_size": "big", "dataset_title": None, "entry_id": "e9"}, []
+        )
+        assert inv.file_md5sum == 5
+        assert inv.file_size == "big"
+        assert inv.dataset_title is None
+        assert inv.entry_id == "e9"
+
+    def test_carries_blocking_reasons(self):
+        inv = InvalidRecord.from_record({"file_name": 7, "file_md5sum": "z"}, ["file_size: expected an integer"])
+        assert inv.file_name == "7"
+        assert inv.file_md5sum == "z"
+        assert inv.reasons == ["file_size: expected an integer"]

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -36,11 +36,18 @@ class TestInvalidRecord:
         assert inv.file_name == expected
         assert isinstance(inv.file_name, str)
 
-    @pytest.mark.parametrize("raw,expected", [(None, ""), (0, ""), (".bam", ".bam")])
+    @pytest.mark.parametrize("raw,expected", [(None, ""), (0, "0"), (".bam", ".bam")])
     def test_coerces_file_format_to_str(self, raw, expected):
         inv = InvalidRecord.from_record({"file_format": raw}, [])
         assert inv.file_format == expected
         assert isinstance(inv.file_format, str)
+
+    @pytest.mark.parametrize("raw,expected", [(None, ""), (0, "0"), (False, "False"), ("", "")])
+    def test_only_null_becomes_empty_falsy_values_are_preserved(self, raw, expected):
+        # Only None (absent/null) maps to ""; a falsy-but-present drift like 0/False
+        # is stringified, not erased (a str(x or "") would collapse both to "").
+        inv = InvalidRecord.from_record({"file_name": raw}, [])
+        assert inv.file_name == expected
 
     def test_passes_other_identity_fields_through_raw(self):
         # md5/size/title/entry_id are echoed as-is on the validation_failed path —


### PR DESCRIPTION
Closes #172.

## What changed

`run()` now parses each routed record into a typed work item at the load boundary instead of passing raw `dict`s downstream and re-deriving field safety at every consumer.

- New `src/meta_disco/records.py`:
  - `ClassifierRecord` (valid stream) — classifier-relevant fields are `str`/`int` by construction.
  - `InvalidRecord` (invalid stream) — coerces the echoed string identity fields in one `from_record` constructor and carries the blocking reasons for the `validation_failed` row.
  - Both expose the same six identity attributes, so `_build_record` and the work-list steps read them uniformly.
- `_partition_records` splits filtered records using `classification_blocking_reasons` (unchanged from #161).
- The classifier/fetch path (`_process_single_record` → `_fetch_and_classify`) now reads typed attributes — the five `record.get(...)` reads and the `assert isinstance(md5, str)` are gone. `_build_record`'s `str(... or "")` coercions are gone too.
- Skip-complete now runs before partitioning, so an already-complete resume validates no records.
- Repointed the stale `classification.yaml` `#33` reference to #172.

`_filter_records` keeps its `str(... or "")` routing guard — it runs before parsing and must tolerate raw non-dict/garbage elements.

## Why

#171 (issue #161) fixed a recurring corner case with scattered `str(... or "")` guards: the pipeline validated a record against the Pydantic contract, then threw the model away and kept the dict, so every consumer re-derived whether a field was safe to use. This generalizes those point fixes into *parse, don't validate* — construct a typed record at the boundary so the guards become unnecessary.

## Assumptions I made

- **The split criterion stays `classification_blocking_reasons`, not full strict validation.** A record that violates the contract only on a field the classifier never reads (e.g. `drs_uri`) must still classify — that is #161's deliberate behavior. Modeling the valid stream over the full contract would have silently widened the divert set. `test_partition_routes_by_classifier_relevant_fields` pins this.
- **`LenientIdentityView` was merged into `InvalidRecord`** (during `/simplify`): the view only ever lived inside an `InvalidRecord`, so one class removes a `.view` hop and forwarding properties.
- **`_is_cached` keeps its own md5 type/format guard.** An `InvalidRecord`'s `file_md5sum` is raw `Any` and reaches `_is_cached` via `_print_cache_stats`, so the guard is load-bearing at that boundary.
- The `validate_metadata` gate's `OSError` handling is out of scope (an I/O boundary, not a field-type issue).

## How to verify

Definition of done (from the issue / my plan comment) mapped to steps:

1. **Typed views are the only thing passed past the load boundary** — read `src/meta_disco/records.py` and `ClassifyPipeline.run()`; `work` is `list[ClassifierRecord | InvalidRecord]`.
2. **Divert behavior unchanged (non-classifier-field drift still classifies)** — `uv run pytest tests/test_pipeline.py -k partition_routes -v` and `tests/test_records.py`.
3. **The #171 guards and md5 assert are removed; routing guard retained** — `grep -n 'str(.* or "")' src/meta_disco/pipeline.py` shows only the two lines in `_filter_records`.
4. **Stale `#33` reference repointed** — `sed -n '19,20p' src/meta_disco/schema/classification.yaml`.
5. **Output is unchanged on real data** — run any `make classify-<type>` against a warm evidence cache before and after this branch; classifications are byte-identical. Verified locally: a `main`-vs-branch compare over **249,202 real records** (bam/vcf/fastq/fasta/gfa) was identical in metadata and every classification record, and a full-corpus pass built a `ClassifierRecord` for all 758,658 records with 0 crashes.
6. **Suite green** — `make test-all`, `make lint`, `make type` (0 errors).
