### PR TITLE
Fetch failures become not_classified rows, not dropped records (#155)

### DIFF
--- a/docs/plans/155-fetch-failures-not-classified.md
+++ b/docs/plans/155-fetch-failures-not-classified.md
@@ -1,0 +1,152 @@
+# Plan — #155: Fetch failures become `not_classified` rows, not dropped records
+
+**Outcome:** when a fetcher cannot read a file, the record is written as a
+`not_classified` row naming the cause, instead of vanishing from the output. A
+missing row is indistinguishable from a file that was never seen; that is worse
+than an honest `not_classified` and cuts against *accuracy over coverage*.
+
+## Background
+
+#151 converted `fetch_gfa_segment_tags` to raise `fetchers.FetchError(reason)`
+instead of returning `None`. `_fetch_and_classify` catches it and emits a row whose
+five dimensions are all `not_classified`, each carrying the cause as evidence
+(`{"rule_id": "fetch_failed", "reason": "HTTP 404 …"}`). The other four header
+fetchers still `return None` on failure, so `_fetch_and_classify` returns
+`(None, False)` and `_process_single_record` drops the record entirely.
+
+The GFA fetcher (`fetchers.py`) is the template. Its failure block:
+
+```python
+except FetchError:
+    raise                       # already carries its reason — don't re-wrap
+except requests.Timeout as e:
+    raise FetchError(f"Timeout reading GFA head: {e}") from e
+except Exception as e:
+    raise FetchError(f"{type(e).__name__}: {e}") from e   # bug surfaces as a row, not a vanish
+```
+
+The four to convert (each with a `return None` failure shape):
+`fetch_bam_header`, `fetch_vcf_header`, `fetch_fastq_reads`, `fetch_fasta_headers`.
+
+Note: `fetch_vcf_header` / `fetch_fastq_reads` / `fetch_fasta_headers` already
+`except FetchError: return None` — they catch the non-2xx `FetchError` that
+`_fetch_range` raises and **swallow** it. Converting them is partly *deleting* that
+swallow so the `FetchError` propagates (as GFA's `except FetchError: raise` does),
+plus turning `Timeout`/`Exception`/empty-content `return None` into raises.
+
+## Impact (measured, warm cache)
+
+From the #172 verification runs (evidence cache warm, so only genuinely
+unfetchable files fail):
+
+| type | records currently **dropped** → would become `not_classified` |
+|------|--------------------------------------------------------------|
+| bam | 1 |
+| vcf | 23 |
+| fastq | 0 |
+| fasta | 0 |
+| gfa | 0 (already converted; 14 surface as `content_unreadable`) |
+
+These are a **floor**: a full run over the network (not warm cache) fails more
+uncached fetches, so the real count is higher and is the number task 4 must report.
+
+## Key decisions to make deliberately (issue task 3)
+
+1. **`samtools` not found = crash, not `FetchError`.** `fetch_bam_header`'s
+   `except FileNotFoundError` ("samtools not found") is an *environment* failure that
+   affects **every** BAM record. It must fail the run loudly, not silently mark all
+   BAMs `not_classified`. Keep it as a raised, non-`FetchError` error (or let it
+   propagate). Only per-file read failures (`returncode != 0`, `TimeoutExpired`,
+   parse errors) become `FetchError`. **Recommendation: crash on missing samtools.**
+2. **`except Exception` → `FetchError` (wrap, per #151).** A parser/programming bug
+   becomes a `not_classified` row whose evidence names the cause (`TypeError: …`) —
+   visible and resumable — rather than crashing the whole run. This is #151's choice;
+   follow it for consistency. Trade-off: a bug hides as data rather than a stack
+   trace, but the row names it, so it is diagnosable in the output.
+   **Recommendation: wrap, matching GFA.** (CLAUDE.md's "fail loud" applies to
+   *internal* contract violations; a fetch is a network/IO boundary, so a caught,
+   reported failure is the boundary-appropriate behavior.)
+3. **Drop the now-dead `None` contract.** Once no fetcher returns `None`, change the
+   four signatures `-> str | None` → `-> str` (and `fetch_fastq_reads`'s return type
+   likewise), remove `if raw_data is None: return None, False` in `_fetch_and_classify`
+   (return type `tuple[dict | None, bool]` → `tuple[dict, bool]`), and remove the dead
+   `if classifications is None` branches in `_process_single_record` and
+   `classify_single`. Let a `None` slipping through be a loud bug, not a silent drop.
+
+## Design / implementation steps
+
+1. **Convert the four fetchers** (`fetchers.py`) to the GFA failure shape:
+   - `fetch_vcf_header` / `fetch_fastq_reads` / `fetch_fasta_headers`: delete
+     `except FetchError: return None` (let it propagate); convert `Timeout` and
+     `Exception` and any empty/non-2xx `return None` into `raise FetchError(reason)`.
+   - `fetch_bam_header`: `returncode != 0` → `raise FetchError` with the samtools
+     stderr as reason; `TimeoutExpired` → `FetchError`; **`FileNotFoundError` (samtools
+     missing) → crash** per decision 1; other `Exception` → `FetchError`.
+   - Decide the empty-but-successful case (bam `returncode == 0` with empty stdout →
+     currently returns `""`): leave as a readable-but-empty header the classifier
+     handles, or treat as `FetchError`. Note it explicitly; do not leave it ambiguous.
+2. **Update return types** `-> str | None` → `-> str` on the four (and the return
+   type of `_fetch_and_classify`), matching the new no-`None` contract.
+3. **Remove dead `None` handling** in `_fetch_and_classify`, `_process_single_record`,
+   and `classify_single` (step from decision 3).
+4. **The `dropped` counter becomes vestigial.** With no drops, `_run_parallel`'s
+   `dropped` is always 0 and `RecordOutcome.result` is never `None`. Decide:
+   - **Keep** `dropped` in `_save_final` metadata as a literal `0` (with a comment)
+     for output-schema stability, OR
+   - **Remove** the drop path (`RecordOutcome.result: dict`, drop the `else: dropped`
+     branch) and the `dropped` metadata key, updating consumers.
+   `errored` stays meaningful (a non-`FetchError` bug can still crash a worker).
+   **Recommendation:** keep `dropped: 0` in the metadata for back-compat, remove the
+   unreachable `result is None` branch in `update_progress`. Flag for review.
+5. **Fix the direct caller** `scripts/classify_hprc_files.py` — it calls
+   `fetch_bam_header` / `fetch_fastq_reads` / `fetch_fasta_headers` directly and
+   checks `raw_data is None`. Those calls now raise `FetchError`; wrap them (or route
+   through the same `classify_without_content` fallback) so the HPRC path doesn't
+   crash on a fetch failure.
+6. **Fix stale docs.** The `fetchers.py` module docstring says "`fetch_bam_header`
+   never raises FetchError" — update it. Grep the module docstring and per-fetcher
+   docstrings for "return None"/"silently"/"drops the record" and correct each.
+
+## Coverage / report denominators (issue task 5)
+
+`scripts/generate_coverage_report.py` and `scripts/generate_classification_report.py`
+consume the run metadata / classification rows. A `not_classified` spike must not
+misreport denominators: verify these scripts count total emitted rows (a
+`not_classified` row is a *present* row with a status, not a missing one) and that
+`dropped`/`failed` going to ~0 doesn't skew a "classified / total" ratio. Inspect
+both before/after and confirm the numbers move the expected way.
+
+## Verification (issue task 4 — the number that matters)
+
+- Full run per header type on `main` vs branch (warm cache + a real network pass),
+  and report, per file type, **how many `not_classified` rows appear that previously
+  vanished** — the delta in emitted record count plus the `content_unreadable`/
+  `dropped` shift. This is currently unknown and is the core deliverable.
+- Confirm the reasons are real (`HTTP 404 …`, timeouts), not masked programming bugs
+  — spot-check a sample of the new rows' evidence.
+- `make test-all`, `make lint`, `make format-check`, `make type` green.
+- Unit tests: each converted fetcher raises `FetchError` (not returns `None`) on a
+  non-2xx / timeout / parse error; `fetch_bam_header` **raises (crashes)** on missing
+  samtools; `_fetch_and_classify` turns a `FetchError` into a `content_unreadable`
+  row and no longer has a `None`-drop path.
+
+## Out of scope
+
+- #149 (BGZF multi-member truncation) and #153 (off-by-one `end_byte`) — separate
+  fetch-correctness bugs.
+- #156 (mirror availability report — HEAD every md5 to find missing objects).
+- #154 (fact model — fetch failure as a fact) — this issue is the direct fix; the
+  fact-model refactor would subsume it later.
+
+## Definition of done
+
+- [ ] The four fetchers raise `FetchError(reason)` on read failure; none return `None`.
+- [ ] `samtools`-missing crashes the run (decision 1); parser bugs surface as
+      `not_classified` rows (decision 2) — both covered by tests.
+- [ ] Dead `None` branches removed; fetcher/`_fetch_and_classify` return types tightened.
+- [ ] `scripts/classify_hprc_files.py` handles the new raising behavior.
+- [ ] Stale "never raises / returns None / drops the record" docstrings corrected.
+- [ ] Coverage + classification reports verified to handle the `not_classified` spike.
+- [ ] Before/after corpus comparison reported per file type (the previously-unknown
+      count of records that stop vanishing).
+- [ ] `make test-all` / `lint` / `format-check` / `type` green.

--- a/scripts/classify_hprc_files.py
+++ b/scripts/classify_hprc_files.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from pathlib import Path
 
 from meta_disco.fetchers import (
+    FetchError,
     fetch_bam_header,
     fetch_fasta_headers,
     fetch_fastq_reads,
@@ -76,35 +77,41 @@ def classify_sequencing_data(
         classifications = None
 
         if fn.endswith((".bam", ".cram")):
-            raw_data = fetch_bam_header(
-                bam_evidence,
-                key,
-                file_name=fn,
-                use_cache=True,
-                url=url,
-            )
-            if raw_data is not None:
+            # A FetchError (unreadable content) skips the file, as the pre-#155
+            # None return did; a missing-samtools FileNotFoundError still propagates.
+            try:
+                raw_data = fetch_bam_header(
+                    bam_evidence,
+                    key,
+                    file_name=fn,
+                    use_cache=True,
+                    url=url,
+                )
                 classifications = classify_from_header(
                     raw_data,
                     file_name=fn,
                     file_size=file_size,
                     file_format=".cram" if fn.endswith(".cram") else ".bam",
                 )
+            except FetchError:
+                pass
         elif fn.endswith((".fastq.gz", ".fastq")):
-            raw_data = fetch_fastq_reads(
-                fastq_evidence,
-                key,
-                file_name=fn,
-                is_gzipped=fn.endswith(".gz"),
-                use_cache=True,
-                url=url,
-            )
-            if raw_data is not None:
+            try:
+                raw_data = fetch_fastq_reads(
+                    fastq_evidence,
+                    key,
+                    file_name=fn,
+                    is_gzipped=fn.endswith(".gz"),
+                    use_cache=True,
+                    url=url,
+                )
                 classifications = classify_from_fastq_header(
                     raw_data,
                     file_name=fn,
                     file_size=file_size,
                 )
+            except FetchError:
+                pass
         else:
             # FAST5, POD5, etc. — classify from filename only
             skipped += 1
@@ -152,31 +159,34 @@ def classify_assemblies(
         if (i + 1) % 100 == 0 or i == 0:
             print(f"  [{i + 1}/{len(records)}] {fn[:50]}", flush=True)
 
-        raw_data = fetch_fasta_headers(
-            fasta_evidence,
-            key,
-            file_name=fn,
-            is_gzipped=fn.endswith(".gz"),
-            use_cache=True,
-            url=url,
-        )
-
-        if raw_data is not None:
-            classifications = classify_from_fasta_header(
-                raw_data,
+        try:
+            raw_data = fetch_fasta_headers(
+                fasta_evidence,
+                key,
                 file_name=fn,
-                file_size=file_size,
+                is_gzipped=fn.endswith(".gz"),
+                use_cache=True,
+                url=url,
             )
-            success += 1
-            results.append(
-                {
-                    "file_name": fn,
-                    "key": key,
-                    "file_size": file_size,
-                    "classifications": classifications,
-                    "catalog": "assemblies",
-                }
-            )
+        except FetchError:
+            # Unreadable content skips the file, as the pre-#155 None return did.
+            continue
+
+        classifications = classify_from_fasta_header(
+            raw_data,
+            file_name=fn,
+            file_size=file_size,
+        )
+        success += 1
+        results.append(
+            {
+                "file_name": fn,
+                "key": key,
+                "file_size": file_size,
+                "classifications": classifications,
+                "catalog": "assemblies",
+            }
+        )
 
     print(f"  Classified: {success}, Failed: {len(records) - success}")
     return results

--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -236,7 +236,7 @@ def fetch_bam_header(
         "md5sum": md5sum,
         "file_name": file_name,
         "header_text": header_text,
-        "header_line_count": len(header_text.split("\n")),
+        "header_line_count": len(header_text.splitlines()),
         "fetch_timestamp": _timestamp(),
     }
     if url:

--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -39,9 +39,8 @@ class FetchError(Exception):
     `not_classified` row naming the cause instead of vanishing (#155). One
     exception: `fetch_bam_header` lets a `FileNotFoundError` (samtools not
     installed) propagate as itself, since a missing tool is an environment failure
-    for every BAM record, not unreadable content for one. Each failure prints one
-    line via `_fetch_and_classify`; the mirror missing an unknown number of objects
-    is tracked separately (#156).
+    for every BAM record, not unreadable content for one. The mirror missing an
+    unknown number of objects is tracked separately (#156).
     """
 
     def __init__(self, reason: str):

--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -31,13 +31,15 @@ class FetchError(Exception):
     classification evidence, and should name the actual failure (an HTTP status,
     an exception type), not merely that something went wrong.
 
-    Raised by `_fetch_range` on any non-2xx response, and by
-    `fetch_gfa_segment_tags` around its parse. The other three range-based
-    fetchers (vcf, fastq, fasta) catch it and return None *silently*, so their
-    records are still dropped without a stated cause (see #155) — and so a
-    corpus-wide run is not flooded with one line per missing mirror object
-    (#156). `fetch_bam_header` never raises FetchError: it shells out to samtools
-    rather than calling `_fetch_range`.
+    Raised by `_fetch_range` on any non-2xx response, and by every header fetcher
+    (bam/vcf/fastq/fasta/gfa) when the content cannot be read or parsed — each
+    propagates it (rather than returning None), so its record is written as a
+    `not_classified` row naming the cause instead of vanishing (#155). One
+    exception: `fetch_bam_header` lets a `FileNotFoundError` (samtools not
+    installed) propagate as itself, since a missing tool is an environment failure
+    for every BAM record, not unreadable content for one. Each failure prints one
+    line via `_fetch_and_classify`; the mirror missing an unknown number of objects
+    is tracked separately (#156).
     """
 
     def __init__(self, reason: str):
@@ -90,9 +92,10 @@ def _fetch_range(md5sum: str, end_byte: int, timeout: int = 60, url: str | None 
     Raises FetchError naming the HTTP status on a non-2xx response. 404 means the
     mirror does not hold this md5 — which is not the same as the file not existing,
     since the catalog entry may still carry a size and a DRS URI. The vcf/fastq/fasta
-    callers catch it in an explicit `except FetchError` and return None silently,
-    so their records are still dropped without a cause (see #155). That clause must
-    precede their `except Exception`, or a non-2xx would be reported as an error.
+    callers re-raise it in an explicit `except FetchError: raise`, so the record
+    becomes a `not_classified` row with the HTTP status as its reason (#155). That
+    clause must precede their `except Exception`, or a non-2xx would be re-wrapped as
+    a generic error.
     """
     fetch_url = url or f"{S3_MIRROR_URL}/{md5sum}.md5"
     headers = {"Range": f"bytes=0-{end_byte}"}
@@ -145,11 +148,18 @@ def fetch_bam_header(
     use_cache: bool = True,
     url: str | None = None,
     **kwargs,
-) -> str | None:
+) -> str:
     """Read BAM/CRAM header from S3 using samtools.
 
     If url is provided, fetches from that URL directly. Otherwise uses the AnVIL S3 mirror.
-    Returns raw SAM header text or None.
+    Returns raw SAM header text (possibly empty for a readable header-less file).
+
+    Raises ``FetchError`` naming the cause when the header cannot be read (samtools
+    exits non-zero, times out, or the parse fails), so the record is kept as a
+    ``not_classified`` row instead of vanishing (#155). ``samtools`` being absent is
+    *not* a ``FetchError``: it is an environment failure affecting every BAM record,
+    so the ``FileNotFoundError`` propagates rather than masquerading as unreadable
+    content (it surfaces as an errored record, or crashes the sequential path).
     """
     if use_cache:
         cached = load_cached_evidence(evidence_dir, md5sum)
@@ -165,7 +175,7 @@ def fetch_bam_header(
             timeout=120,
         )
         if result.returncode != 0:
-            return None
+            raise FetchError(f"samtools view -H exited {result.returncode}: {result.stderr.strip() or 'no stderr'}")
 
         header_text = result.stdout
         if header_text:
@@ -181,15 +191,16 @@ def fetch_bam_header(
             save_evidence(evidence_dir, md5sum, evidence)
 
         return header_text
-    except subprocess.TimeoutExpired:
-        print(f"Timeout reading header for {md5sum}")
-        return None
+    except subprocess.TimeoutExpired as e:
+        raise FetchError(f"Timeout reading BAM header: {e}") from e
     except FileNotFoundError:
-        print("Error: samtools not found. Please install samtools.")
-        return None
+        # samtools missing is an environment failure affecting every BAM record —
+        # let it propagate (not a FetchError) so it does not become not_classified data.
+        raise
+    except FetchError:
+        raise  # already carries its reason — don't re-wrap as "FetchError: ..."
     except Exception as e:
-        print(f"Error reading header for {md5sum}: {e}")
-        return None
+        raise FetchError(f"{type(e).__name__}: {e}") from e
 
 
 # =============================================================================
@@ -234,11 +245,13 @@ def fetch_vcf_header(
     use_cache: bool = True,
     url: str | None = None,
     **kwargs,
-) -> str | None:
+) -> str:
     """Read VCF header from S3 via range request.
 
     If url is provided, fetches from that URL directly. Otherwise uses the AnVIL S3 mirror.
-    Returns header text (lines starting with #) or None.
+    Returns header text (lines starting with #). Raises ``FetchError`` naming the
+    cause when the range request fails or no header is found, so the record is kept
+    as a ``not_classified`` row instead of vanishing (#155).
     """
     if use_cache:
         cached = load_cached_evidence(evidence_dir, md5sum)
@@ -279,20 +292,14 @@ def fetch_vcf_header(
             save_evidence(evidence_dir, md5sum, evidence)
             return header_text
 
-        return None
+        raise FetchError("no VCF header lines (no '#' lines) in first 1MB")
 
     except FetchError:
-        # A non-2xx response. Silent, as before FetchError existed: this fetcher
-        # drops the record rather than reporting a cause (see #155). Printing per
-        # file would flood the run — the mirror is missing an unknown number of
-        # objects (#156).
-        return None
-    except requests.Timeout:
-        print(f"Timeout reading header for {md5sum}")
-        return None
+        raise  # propagate its reason (a non-2xx from _fetch_range, or the check above)
+    except requests.Timeout as e:
+        raise FetchError(f"Timeout reading VCF header: {e}") from e
     except Exception as e:
-        print(f"Error reading header for {md5sum}: {e}")
-        return None
+        raise FetchError(f"{type(e).__name__}: {e}") from e
 
 
 # =============================================================================
@@ -309,11 +316,13 @@ def fetch_fastq_reads(
     use_cache: bool = True,
     url: str | None = None,
     **kwargs,
-) -> list[str] | None:
+) -> list[str]:
     """Read first N read names from a FASTQ file on S3.
 
     If url is provided, fetches from that URL directly. Otherwise uses the AnVIL S3 mirror.
-    Returns list of read name lines (starting with @) or None.
+    Returns list of read name lines (starting with @). Raises ``FetchError`` naming
+    the cause when the range request fails or no read names are found, so the record
+    is kept as a ``not_classified`` row instead of vanishing (#155).
     """
     if use_cache:
         cached = load_cached_evidence(evidence_dir, md5sum)
@@ -349,21 +358,16 @@ def fetch_fastq_reads(
             if url:
                 evidence["source_url"] = url
             save_evidence(evidence_dir, md5sum, evidence)
+            return read_names
 
-        return read_names if read_names else None
+        raise FetchError("no FASTQ read names (no '@' lines) in first 256KB")
 
     except FetchError:
-        # A non-2xx response. Silent, as before FetchError existed: this fetcher
-        # drops the record rather than reporting a cause (see #155). Printing per
-        # file would flood the run — the mirror is missing an unknown number of
-        # objects (#156).
-        return None
-    except requests.Timeout:
-        print(f"Timeout reading FASTQ for {md5sum}")
-        return None
+        raise  # propagate its reason (a non-2xx from _fetch_range, or the check above)
+    except requests.Timeout as e:
+        raise FetchError(f"Timeout reading FASTQ: {e}") from e
     except Exception as e:
-        print(f"Error reading FASTQ for {md5sum}: {e}")
-        return None
+        raise FetchError(f"{type(e).__name__}: {e}") from e
 
 
 # =============================================================================
@@ -379,11 +383,14 @@ def fetch_fasta_headers(
     use_cache: bool = True,
     url: str | None = None,
     **kwargs,
-) -> list[str] | None:
+) -> list[str]:
     """Read contig names from a FASTA file on S3.
 
     If url is provided, fetches from that URL directly. Otherwise uses the AnVIL S3 mirror.
-    Returns list of contig names (from > header lines, without >) or None.
+    Returns list of contig names (from > header lines, without >); an empty list when
+    the fetched head holds no contig line is a readable result, not a failure. Raises
+    ``FetchError`` naming the cause when the range request itself fails, so the record
+    is kept as a ``not_classified`` row instead of vanishing (#155).
     """
     if use_cache:
         cached = load_cached_evidence(evidence_dir, md5sum)
@@ -420,17 +427,11 @@ def fetch_fasta_headers(
         return contig_names
 
     except FetchError:
-        # A non-2xx response. Silent, as before FetchError existed: this fetcher
-        # drops the record rather than reporting a cause (see #155). Printing per
-        # file would flood the run — the mirror is missing an unknown number of
-        # objects (#156).
-        return None
-    except requests.Timeout:
-        print(f"Timeout reading FASTA for {md5sum}")
-        return None
+        raise  # propagate its reason (a non-2xx from _fetch_range)
+    except requests.Timeout as e:
+        raise FetchError(f"Timeout reading FASTA: {e}") from e
     except Exception as e:
-        print(f"Error reading FASTA for {md5sum}: {e}")
-        return None
+        raise FetchError(f"{type(e).__name__}: {e}") from e
 
 
 # =============================================================================

--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -201,14 +201,17 @@ def fetch_bam_header(
     """Read BAM/CRAM header from S3 using samtools.
 
     If url is provided, fetches from that URL directly. Otherwise uses the AnVIL S3 mirror.
-    Returns raw SAM header text (possibly empty for a readable header-less file).
+    Returns raw (non-empty) SAM header text.
 
     Raises ``FetchError`` naming the cause when the header cannot be read (samtools
-    exits non-zero, times out, or the parse fails), so the record is kept as a
-    ``not_classified`` row instead of vanishing (#155). ``samtools`` being absent is
-    *not* a ``FetchError`` (see ``passthrough`` on the decorator): it is an
-    environment failure affecting every BAM record, so the ``FileNotFoundError``
-    propagates rather than masquerading as unreadable content.
+    exits non-zero, times out, returns an empty header, or the parse fails), so the
+    record is kept as a ``not_classified`` row instead of vanishing (#155). An empty
+    header is a failure, not a readable result — a valid BAM/CRAM always carries at
+    least an ``@HD``/``@SQ`` line — so it raises like the vcf/fastq empty-content
+    cases rather than caching an empty string. ``samtools`` being absent is *not* a
+    ``FetchError`` (see ``passthrough`` on the decorator): it is an environment
+    failure affecting every BAM record, so the ``FileNotFoundError`` propagates
+    rather than masquerading as unreadable content.
     """
     if use_cache:
         cached = load_cached_evidence(evidence_dir, md5sum)
@@ -226,17 +229,19 @@ def fetch_bam_header(
         raise FetchError(f"samtools view -H exited {result.returncode}: {result.stderr.strip() or 'no stderr'}")
 
     header_text = result.stdout
-    if header_text:
-        evidence = {
-            "md5sum": md5sum,
-            "file_name": file_name,
-            "header_text": header_text,
-            "header_line_count": len(header_text.split("\n")),
-            "fetch_timestamp": _timestamp(),
-        }
-        if url:
-            evidence["source_url"] = url
-        save_evidence(evidence_dir, md5sum, evidence)
+    if not header_text:
+        raise FetchError("samtools returned an empty SAM header")
+
+    evidence = {
+        "md5sum": md5sum,
+        "file_name": file_name,
+        "header_text": header_text,
+        "header_line_count": len(header_text.split("\n")),
+        "fetch_timestamp": _timestamp(),
+    }
+    if url:
+        evidence["source_url"] = url
+    save_evidence(evidence_dir, md5sum, evidence)
 
     return header_text
 

--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -7,7 +7,9 @@ Shared evidence cache helpers are parameterized by evidence_dir so the
 same logic works for all file types.
 """
 
+import functools
 import json
+import shutil
 import subprocess
 import time
 import zlib
@@ -45,6 +47,39 @@ class FetchError(Exception):
     def __init__(self, reason: str):
         super().__init__(reason)
         self.reason = reason
+
+
+def wrap_as_fetch_error(label: str, passthrough: tuple[type[BaseException], ...] = ()):
+    """Decorate a fetcher so any read/parse failure surfaces as ``FetchError``.
+
+    Centralizes the wrapping policy every fetcher shares (#155), so the ordering
+    rule lives in one place instead of a hand-copied ``except`` tail per fetcher:
+
+    * a ``FetchError`` raised in the body passes through unchanged — its ``reason``
+      is already specific (e.g. the HTTP status from ``_fetch_range`` or an
+      empty-content message);
+    * exception types in ``passthrough`` propagate as themselves — for an
+      *environment* failure (``fetch_bam_header`` passes ``FileNotFoundError`` when
+      samtools is absent) that must not become one file's unreadable content;
+    * everything else becomes ``FetchError(f"{label}: {type(e).__name__}: {e}")``,
+      so the record is kept as a ``not_classified`` row naming the cause.
+    """
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            try:
+                return fn(*args, **kwargs)
+            except FetchError:
+                raise
+            except passthrough:
+                raise
+            except Exception as e:
+                raise FetchError(f"{label}: {type(e).__name__}: {e}") from e
+
+        return wrapper
+
+    return decorator
 
 
 # =============================================================================
@@ -91,11 +126,9 @@ def _fetch_range(md5sum: str, end_byte: int, timeout: int = 60, url: str | None 
 
     Raises FetchError naming the HTTP status on a non-2xx response. 404 means the
     mirror does not hold this md5 — which is not the same as the file not existing,
-    since the catalog entry may still carry a size and a DRS URI. The vcf/fastq/fasta
-    callers re-raise it in an explicit `except FetchError: raise`, so the record
-    becomes a `not_classified` row with the HTTP status as its reason (#155). That
-    clause must precede their `except Exception`, or a non-2xx would be re-wrapped as
-    a generic error.
+    since the catalog entry may still carry a size and a DRS URI. `@wrap_as_fetch_error`
+    lets this FetchError pass through unchanged, so the record becomes a
+    `not_classified` row with the HTTP status as its reason (#155).
     """
     fetch_url = url or f"{S3_MIRROR_URL}/{md5sum}.md5"
     headers = {"Range": f"bytes=0-{end_byte}"}
@@ -141,6 +174,22 @@ def _decode_bytes(content: bytes) -> str:
 # =============================================================================
 
 
+def require_samtools() -> None:
+    """Abort the run if samtools is not on PATH (FileTypeConfig.preflight for BAM).
+
+    Run once before the worker pool: a missing tool then fails fast with one clear
+    message, instead of every BAM record's ``samtools`` call raising
+    ``FileNotFoundError`` and the records vanishing — the disappearance #155 exists
+    to prevent. The per-record ``FileNotFoundError`` passthrough in
+    ``fetch_bam_header`` remains as a backstop for a tool removed mid-run.
+    """
+    if shutil.which("samtools") is None:
+        raise RuntimeError(
+            "samtools not found on PATH — required to read BAM/CRAM headers. Install samtools and retry."
+        )
+
+
+@wrap_as_fetch_error("BAM header", passthrough=(FileNotFoundError,))
 def fetch_bam_header(
     evidence_dir: Path,
     md5sum: str,
@@ -157,9 +206,9 @@ def fetch_bam_header(
     Raises ``FetchError`` naming the cause when the header cannot be read (samtools
     exits non-zero, times out, or the parse fails), so the record is kept as a
     ``not_classified`` row instead of vanishing (#155). ``samtools`` being absent is
-    *not* a ``FetchError``: it is an environment failure affecting every BAM record,
-    so the ``FileNotFoundError`` propagates rather than masquerading as unreadable
-    content (it surfaces as an errored record, or crashes the sequential path).
+    *not* a ``FetchError`` (see ``passthrough`` on the decorator): it is an
+    environment failure affecting every BAM record, so the ``FileNotFoundError``
+    propagates rather than masquerading as unreadable content.
     """
     if use_cache:
         cached = load_cached_evidence(evidence_dir, md5sum)
@@ -167,40 +216,29 @@ def fetch_bam_header(
             return cached["header_text"]
 
     fetch_url = url or f"{S3_MIRROR_URL}/{md5sum}.md5"
-    try:
-        result = subprocess.run(
-            ["samtools", "view", "-H", fetch_url],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        if result.returncode != 0:
-            raise FetchError(f"samtools view -H exited {result.returncode}: {result.stderr.strip() or 'no stderr'}")
+    result = subprocess.run(
+        ["samtools", "view", "-H", fetch_url],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        raise FetchError(f"samtools view -H exited {result.returncode}: {result.stderr.strip() or 'no stderr'}")
 
-        header_text = result.stdout
-        if header_text:
-            evidence = {
-                "md5sum": md5sum,
-                "file_name": file_name,
-                "header_text": header_text,
-                "header_line_count": len(header_text.split("\n")),
-                "fetch_timestamp": _timestamp(),
-            }
-            if url:
-                evidence["source_url"] = url
-            save_evidence(evidence_dir, md5sum, evidence)
+    header_text = result.stdout
+    if header_text:
+        evidence = {
+            "md5sum": md5sum,
+            "file_name": file_name,
+            "header_text": header_text,
+            "header_line_count": len(header_text.split("\n")),
+            "fetch_timestamp": _timestamp(),
+        }
+        if url:
+            evidence["source_url"] = url
+        save_evidence(evidence_dir, md5sum, evidence)
 
-        return header_text
-    except subprocess.TimeoutExpired as e:
-        raise FetchError(f"Timeout reading BAM header: {e}") from e
-    except FileNotFoundError:
-        # samtools missing is an environment failure affecting every BAM record —
-        # let it propagate (not a FetchError) so it does not become not_classified data.
-        raise
-    except FetchError:
-        raise  # already carries its reason — don't re-wrap as "FetchError: ..."
-    except Exception as e:
-        raise FetchError(f"{type(e).__name__}: {e}") from e
+    return header_text
 
 
 # =============================================================================
@@ -237,6 +275,7 @@ def extract_max_positions(variant_lines: list[str], max_variants: int = 100) -> 
     return max_positions
 
 
+@wrap_as_fetch_error("VCF header")
 def fetch_vcf_header(
     evidence_dir: Path,
     md5sum: str,
@@ -258,48 +297,40 @@ def fetch_vcf_header(
         if cached and cached.get("header_text"):
             return cached["header_text"]
 
-    try:
-        content = _fetch_range(md5sum, 1048576, timeout=60, url=url)  # 1MB
-        raw_bytes = len(content)
+    content = _fetch_range(md5sum, 1048576, timeout=60, url=url)  # 1MB
+    raw_bytes = len(content)
 
-        content = _decompress_if_gzipped(content, is_gzipped)
-        text = _decode_bytes(content)
+    content = _decompress_if_gzipped(content, is_gzipped)
+    text = _decode_bytes(content)
 
-        header_lines = []
-        variant_lines = []
+    header_lines = []
+    variant_lines = []
 
-        for line in text.split("\n"):
-            if line.startswith("#"):
-                header_lines.append(line)
-            elif line.strip() and len(variant_lines) < 100:
-                variant_lines.append(line)
+    for line in text.split("\n"):
+        if line.startswith("#"):
+            header_lines.append(line)
+        elif line.strip() and len(variant_lines) < 100:
+            variant_lines.append(line)
 
-        if header_lines:
-            header_text = "\n".join(header_lines)
-            max_positions = extract_max_positions(variant_lines) if variant_lines else None
-            evidence = {
-                "md5sum": md5sum,
-                "file_name": file_name,
-                "header_text": header_text,
-                "header_line_count": len(header_lines),
-                "raw_bytes_fetched": raw_bytes,
-                "fetch_timestamp": _timestamp(),
-            }
-            if max_positions:
-                evidence["max_positions"] = max_positions
-            if url:
-                evidence["source_url"] = url
-            save_evidence(evidence_dir, md5sum, evidence)
-            return header_text
+    if header_lines:
+        header_text = "\n".join(header_lines)
+        max_positions = extract_max_positions(variant_lines) if variant_lines else None
+        evidence = {
+            "md5sum": md5sum,
+            "file_name": file_name,
+            "header_text": header_text,
+            "header_line_count": len(header_lines),
+            "raw_bytes_fetched": raw_bytes,
+            "fetch_timestamp": _timestamp(),
+        }
+        if max_positions:
+            evidence["max_positions"] = max_positions
+        if url:
+            evidence["source_url"] = url
+        save_evidence(evidence_dir, md5sum, evidence)
+        return header_text
 
-        raise FetchError("no VCF header lines (no '#' lines) in first 1MB")
-
-    except FetchError:
-        raise  # propagate its reason (a non-2xx from _fetch_range, or the check above)
-    except requests.Timeout as e:
-        raise FetchError(f"Timeout reading VCF header: {e}") from e
-    except Exception as e:
-        raise FetchError(f"{type(e).__name__}: {e}") from e
+    raise FetchError("no VCF header lines (no '#' lines) in first 1MB")
 
 
 # =============================================================================
@@ -307,6 +338,7 @@ def fetch_vcf_header(
 # =============================================================================
 
 
+@wrap_as_fetch_error("FASTQ")
 def fetch_fastq_reads(
     evidence_dir: Path,
     md5sum: str,
@@ -329,45 +361,37 @@ def fetch_fastq_reads(
         if cached and cached.get("read_names"):
             return cached["read_names"]
 
-    try:
-        content = _fetch_range(md5sum, 262144, timeout=60, url=url)  # 256KB
-        raw_bytes = len(content)
+    content = _fetch_range(md5sum, 262144, timeout=60, url=url)  # 256KB
+    raw_bytes = len(content)
 
-        content = _decompress_if_gzipped(content, is_gzipped)
-        text = _decode_bytes(content)
+    content = _decompress_if_gzipped(content, is_gzipped)
+    text = _decode_bytes(content)
 
-        lines = text.split("\n")
-        read_names = []
-        i = 0
-        while i < len(lines) and len(read_names) < num_reads:
-            line = lines[i].strip()
-            if line.startswith("@"):
-                read_names.append(line)
-                i += 4  # Skip sequence, +, quality
-            else:
-                i += 1
+    lines = text.split("\n")
+    read_names = []
+    i = 0
+    while i < len(lines) and len(read_names) < num_reads:
+        line = lines[i].strip()
+        if line.startswith("@"):
+            read_names.append(line)
+            i += 4  # Skip sequence, +, quality
+        else:
+            i += 1
 
-        if read_names:
-            evidence = {
-                "md5sum": md5sum,
-                "file_name": file_name,
-                "read_names": read_names,
-                "raw_bytes_fetched": raw_bytes,
-                "fetch_timestamp": _timestamp(),
-            }
-            if url:
-                evidence["source_url"] = url
-            save_evidence(evidence_dir, md5sum, evidence)
-            return read_names
+    if read_names:
+        evidence = {
+            "md5sum": md5sum,
+            "file_name": file_name,
+            "read_names": read_names,
+            "raw_bytes_fetched": raw_bytes,
+            "fetch_timestamp": _timestamp(),
+        }
+        if url:
+            evidence["source_url"] = url
+        save_evidence(evidence_dir, md5sum, evidence)
+        return read_names
 
-        raise FetchError("no FASTQ read names (no '@' lines) in first 256KB")
-
-    except FetchError:
-        raise  # propagate its reason (a non-2xx from _fetch_range, or the check above)
-    except requests.Timeout as e:
-        raise FetchError(f"Timeout reading FASTQ: {e}") from e
-    except Exception as e:
-        raise FetchError(f"{type(e).__name__}: {e}") from e
+    raise FetchError("no FASTQ read names (no '@' lines) in first 256KB")
 
 
 # =============================================================================
@@ -375,6 +399,7 @@ def fetch_fastq_reads(
 # =============================================================================
 
 
+@wrap_as_fetch_error("FASTA")
 def fetch_fasta_headers(
     evidence_dir: Path,
     md5sum: str,
@@ -397,41 +422,33 @@ def fetch_fasta_headers(
         if cached and "contig_names" in cached:
             return cached["contig_names"]
 
-    try:
-        content = _fetch_range(md5sum, 262144, timeout=60, url=url)  # 256KB
-        raw_bytes = len(content)
+    content = _fetch_range(md5sum, 262144, timeout=60, url=url)  # 256KB
+    raw_bytes = len(content)
 
-        content = _decompress_if_gzipped(content, is_gzipped)
-        text = _decode_bytes(content)
+    content = _decompress_if_gzipped(content, is_gzipped)
+    text = _decode_bytes(content)
 
-        contig_names = []
-        for line in text.split("\n"):
-            line = line.strip()
-            if line.startswith(">"):
-                name = line[1:].split()[0] if line[1:].strip() else line[1:].strip()
-                if name:
-                    contig_names.append(name)
+    contig_names = []
+    for line in text.split("\n"):
+        line = line.strip()
+        if line.startswith(">"):
+            name = line[1:].split()[0] if line[1:].strip() else line[1:].strip()
+            if name:
+                contig_names.append(name)
 
-        evidence = {
-            "md5sum": md5sum,
-            "file_name": file_name,
-            "contig_names": contig_names,
-            "contig_count": len(contig_names),
-            "raw_bytes_fetched": raw_bytes,
-            "fetch_timestamp": _timestamp(),
-        }
-        if url:
-            evidence["source_url"] = url
-        save_evidence(evidence_dir, md5sum, evidence)
+    evidence = {
+        "md5sum": md5sum,
+        "file_name": file_name,
+        "contig_names": contig_names,
+        "contig_count": len(contig_names),
+        "raw_bytes_fetched": raw_bytes,
+        "fetch_timestamp": _timestamp(),
+    }
+    if url:
+        evidence["source_url"] = url
+    save_evidence(evidence_dir, md5sum, evidence)
 
-        return contig_names
-
-    except FetchError:
-        raise  # propagate its reason (a non-2xx from _fetch_range)
-    except requests.Timeout as e:
-        raise FetchError(f"Timeout reading FASTA: {e}") from e
-    except Exception as e:
-        raise FetchError(f"{type(e).__name__}: {e}") from e
+    return contig_names
 
 
 # =============================================================================
@@ -490,6 +507,7 @@ def parse_gfa_segment_tags(text: str, truncated: bool = True) -> list[dict]:
     return segments
 
 
+@wrap_as_fetch_error("GFA head")
 def fetch_gfa_segment_tags(
     evidence_dir: Path,
     md5sum: str,
@@ -533,42 +551,33 @@ def fetch_gfa_segment_tags(
         if cached and "gfa_segment_tags" in cached:
             return cached["gfa_segment_tags"]
 
-    try:
-        # end_byte is inclusive, so 262143 fetches exactly HEAD_BYTES.
-        content = _fetch_range(md5sum, HEAD_BYTES - 1, timeout=60, url=url)
-        raw_bytes = len(content)
+    # end_byte is inclusive, so 262143 fetches exactly HEAD_BYTES. A read/parse
+    # failure — including a programming error in parse_gfa_segment_tags — is wrapped
+    # as FetchError by @wrap_as_fetch_error, so it surfaces as a not_classified row
+    # naming the cause rather than silently deleting the file's row.
+    content = _fetch_range(md5sum, HEAD_BYTES - 1, timeout=60, url=url)
+    raw_bytes = len(content)
 
-        # Fewer bytes than we asked for means we hold the whole file; a gzip stream
-        # that ends with nothing after it means we decoded all of it. Only when both
-        # hold is the text complete, so an unterminated final line is a real record.
-        # (BGZF fails the second test: its first member ends but more members follow.)
-        got_whole_file = raw_bytes < HEAD_BYTES
-        content, stream_complete = _decompress_head(content, is_gzipped)
-        text = _decode_bytes(content)
+    # Fewer bytes than we asked for means we hold the whole file; a gzip stream
+    # that ends with nothing after it means we decoded all of it. Only when both
+    # hold is the text complete, so an unterminated final line is a real record.
+    # (BGZF fails the second test: its first member ends but more members follow.)
+    got_whole_file = raw_bytes < HEAD_BYTES
+    content, stream_complete = _decompress_head(content, is_gzipped)
+    text = _decode_bytes(content)
 
-        segment_tags = parse_gfa_segment_tags(text, truncated=not (got_whole_file and stream_complete))
+    segment_tags = parse_gfa_segment_tags(text, truncated=not (got_whole_file and stream_complete))
 
-        evidence = {
-            "md5sum": md5sum,
-            "file_name": file_name,
-            "gfa_segment_tags": segment_tags,
-            "tagged_segment_count": len(segment_tags),
-            "raw_bytes_fetched": raw_bytes,
-            "fetch_timestamp": _timestamp(),
-        }
-        if url:
-            evidence["source_url"] = url
-        save_evidence(evidence_dir, md5sum, evidence)
+    evidence = {
+        "md5sum": md5sum,
+        "file_name": file_name,
+        "gfa_segment_tags": segment_tags,
+        "tagged_segment_count": len(segment_tags),
+        "raw_bytes_fetched": raw_bytes,
+        "fetch_timestamp": _timestamp(),
+    }
+    if url:
+        evidence["source_url"] = url
+    save_evidence(evidence_dir, md5sum, evidence)
 
-        return segment_tags
-
-    except FetchError:
-        raise  # already carries its reason — don't re-wrap as "FetchError: ..."
-    except requests.Timeout as e:
-        raise FetchError(f"Timeout reading GFA head: {e}") from e
-    except Exception as e:
-        # Wrapped, not swallowed: the caller turns this into a not_classified
-        # record whose evidence names the cause. A programming error in the
-        # parser therefore surfaces as `TypeError: ...` in the output rather
-        # than silently deleting the file's row.
-        raise FetchError(f"{type(e).__name__}: {e}") from e
+    return segment_tags

--- a/src/meta_disco/file_types.py
+++ b/src/meta_disco/file_types.py
@@ -11,6 +11,7 @@ from .fetchers import (
     fetch_fastq_reads,
     fetch_gfa_segment_tags,
     fetch_vcf_header,
+    require_samtools,
 )
 from .header_classifier import (
     GRAPH_TEXT_EXTENSIONS,
@@ -31,6 +32,8 @@ BAM_CONFIG = FileTypeConfig(
     summary_printer=print_bam_summary,
     # @SQ contig lengths, @RG platform; assay_type is inferred from those.
     content_fields=("data_modality", "data_type", "reference_assembly", "platform", "assay_type"),
+    # samtools reads BAM/CRAM headers — fail fast if it is not installed.
+    preflight=require_samtools,
 )
 
 VCF_CONFIG = FileTypeConfig(

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -244,8 +244,13 @@ class ClassifyPipeline:
 
         # Fail fast on a missing environment dependency (e.g. samtools for BAM)
         # before the pool starts, so it aborts once with a clear message instead of
-        # every record failing to read and vanishing.
-        if self.config.preflight is not None:
+        # every record failing to read and vanishing. Only when a record will actually
+        # invoke the fetcher: an all-cached resume run reads evidence from disk and
+        # needs no tool, so it must not abort.
+        will_fetch = any(
+            not (self.resume and w.file_md5sum in cached_md5s) for w in work if isinstance(w, ClassifierRecord)
+        )
+        if self.config.preflight is not None and will_fetch:
             self.config.preflight()
 
         self.evidence_dir.mkdir(parents=True, exist_ok=True)

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -243,11 +243,14 @@ class ClassifyPipeline:
         if not work:
             return []
 
-        # Fail fast on a missing environment dependency (e.g. samtools for BAM)
-        # before the pool starts, so it aborts once with a clear message instead of
-        # every record failing to read and vanishing. Only when a record will actually
-        # invoke the fetcher: an all-cached resume run reads evidence from disk and
-        # needs no tool, so it must not abort.
+        # Best-effort fast-fail on a missing environment dependency (e.g. samtools
+        # for BAM) before the pool starts, so it aborts once with a clear message
+        # instead of every record failing to read and vanishing. Skipped when every
+        # record is already cached (`_is_cached` = evidence file present), since a
+        # warm resume run serves from disk without the tool. This is keyed on file
+        # existence, not evidence validity: a corrupt/partial evidence file passes
+        # `_is_cached` yet the fetcher re-fetches — for that case the per-record
+        # passthrough (bam's `FileNotFoundError`) is the backstop, not this guard.
         will_fetch = any(
             not (self.resume and w.file_md5sum in cached_md5s) for w in work if isinstance(w, ClassifierRecord)
         )

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -275,9 +275,11 @@ class ClassifyPipeline:
     ) -> dict:
         """Classify a single file by MD5. Does not require a full pipeline instance.
 
-        Always returns a record: a fetch failure yields filename-only
-        ``not_classified`` classifications (the fetcher raises ``FetchError``), never
-        ``None`` (#155).
+        Never returns ``None`` (#155): a fetch failure surfaces as a ``FetchError``,
+        which yields filename-only ``not_classified`` classifications. It does not
+        catch everything, though — an environment error (missing samtools raises
+        ``FileNotFoundError``) or an unexpected exception from the fetcher/classifier
+        propagates rather than returning a record.
         """
         evidence_dir = evidence_base / config.name
         evidence_dir.mkdir(parents=True, exist_ok=True)

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -60,15 +60,16 @@ def load_records(input_path: Path) -> list:
 class RecordOutcome(NamedTuple):
     """The outcome of processing one record, tallied by ``_run_parallel``.
 
-    ``result`` is the output record, or ``None`` when the fetcher gave no cause to
-    keep the row (a drop). The three flags are mutually exclusive and only one, at
-    most, is set: a record is written as ``validation_failed`` (failed the input
-    contract), ``was_cached`` (evidence already on disk), ``content_unreadable``
-    (fetch failed, classified from the filename), or none of these (a fresh fetch).
-    Named so the four fields cannot be transposed at the unpack sites.
+    ``result`` is always the output record — every record produces a row now that
+    fetchers raise ``FetchError`` instead of returning ``None`` (#155). The three
+    flags are mutually exclusive and only one, at most, is set: a record is written
+    as ``validation_failed`` (failed the input contract), ``was_cached`` (evidence
+    already on disk), ``content_unreadable`` (fetch failed, classified from the
+    filename), or none of these (a fresh fetch). Named so the four fields cannot be
+    transposed at the unpack sites.
     """
 
-    result: dict | None
+    result: dict
     was_cached: bool
     content_unreadable: bool
     validation_failed: bool
@@ -99,19 +100,20 @@ def _fetch_and_classify(
     file_format: str | None,
     is_gzipped: bool,
     use_cache: bool,
-) -> tuple[dict | None, bool]:
+) -> tuple[dict, bool]:
     """Fetch a file's content and classify it.
 
-    Returns ``(classifications, content_unreadable)``. Three outcomes:
+    Returns ``(classifications, content_unreadable)``. Two outcomes:
 
     * content read        -> ``(classifications, False)``
     * content unreadable  -> ``(filename-only classifications, True)``. The fetcher
-      raised FetchError naming its cause, so the file stays in the output.
-    * fetch returned None -> ``(None, False)``. No cause given, so the caller drops
-      the record (see #155).
+      raised FetchError naming its cause, so the file stays in the output as a
+      ``not_classified`` row rather than vanishing (#155).
 
-    Shared by ``ClassifyPipeline.classify_single`` and ``_process_single_record``
-    so the fallback cannot drift between the single-file and batch paths.
+    Every record therefore yields a row — a fetcher signals failure by raising, never
+    by returning ``None``. Shared by ``ClassifyPipeline.classify_single`` and
+    ``_process_single_record`` so the fallback cannot drift between the single-file
+    and batch paths.
     """
     try:
         raw_data = config.fetcher(
@@ -131,9 +133,6 @@ def _fetch_and_classify(
             allowed_extensions=config.extensions,
             content_fields=config.content_fields,
         ), True
-
-    if raw_data is None:
-        return None, False
 
     return config.classifier(
         raw_data,
@@ -258,8 +257,13 @@ class ClassifyPipeline:
         is_gzipped: bool = True,
         use_cache: bool = True,
         evidence_base: Path = Path("data/evidence/anvil"),
-    ) -> dict | None:
-        """Classify a single file by MD5. Does not require a full pipeline instance."""
+    ) -> dict:
+        """Classify a single file by MD5. Does not require a full pipeline instance.
+
+        Always returns a record: a fetch failure yields filename-only
+        ``not_classified`` classifications (the fetcher raises ``FetchError``), never
+        ``None`` (#155).
+        """
         evidence_dir = evidence_base / config.name
         evidence_dir.mkdir(parents=True, exist_ok=True)
 
@@ -273,8 +277,6 @@ class ClassifyPipeline:
             is_gzipped=is_gzipped,
             use_cache=use_cache,
         )
-        if classifications is None:
-            return None
         return {
             "file_name": file_name,
             "md5sum": md5sum,
@@ -433,11 +435,6 @@ class ClassifyPipeline:
             is_gzipped=is_gzipped,
             use_cache=self.resume,
         )
-        if classifications is None:
-            # A dropped row (no result) carries no outcome flags — was_cached would
-            # otherwise mislabel the dropped record as "[cached]" in the progress line.
-            return RecordOutcome(None, was_cached=False, content_unreadable=False, validation_failed=False)
-
         if content_unreadable:
             # was_cached is a file-existence stat taken before the fetch. A fetcher
             # only raises after its own cache check missed, so it went to the
@@ -475,7 +472,9 @@ class ClassifyPipeline:
     def _run_parallel(self, work: list[ClassifierRecord | InvalidRecord]) -> list[dict]:
         """ThreadPoolExecutor with progress tracking, returns classifications."""
         successful = 0
-        dropped = 0  # fetcher returned None: no cause given
+        # Fetch failures now surface as content_unreadable rows, never as dropped
+        # records (#155); kept as a constant 0 for output-schema stability.
+        dropped = 0
         errored = 0  # worker raised: a cause was printed
         invalid = 0  # failed input validation: written, classified as nothing (#161)
         from_cache = 0
@@ -489,21 +488,18 @@ class ClassifyPipeline:
         with NdjsonWriter(self.output_path) as writer:
 
             def update_progress(outcome: RecordOutcome, file_name: str):
-                nonlocal successful, dropped, from_cache, processed, unreadable, invalid
+                nonlocal successful, from_cache, processed, unreadable, invalid
                 with lock:
                     processed += 1
-                    if outcome.result is not None:
-                        writer.write(outcome.result)
-                        if outcome.validation_failed:
-                            invalid += 1
-                        else:
-                            successful += 1
-                            if outcome.was_cached:
-                                from_cache += 1
-                            elif outcome.content_unreadable:
-                                unreadable += 1
+                    writer.write(outcome.result)
+                    if outcome.validation_failed:
+                        invalid += 1
                     else:
-                        dropped += 1
+                        successful += 1
+                        if outcome.was_cached:
+                            from_cache += 1
+                        elif outcome.content_unreadable:
+                            unreadable += 1
                     cache_indicator = "[cached] " if outcome.was_cached else ""
                     # file_name is a str on both work streams (ClassifierRecord types it,
                     # InvalidRecord coerces it), so the slice cannot raise.

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -60,13 +60,13 @@ def load_records(input_path: Path) -> list:
 class RecordOutcome(NamedTuple):
     """The outcome of processing one record, tallied by ``_run_parallel``.
 
-    ``result`` is always the output record — every record produces a row now that
-    fetchers raise ``FetchError`` instead of returning ``None`` (#155). The three
-    flags are mutually exclusive and only one, at most, is set: a record is written
-    as ``validation_failed`` (failed the input contract), ``was_cached`` (evidence
-    already on disk), ``content_unreadable`` (fetch failed, classified from the
-    filename), or none of these (a fresh fetch). Named so the four fields cannot be
-    transposed at the unpack sites.
+    ``result`` is the output record for this item (a ``dict`` — see the field type;
+    a record is only diverted to ``errored`` in ``_run_parallel`` by *raising*, which
+    produces no ``RecordOutcome``). The three flags are mutually exclusive and only
+    one, at most, is set: ``validation_failed`` (failed the input contract),
+    ``was_cached`` (evidence already on disk), ``content_unreadable`` (fetch failed,
+    classified from the filename), or none of these (a fresh fetch). Named so the four
+    fields cannot be transposed at the unpack sites.
     """
 
     result: dict
@@ -107,15 +107,16 @@ def _fetch_and_classify(
 ) -> tuple[dict, bool]:
     """Fetch a file's content and classify it.
 
-    Returns ``(classifications, content_unreadable)``. Two outcomes:
+    Returns ``(classifications, content_unreadable)``:
 
     * content read        -> ``(classifications, False)``
-    * content unreadable  -> ``(filename-only classifications, True)``. The fetcher
-      raised FetchError naming its cause, so the file stays in the output as a
+    * content unreadable  -> ``(filename-only classifications, True)``, when the
+      fetcher raised ``FetchError``; the file stays in the output as a
       ``not_classified`` row rather than vanishing (#155).
 
-    Every record therefore yields a row — a fetcher signals failure by raising, never
-    by returning ``None``. Shared by ``ClassifyPipeline.classify_single`` and
+    A fetcher signals failure by raising ``FetchError``, not by returning ``None``.
+    An exception the fetcher does not wrap (e.g. a missing-tool ``FileNotFoundError``)
+    propagates. Shared by ``ClassifyPipeline.classify_single`` and
     ``_process_single_record`` so the fallback cannot drift between the single-file
     and batch paths.
     """

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -88,6 +88,10 @@ class FileTypeConfig:
     # fetch failure to the answers the unread bytes would have informed — never
     # to dimensions only the filename can supply.
     content_fields: tuple[str, ...] = ()
+    # Environment check run once before the worker pool (e.g. an external tool
+    # must be installed). Raises to abort the run fast, instead of letting every
+    # record fail the same way and vanish. None means no check.
+    preflight: Callable | None = None
 
 
 def _fetch_and_classify(
@@ -237,6 +241,12 @@ class ClassifyPipeline:
 
         if not work:
             return []
+
+        # Fail fast on a missing environment dependency (e.g. samtools for BAM)
+        # before the pool starts, so it aborts once with a clear message instead of
+        # every record failing to read and vanishing.
+        if self.config.preflight is not None:
+            self.config.preflight()
 
         self.evidence_dir.mkdir(parents=True, exist_ok=True)
         classifications = self._run_parallel(work)
@@ -472,9 +482,6 @@ class ClassifyPipeline:
     def _run_parallel(self, work: list[ClassifierRecord | InvalidRecord]) -> list[dict]:
         """ThreadPoolExecutor with progress tracking, returns classifications."""
         successful = 0
-        # Fetch failures now surface as content_unreadable rows, never as dropped
-        # records (#155); kept as a constant 0 for output-schema stability.
-        dropped = 0
         errored = 0  # worker raised: a cause was printed
         invalid = 0  # failed input validation: written, classified as nothing (#161)
         from_cache = 0
@@ -528,7 +535,6 @@ class ClassifyPipeline:
         print(f"  From cache: {from_cache}")
         print(f"  New fetches: {successful - from_cache - unreadable}")
         print(f"  Content unreadable, classified from filename: {unreadable}")
-        print(f"Dropped (fetcher gave no cause): {dropped}")
         if errored:
             print(f"Errored (cause printed above): {errored}")
         if invalid:
@@ -536,7 +542,6 @@ class ClassifyPipeline:
         classifications = self._save_final(
             total,
             successful,
-            dropped,
             from_cache=from_cache,
             unreadable=unreadable,
             errored=errored,
@@ -552,7 +557,6 @@ class ClassifyPipeline:
         self,
         total: int,
         successful: int,
-        dropped: int,
         from_cache: int,
         unreadable: int,
         errored: int = 0,
@@ -565,10 +569,10 @@ class ClassifyPipeline:
         one whose content was read, because a file type whose ``content_fields``
         is empty leaves no ``fetch_failed`` evidence behind.
 
-        ``dropped`` (the fetcher returned None, giving no cause) and ``errored``
-        (a worker raised, and the cause was printed) are recorded separately, and
-        ``failed`` is kept as their sum so existing consumers of that key still
-        read the total number of records that produced no row.
+        ``errored`` (a worker raised, and the cause was printed) is the only way a
+        record now produces no row, so ``failed`` equals it. ``dropped`` is retired —
+        a fetch failure is written as a ``content_unreadable`` row, never dropped
+        (#155) — but the key is still emitted as ``0`` for output-schema stability.
 
         ``validation_failed`` (the record failed the input contract, issue #161)
         produced a row — every dimension ``not_classified`` — so it is counted
@@ -588,12 +592,13 @@ class ClassifyPipeline:
                 {
                     "metadata": {
                         "total_to_process": total,
-                        "processed": successful + dropped + errored + validation_failed,
+                        "processed": successful + errored + validation_failed,
                         "successful": successful,
-                        # `failed` = every record that produced no row, whether the
-                        # fetcher gave no cause (dropped) or a worker raised (errored).
-                        "failed": dropped + errored,
-                        "dropped": dropped,
+                        # `failed` = every record that produced no row. A fetch failure
+                        # no longer drops a record (#155), so only a raising worker
+                        # (errored) does. `dropped` stays as a constant 0 for consumers.
+                        "failed": errored,
+                        "dropped": 0,
                         "errored": errored,
                         "validation_failed": validation_failed,
                         "from_cache": from_cache,

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -1,0 +1,109 @@
+"""Fetcher failure behavior: a read failure raises FetchError, never returns None (#155).
+
+samtools being absent is the one exception — an environment failure that must
+propagate as itself, not masquerade as unreadable content.
+"""
+
+import subprocess
+
+import pytest
+
+import meta_disco.fetchers as fetchers
+from meta_disco.fetchers import (
+    FetchError,
+    fetch_bam_header,
+    fetch_fasta_headers,
+    fetch_fastq_reads,
+    fetch_vcf_header,
+)
+
+MD5 = "a" * 32
+
+
+class _Resp:
+    def __init__(self, status_code, content=b""):
+        self.status_code = status_code
+        self.content = content
+
+
+@pytest.fixture
+def evidence_dir(tmp_path):
+    return tmp_path / "ev"
+
+
+def _patch_get(monkeypatch, resp):
+    monkeypatch.setattr(fetchers.requests, "get", lambda *a, **k: resp)
+
+
+class TestRangeFetchers:
+    def test_vcf_non_2xx_raises_fetcherror(self, monkeypatch, evidence_dir):
+        _patch_get(monkeypatch, _Resp(404))
+        with pytest.raises(FetchError) as exc:
+            fetch_vcf_header(evidence_dir, MD5, use_cache=False)
+        assert "404" in exc.value.reason
+
+    def test_vcf_empty_header_raises_fetcherror(self, monkeypatch, evidence_dir):
+        _patch_get(monkeypatch, _Resp(200, b"not a header line\nanother\n"))
+        with pytest.raises(FetchError) as exc:
+            fetch_vcf_header(evidence_dir, MD5, is_gzipped=False, use_cache=False)
+        assert "no VCF header" in exc.value.reason
+
+    def test_fastq_non_2xx_raises_fetcherror(self, monkeypatch, evidence_dir):
+        _patch_get(monkeypatch, _Resp(403))
+        with pytest.raises(FetchError):
+            fetch_fastq_reads(evidence_dir, MD5, use_cache=False)
+
+    def test_fastq_empty_raises_fetcherror(self, monkeypatch, evidence_dir):
+        _patch_get(monkeypatch, _Resp(200, b"no read names here\n"))
+        with pytest.raises(FetchError) as exc:
+            fetch_fastq_reads(evidence_dir, MD5, is_gzipped=False, use_cache=False)
+        assert "no FASTQ read names" in exc.value.reason
+
+    def test_fasta_non_2xx_raises_fetcherror(self, monkeypatch, evidence_dir):
+        _patch_get(monkeypatch, _Resp(500))
+        with pytest.raises(FetchError):
+            fetch_fasta_headers(evidence_dir, MD5, use_cache=False)
+
+    def test_fasta_empty_contigs_is_readable_not_error(self, monkeypatch, evidence_dir):
+        # No '>' lines in the fetched head is a readable empty result, not a failure.
+        _patch_get(monkeypatch, _Resp(200, b"ACGTACGT\nACGTACGT\n"))
+        assert fetch_fasta_headers(evidence_dir, MD5, is_gzipped=False, use_cache=False) == []
+
+
+class TestBamFetcher:
+    def _patch_run(self, monkeypatch, fn):
+        monkeypatch.setattr(fetchers.subprocess, "run", fn)
+
+    def test_returncode_nonzero_raises_fetcherror(self, monkeypatch, evidence_dir):
+        self._patch_run(
+            monkeypatch,
+            lambda *a, **k: subprocess.CompletedProcess(a, returncode=1, stdout="", stderr="curl: (22) 404"),
+        )
+        with pytest.raises(FetchError) as exc:
+            fetch_bam_header(evidence_dir, MD5, use_cache=False)
+        assert "404" in exc.value.reason
+
+    def test_missing_samtools_propagates_not_fetcherror(self, monkeypatch, evidence_dir):
+        # An absent tool affects every BAM record — it must NOT become not_classified
+        # data, so it propagates as FileNotFoundError rather than FetchError.
+        def _run(*a, **k):
+            raise FileNotFoundError(2, "No such file or directory", "samtools")
+
+        self._patch_run(monkeypatch, _run)
+        with pytest.raises(FileNotFoundError):
+            fetch_bam_header(evidence_dir, MD5, use_cache=False)
+
+    def test_timeout_raises_fetcherror(self, monkeypatch, evidence_dir):
+        def _run(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="samtools", timeout=120)
+
+        self._patch_run(monkeypatch, _run)
+        with pytest.raises(FetchError):
+            fetch_bam_header(evidence_dir, MD5, use_cache=False)
+
+    def test_success_returns_header(self, monkeypatch, evidence_dir):
+        self._patch_run(
+            monkeypatch,
+            lambda *a, **k: subprocess.CompletedProcess(a, returncode=0, stdout="@HD\tVN:1.6\n", stderr=""),
+        )
+        assert fetch_bam_header(evidence_dir, MD5, use_cache=False) == "@HD\tVN:1.6\n"

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -7,6 +7,7 @@ propagate as itself, not masquerade as unreadable content.
 import subprocess
 
 import pytest
+import requests
 
 import meta_disco.fetchers as fetchers
 from meta_disco.fetchers import (
@@ -69,6 +70,16 @@ class TestRangeFetchers:
         # No '>' lines in the fetched head is a readable empty result, not a failure.
         _patch_get(monkeypatch, _Resp(200, b"ACGTACGT\nACGTACGT\n"))
         assert fetch_fasta_headers(evidence_dir, MD5, is_gzipped=False, use_cache=False) == []
+
+    @pytest.mark.parametrize("fetcher", [fetch_vcf_header, fetch_fastq_reads, fetch_fasta_headers])
+    def test_request_timeout_is_wrapped_as_fetcherror(self, monkeypatch, evidence_dir, fetcher):
+        # requests.Timeout must be wrapped (by the decorator), not propagate raw.
+        def _timeout(*a, **k):
+            raise requests.Timeout("read timed out")
+
+        monkeypatch.setattr(fetchers.requests, "get", _timeout)
+        with pytest.raises(FetchError):
+            fetcher(evidence_dir, MD5, use_cache=False)
 
 
 class TestBamFetcher:

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -15,6 +15,7 @@ from meta_disco.fetchers import (
     fetch_fasta_headers,
     fetch_fastq_reads,
     fetch_vcf_header,
+    require_samtools,
 )
 
 MD5 = "a" * 32
@@ -107,3 +108,14 @@ class TestBamFetcher:
             lambda *a, **k: subprocess.CompletedProcess(a, returncode=0, stdout="@HD\tVN:1.6\n", stderr=""),
         )
         assert fetch_bam_header(evidence_dir, MD5, use_cache=False) == "@HD\tVN:1.6\n"
+
+
+class TestRequireSamtools:
+    def test_raises_when_missing(self, monkeypatch):
+        monkeypatch.setattr(fetchers.shutil, "which", lambda _: None)
+        with pytest.raises(RuntimeError, match="samtools not found"):
+            require_samtools()
+
+    def test_ok_when_present(self, monkeypatch):
+        monkeypatch.setattr(fetchers.shutil, "which", lambda _: "/usr/bin/samtools")
+        require_samtools()  # must not raise

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -102,6 +102,16 @@ class TestBamFetcher:
         with pytest.raises(FetchError):
             fetch_bam_header(evidence_dir, MD5, use_cache=False)
 
+    def test_empty_header_raises_fetcherror(self, monkeypatch, evidence_dir):
+        # returncode 0 but no header — a valid BAM always has @HD/@SQ, so an empty
+        # header is a failure, not a readable result.
+        self._patch_run(
+            monkeypatch,
+            lambda *a, **k: subprocess.CompletedProcess(a, returncode=0, stdout="", stderr=""),
+        )
+        with pytest.raises(FetchError, match="empty SAM header"):
+            fetch_bam_header(evidence_dir, MD5, use_cache=False)
+
     def test_success_returns_header(self, monkeypatch, evidence_dir):
         self._patch_run(
             monkeypatch,

--- a/tests/test_output_shape.py
+++ b/tests/test_output_shape.py
@@ -161,7 +161,10 @@ def build_output(tmp_path: Path) -> dict:
     """
     out = {}
     for ftype, records in GOLDEN_INPUTS.items():
-        config = dataclasses.replace(FILE_TYPE_REGISTRY[ftype], fetcher=_make_stub_fetcher(ftype))
+        # Stub the fetcher (network-free), and drop the config's preflight with it:
+        # the preflight guards the real fetcher's env deps (e.g. samtools), which the
+        # stub does not use, so it must not run here.
+        config = dataclasses.replace(FILE_TYPE_REGISTRY[ftype], fetcher=_make_stub_fetcher(ftype), preflight=None)
         input_path = tmp_path / f"{ftype}_input.json"
         input_path.write_text(json.dumps({"results": records}))
         # workers=1 forces sequential processing so the record order in the output

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -331,6 +331,48 @@ class TestPipelineRun:
             pipeline.run()
         assert not output.exists()
 
+    def test_preflight_skipped_when_work_is_all_invalid(self, tmp_path):
+        """The preflight guards a fetch-time dependency, so it must not fire when no
+        record will reach the fetcher — e.g. work is entirely validation_failed."""
+
+        def _boom():
+            raise RuntimeError("samtools not found")
+
+        config = _make_config(preflight=_boom)
+        input_path = tmp_path / "in.json"
+        # Drifted file_size -> InvalidRecord, diverted before any fetch.
+        input_path.write_text(
+            json.dumps({"results": [_valid_record(file_name="a.test", file_format=".test", file_size="big")]})
+        )
+        output = tmp_path / "out.json"
+        results = ClassifyPipeline(config, input_path, output, evidence_base=tmp_path / "evidence").run()
+        assert len(results) == 1  # written as validation_failed, not aborted
+        assert json.loads(output.read_text())["metadata"]["validation_failed"] == 1
+
+    def test_preflight_skipped_when_all_cached(self, tmp_path):
+        """An all-cached resume run invokes no fetcher, so the preflight must not fire
+        — the case CI hit (cached/stubbed run with no samtools installed)."""
+        from meta_disco.fetchers import get_evidence_path
+
+        def _boom():
+            raise RuntimeError("samtools not found")
+
+        md5 = "a" * 32
+        pipeline = ClassifyPipeline(
+            _make_config(preflight=_boom),
+            tmp_path / "in.json",
+            tmp_path / "out.json",
+            evidence_base=tmp_path / "evidence",
+            resume=True,
+        )
+        (tmp_path / "in.json").write_text(
+            json.dumps({"results": [_valid_record(file_md5sum=md5, file_name="a.test", file_format=".test")]})
+        )
+        ev = get_evidence_path(pipeline.evidence_dir, md5)
+        ev.parent.mkdir(parents=True, exist_ok=True)
+        ev.write_text("{}")
+        assert len(pipeline.run()) == 1  # must not raise despite the raising preflight
+
     def test_partition_routes_by_classifier_relevant_fields(self, tmp_path):
         """The load-boundary split (#172) preserves #161's divert rule: a contract
         violation only on a field the classifier never reads (drs_uri) still yields a

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -316,6 +316,21 @@ class TestPipelineRun:
         meta = json.loads((tmp_path / "out.json").read_text())["metadata"]
         assert meta["validation_failed"] == 1
 
+    def test_preflight_aborts_before_processing(self, input_file, tmp_path):
+        """A failing preflight (e.g. a missing external tool) aborts run() before the
+        worker pool, so no output is written — a missing dependency fails fast instead
+        of every record failing and vanishing (#155)."""
+
+        def _boom():
+            raise RuntimeError("samtools not found")
+
+        config = _make_config(preflight=_boom)
+        output = tmp_path / "out.json"
+        pipeline = ClassifyPipeline(config, input_file, output, evidence_base=tmp_path / "evidence")
+        with pytest.raises(RuntimeError, match="samtools not found"):
+            pipeline.run()
+        assert not output.exists()
+
     def test_partition_routes_by_classifier_relevant_fields(self, tmp_path):
         """The load-boundary split (#172) preserves #161's divert rule: a contract
         violation only on a field the classifier never reads (drs_uri) still yields a

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -160,22 +160,24 @@ class TestPipelineRun:
         results = pipeline.run()
         assert len(results) == 1
 
-    def test_fetcher_returns_none(self, input_file, tmp_path):
-        """Files where fetcher returns None are counted as failures."""
-        config = _make_config(fetcher=lambda evidence_dir, md5, **kw: None)
-        output = tmp_path / "out.json"
-        pipeline = ClassifyPipeline(
-            config,
-            input_file,
-            output,
-            evidence_base=tmp_path / "evidence",
-        )
-        results = pipeline.run()
-        assert len(results) == 0
+    def test_fetch_failure_writes_not_classified_row_never_dropped(self, input_file, tmp_path):
+        """A fetcher that raises FetchError keeps the record as a content_unreadable
+        row (classified from the filename), never dropped (#155)."""
+        from meta_disco.fetchers import FetchError
 
-        with output.open() as f:
-            data = json.load(f)
-        assert data["metadata"]["failed"] == 2
+        def _boom(evidence_dir, md5, **kw):
+            raise FetchError("HTTP 404 from AnVIL S3 mirror range request")
+
+        config = _make_config(fetcher=_boom)
+        output = tmp_path / "out.json"
+        pipeline = ClassifyPipeline(config, input_file, output, evidence_base=tmp_path / "evidence")
+        results = pipeline.run()
+        assert len(results) == 2  # both .test files written, none dropped
+
+        data = json.loads(output.read_text())
+        assert data["metadata"]["dropped"] == 0
+        assert data["metadata"]["failed"] == 0
+        assert data["metadata"]["content_unreadable"] == 2
 
     @pytest.mark.parametrize("workers", [1, 2])
     def test_null_file_name_is_written_as_validation_failed_not_lost(self, tmp_path, workers):
@@ -398,30 +400,6 @@ class TestPipelineRun:
         )
         assert pipeline._is_cached(md5) is False
 
-    def test_dropped_record_is_not_flagged_cached(self, tmp_path):
-        """A dropped row (fetcher returned None) carries no outcome flags, even if its
-        md5 was cached — otherwise the progress line mislabels it '[cached]'."""
-        from meta_disco.fetchers import get_evidence_path
-
-        md5 = "a" * 32
-        pipeline = ClassifyPipeline(
-            _make_config(fetcher=lambda evidence_dir, md5, **kw: None),
-            tmp_path / "in.json",
-            tmp_path / "out.json",
-            evidence_base=tmp_path / "evidence",
-            resume=True,
-        )
-        ev = get_evidence_path(pipeline.evidence_dir, md5)
-        ev.parent.mkdir(parents=True, exist_ok=True)
-        ev.write_text("{}")
-        assert pipeline._is_cached(md5) is True
-
-        outcome = pipeline._process_single_record(
-            ClassifierRecord.from_record(_valid_record(file_md5sum=md5, file_name="x.test", file_format=".test"))
-        )
-        assert outcome.result is None
-        assert outcome.was_cached is False
-
     def test_parallel_workers(self, input_file, tmp_path):
         config = _make_config()
         output = tmp_path / "out.json"
@@ -638,28 +616,30 @@ class TestFileTypeConfigs:
         assert meta["from_cache"] == 0
         assert meta["successful"] == 2
 
-    def test_dropped_and_errored_are_counted_separately(self, tmp_path):
-        """`Dropped (fetcher gave no cause)` must not absorb records whose worker
-        raised and printed a cause. `failed` stays the sum, for existing consumers."""
+    def test_fetcherror_is_unreadable_row_but_a_bug_is_errored(self, tmp_path):
+        """A FetchError keeps the record as a content_unreadable row; a non-FetchError
+        bug in a fetcher surfaces as errored (no row), not a silent drop. `dropped` is
+        0 now that fetch failures are never dropped (#155); `failed` = dropped + errored."""
         import dataclasses
 
+        from meta_disco.fetchers import FetchError
         from meta_disco.file_types import FILE_TYPE_REGISTRY
         from meta_disco.pipeline import ClassifyPipeline
 
-        boom_md5 = "a" * 32
+        bug_md5 = "a" * 32
 
-        def _explode(evidence_dir, md5, **kwargs):
-            if md5 == boom_md5:
+        def _fetch(evidence_dir, md5, **kwargs):
+            if md5 == bug_md5:
                 raise TypeError("a bug in the parser, not a fetch failure")
-            return  # silent drop, no cause
+            raise FetchError("HTTP 404 from AnVIL S3 mirror range request")
 
-        config = dataclasses.replace(FILE_TYPE_REGISTRY["gfa"], fetcher=_explode)
+        config = dataclasses.replace(FILE_TYPE_REGISTRY["gfa"], fetcher=_fetch)
         input_path = tmp_path / "in.json"
         input_path.write_text(
             json.dumps(
                 {
                     "results": [
-                        _valid_record(file_md5sum=boom_md5, file_name="a.gfa", file_format=".gfa"),
+                        _valid_record(file_md5sum=bug_md5, file_name="a.gfa", file_format=".gfa"),
                         _valid_record(file_md5sum="b" * 32, file_name="b.gfa", file_format=".gfa"),
                     ]
                 }
@@ -672,31 +652,11 @@ class TestFileTypeConfigs:
         ).run()
 
         meta = json.loads(out_path.read_text())["metadata"]
-        assert meta["dropped"] == 1, "the None-returning fetcher"
-        assert meta["errored"] == 1, "the raising fetcher"
-        assert meta["failed"] == 2, "kept as the sum for existing consumers"
-        assert meta["successful"] == 0
-
-    def test_fetcher_returning_none_still_drops_the_row(self, tmp_path):
-        """Unchanged for the fetchers that give no cause (see #155)."""
-        import dataclasses
-
-        from meta_disco.file_types import FILE_TYPE_REGISTRY
-        from meta_disco.pipeline import ClassifyPipeline
-
-        config = dataclasses.replace(FILE_TYPE_REGISTRY["gfa"], fetcher=lambda evidence_dir, md5, **kw: None)
-        input_path = tmp_path / "in.json"
-        input_path.write_text(
-            json.dumps({"results": [_valid_record(file_md5sum="d" * 32, file_name="graph.gfa", file_format=".gfa")]})
-        )
-        pipeline = ClassifyPipeline(
-            config,
-            input_path,
-            tmp_path / "out.json",
-            evidence_base=tmp_path / "evidence",
-            workers=1,
-        )
-        assert pipeline.run() == []
+        assert meta["dropped"] == 0, "fetch failures are no longer dropped (#155)"
+        assert meta["errored"] == 1, "the TypeError bug — no row"
+        assert meta["content_unreadable"] == 1, "the FetchError — written as not_classified"
+        assert meta["successful"] == 1, "the content_unreadable row counts as written"
+        assert meta["failed"] == 1, "dropped(0) + errored(1)"
 
     def test_configs_have_required_fields(self):
         from meta_disco.file_types import FILE_TYPE_REGISTRY


### PR DESCRIPTION
Closes #155.

## What changed

The four remaining header fetchers (`fetch_bam_header`, `fetch_vcf_header`, `fetch_fastq_reads`, `fetch_fasta_headers`) now **raise `FetchError` on a read failure instead of returning `None`**, so a failed fetch becomes a `not_classified` row naming the cause instead of vanishing from the output — completing what #151 did for GFA.

- **fetchers.py:** all failure paths raise `FetchError` (naming the HTTP status, samtools stderr, timeout, or parse error). `vcf`/`fastq` now raise on *empty* content too (previously a silent `None` drop); `fasta`'s empty contig list stays a readable `[]`. A `@wrap_as_fetch_error(label, passthrough=…)` decorator centralizes the shared except-tail across all five fetchers. `samtools` missing propagates as `FileNotFoundError` (declared `passthrough`), never a `FetchError`.
- **Pre-flight:** new `require_samtools` + `FileTypeConfig.preflight`, called once in `run()` before the worker pool, so a missing samtools aborts fast with one clear message instead of every BAM record failing and vanishing.
- **pipeline.py:** retired the `None` contract — tightened return types (`str|None → str`, `tuple[dict|None,bool] → tuple[dict,bool]`), removed the dead `None`/drop branches in `_fetch_and_classify` / `_process_single_record` / `classify_single` / `update_progress`. `dropped` is retired (a fetch failure is never dropped) but kept in the output metadata as a constant `0` for schema stability; `failed` now equals `errored`.
- **classify_hprc_files.py:** direct fetcher calls catch `FetchError` to skip a file (as the old `None` did); `FileNotFoundError` still propagates.

## Why

A missing output row is indistinguishable from a file that was never seen — worse than an honest `not_classified`, and it cuts against *accuracy over coverage*: the coverage report couldn't tell the file existed, and nothing stated why it wasn't classified.

## Assumptions I made

- **`samtools` missing is an environment failure, not one file's unreadable content** — so it must not become `not_classified` data. Fixed at two levels: a `preflight` that aborts the whole run before the pool, plus a per-record `FileNotFoundError` passthrough as a backstop for a tool removed mid-run.
- **A programming bug in a fetcher/parser surfaces as a `not_classified` row** (wrapped as `FetchError`), matching #151 — visible and resumable, with the cause (`TypeError: …`) in the row's evidence, rather than crashing the run.
- **`dropped` stays in the output metadata as `0`** rather than being removed, so existing consumers of that key don't break.
- Direct-`classify_single` scripts now crash on missing samtools instead of skipping — the intended fail-loud behavior; their `if result is None` branches are dead-but-harmless.

## How to verify

Definition of done (from the issue) mapped to steps:

1. **Four fetchers raise `FetchError`, none return `None`** — `uv run pytest tests/test_fetchers.py -v` (each fetcher raises on non-2xx / timeout / empty / parse failure).
2. **samtools-missing crashes; parser bugs become rows** — `tests/test_fetchers.py::TestRequireSamtools` and `TestBamFetcher::test_missing_samtools_propagates_not_fetcherror`; `tests/test_pipeline.py::TestFileTypeConfigs::test_preflight_aborts_before_processing`.
3. **Dead `None` branches removed; return types tightened** — `grep -n "is None" src/meta_disco/pipeline.py` shows no drop branches; `_fetch_and_classify` returns `tuple[dict, bool]`.
4. **HPRC script handles the raising** — read `scripts/classify_hprc_files.py` (try/except FetchError around each fetch).
5. **Coverage report handles the not_classified spike** — `scripts/generate_coverage_report.py` counts rows (`total = len(records)`) and treats `not_classified` as a status, so the spike lowers the classified ratio and shrinks the `unprocessed = n_files - total` gap; no `dropped`/`failed` denominator dependency.
6. **Before/after corpus (the number that matters)** — run any `make classify-<type>` against a warm evidence cache. Measured this branch vs `main`: **bam 18,662 → 18,663 rows (+1 content_unreadable)**, **vcf 205,010 → 205,033 (+23)**, fastq/fasta unchanged; `dropped: 0` everywhere. The 23 vcf rows carry the reason `"no VCF header lines (no '#' lines) in first 1MB"` — real failures, not masked bugs.
7. **Suite green** — `make test-all` (618 root + 10 schema), `make lint`, `make format-check`, `make type` (0 errors).
