### PR TITLE
Type the output-record envelope with OutputRecord (#204)

### DIFF
--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -30,6 +30,10 @@ def _field_entry(record: dict, field_name: str):
     - nested:     record[field] -> {"value", ...}
     - flat:       record[field] -> value
     Returns whatever is found at the field (a dict entry, a scalar, or None).
+
+    Pipeline output now guarantees the per-field layout (``OutputRecord``, #204); the
+    nested/flat fallbacks remain for the other producers this reader serves (e.g. the
+    label dicts built in ``classify_index_files``).
     """
     cls = record.get("classifications")
     if isinstance(cls, dict) and field_name in cls:

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -20,7 +20,7 @@ from .metadata_schema import (
     classification_blocking_reasons,
     validation_failed_classifications,
 )
-from .records import ClassifierRecord, InvalidRecord
+from .records import ClassifierRecord, InvalidRecord, OutputRecord
 
 # A well-formed md5: lowercase hex, 32 chars — the same shape the input contract
 # (metadata.yaml file_md5sum) requires. Only such a value can key real cached
@@ -60,16 +60,16 @@ def load_records(input_path: Path) -> list:
 class RecordOutcome(NamedTuple):
     """The outcome of processing one record, tallied by ``_run_parallel``.
 
-    ``result`` is the output record for this item (a ``dict`` — see the field type;
-    a record is only diverted to ``errored`` in ``_run_parallel`` by *raising*, which
-    produces no ``RecordOutcome``). The three flags are mutually exclusive and only
-    one, at most, is set: ``validation_failed`` (failed the input contract),
-    ``was_cached`` (evidence already on disk), ``content_unreadable`` (fetch failed,
-    classified from the filename), or none of these (a fresh fetch). Named so the four
-    fields cannot be transposed at the unpack sites.
+    ``result`` is the ``OutputRecord`` for this item (a record is only diverted to
+    ``errored`` in ``_run_parallel`` by *raising*, which produces no ``RecordOutcome``).
+    The three flags are mutually exclusive and only one, at most, is set:
+    ``validation_failed`` (failed the input contract), ``was_cached`` (evidence already
+    on disk), ``content_unreadable`` (fetch failed, classified from the filename), or
+    none of these (a fresh fetch). Named so the four fields cannot be transposed at the
+    unpack sites.
     """
 
-    result: dict
+    result: OutputRecord
     was_cached: bool
     content_unreadable: bool
     validation_failed: bool
@@ -279,6 +279,10 @@ class ClassifyPipeline:
     ) -> dict:
         """Classify a single file by MD5. Does not require a full pipeline instance.
 
+        Returns the canonical seven-key ``OutputRecord`` envelope (#204), the same
+        shape the batch path writes; ``dataset_title``/``entry_id`` are ``None`` here
+        since there is no source record.
+
         Never returns ``None`` (#155): a fetch failure surfaces as a ``FetchError``,
         which yields filename-only ``not_classified`` classifications. It does not
         catch everything, though — an environment error (missing samtools raises
@@ -298,13 +302,13 @@ class ClassifyPipeline:
             is_gzipped=is_gzipped,
             use_cache=use_cache,
         )
-        return {
-            "file_name": file_name,
-            "md5sum": md5sum,
-            "file_size": file_size,
-            "file_format": file_format,
-            "classifications": classifications,
-        }
+        return OutputRecord.from_single(
+            md5sum=md5sum,
+            file_name=file_name,
+            file_size=file_size,
+            file_format=file_format,
+            classifications=classifications,
+        ).to_dict()
 
     # --- Internal ---
 
@@ -469,26 +473,17 @@ class ClassifyPipeline:
         )
 
     @staticmethod
-    def _build_record(item: ClassifierRecord | InvalidRecord, classifications: dict) -> dict:
-        """Wrap a classifications dict in the output record envelope.
+    def _build_record(item: ClassifierRecord | InvalidRecord, classifications: dict) -> OutputRecord:
+        """Wrap a classifications dict in the typed output envelope.
 
         Reads identity off the typed work item (a ``ClassifierRecord`` on the success
-        path, an ``InvalidRecord`` on the ``validation_failed`` path). Both guarantee
-        ``file_name``/``file_format`` are ``str`` — the two fields downstream
-        consumers do string operations on (path building, extension checks) — so no
-        coercion happens here. The other identity fields are echoed as the item
-        carries them: typed on the success path, the raw (possibly drifted) values on
-        the ``validation_failed`` path.
+        path, an ``InvalidRecord`` on the ``validation_failed`` path); ``OutputRecord``
+        is serialized to the seven-key dict at the NDJSON write boundary via
+        ``to_dict``. The identity fields are echoed as the item carries them — typed on
+        the success path, the raw (possibly drifted) values on the ``validation_failed``
+        path — matching what ``classify_single`` writes for the single-file path (#204).
         """
-        return {
-            "file_name": item.file_name,
-            "md5sum": item.file_md5sum,
-            "file_size": item.file_size,
-            "file_format": item.file_format,
-            "dataset_title": item.dataset_title,
-            "classifications": classifications,
-            "entry_id": item.entry_id,
-        }
+        return OutputRecord.from_work_item(item, classifications)
 
     def _run_parallel(self, work: list[ClassifierRecord | InvalidRecord]) -> list[dict]:
         """ThreadPoolExecutor with progress tracking, returns classifications."""
@@ -509,7 +504,7 @@ class ClassifyPipeline:
                 nonlocal successful, from_cache, processed, unreadable, invalid
                 with lock:
                     processed += 1
-                    writer.write(outcome.result)
+                    writer.write(outcome.result.to_dict())
                     if outcome.validation_failed:
                         invalid += 1
                     else:

--- a/src/meta_disco/records.py
+++ b/src/meta_disco/records.py
@@ -28,7 +28,7 @@ stream.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Any
 
 
@@ -128,3 +128,90 @@ class InvalidRecord:
             entry_id=record.get("entry_id"),
             reasons=reasons,
         )
+
+
+@dataclass(frozen=True)
+class OutputRecord:
+    """The per-file output envelope: identity fields wrapping a classifications payload.
+
+    The single shape the pipeline writes per record. Both producers construct it —
+    the batch path (``_build_record`` over a ``ClassifierRecord``/``InvalidRecord``
+    work item) and the single-file path (``classify_single``) — and serialize through
+    ``to_dict``, so the seven-key envelope can no longer drift between them (#204).
+
+    Identity typing mirrors the two paths it is built from: ``file_name`` is ``str``
+    on both (the batch work item types it; ``classify_single`` defaults it to ``""``).
+    ``file_format`` is ``str`` on the batch path but ``str | None`` on the single-file
+    path (its argument is optional). The remaining fields — ``md5sum`` (echoed from
+    ``file_md5sum``), ``file_size``, ``dataset_title``, ``entry_id`` — are passed
+    through as carried, so they are ``Any``: the ``validation_failed`` path may carry
+    drifted (non-string) values, and the classifiable path's guarantee already lives
+    upstream in ``ClassifierRecord``. This record does no string operations on the
+    identity fields (``to_dict`` only echoes them), so the looser typing is safe.
+    ``classifications`` is the dimensions payload plus any per-type extras a classifier
+    merged into it (e.g. the fastq scalar hints), which live inside this dict, never as
+    new envelope keys.
+    """
+
+    # Field order is the serialized envelope order — ``to_dict`` derives the output
+    # dict from these fields, so the two cannot drift and a new field is emitted
+    # automatically. Every field name is also its output key.
+    file_name: str
+    md5sum: Any
+    file_size: Any
+    file_format: str | None
+    dataset_title: Any
+    classifications: dict
+    entry_id: Any
+
+    @classmethod
+    def from_work_item(cls, item: ClassifierRecord | InvalidRecord, classifications: dict) -> OutputRecord:
+        """Build from a parsed work item and its classifications payload.
+
+        Reads the six identity attributes both streams expose (see the module
+        docstring), so it is agnostic to which stream produced ``item``.
+        """
+        return cls(
+            file_name=item.file_name,
+            file_format=item.file_format,
+            md5sum=item.file_md5sum,
+            file_size=item.file_size,
+            dataset_title=item.dataset_title,
+            entry_id=item.entry_id,
+            classifications=classifications,
+        )
+
+    @classmethod
+    def from_single(
+        cls,
+        *,
+        md5sum: str,
+        file_name: str,
+        file_size: int | None,
+        file_format: str | None,
+        classifications: dict,
+    ) -> OutputRecord:
+        """Build from a standalone ``classify_single`` call (no work item, no source record).
+
+        ``dataset_title``/``entry_id`` have no source here and serialize as ``None`` —
+        the envelope's one canonical shape, which is why the single-file path's output
+        carries the same seven keys as the batch path.
+        """
+        return cls(
+            file_name=file_name,
+            file_format=file_format,
+            md5sum=md5sum,
+            file_size=file_size,
+            dataset_title=None,
+            entry_id=None,
+            classifications=classifications,
+        )
+
+    def to_dict(self) -> dict:
+        """Serialize to the output envelope dict (the seven-key shape written to JSON).
+
+        Derived from the dataclass fields (a shallow copy — ``classifications`` is not
+        deep-copied), so every field is emitted, in declaration order, and ``to_dict``
+        cannot drift from the field list.
+        """
+        return {f.name: getattr(self, f.name) for f in fields(self)}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -396,14 +396,14 @@ class TestPipelineRun:
         assert any("file_size" in reason for reason in work[2].reasons)
 
     def test_build_record_echoes_typed_item_identity(self):
-        # _build_record reads identity off the typed work item. On the
-        # validation_failed path that is an InvalidRecord, which has already coerced
+        # _build_record reads identity off the typed work item into an OutputRecord. On
+        # the validation_failed path that is an InvalidRecord, which has already coerced
         # file_name/file_format to str, so the output types stay stable.
         item = InvalidRecord.from_record({"file_name": 123, "file_format": None, "file_md5sum": "x"}, [])
         out = ClassifyPipeline._build_record(item, {})
-        assert out["file_name"] == "123"
-        assert out["file_format"] == ""
-        assert isinstance(out["file_name"], str) and isinstance(out["file_format"], str)
+        assert out.file_name == "123"
+        assert out.file_format == ""
+        assert isinstance(out.file_name, str) and isinstance(out.file_format, str)
 
     @pytest.mark.parametrize("workers", [1, 2])
     def test_non_string_file_name_does_not_crash_progress(self, tmp_path, workers):
@@ -481,6 +481,18 @@ class TestPipelineRun:
         assert result is not None
         assert result["md5sum"] == "test_md5"
         assert "classifications" in result
+        # classify_single now emits the same canonical 7-key envelope as the batch path
+        # (#204): dataset_title/entry_id are present (None) on the single-file path.
+        assert set(result) == {
+            "file_name",
+            "md5sum",
+            "file_size",
+            "file_format",
+            "dataset_title",
+            "classifications",
+            "entry_id",
+        }
+        assert result["dataset_title"] is None and result["entry_id"] is None
 
     def test_gzip_detection(self, tmp_path):
         """When extensions include .gz variants, is_gzipped is inferred from filename."""
@@ -633,7 +645,7 @@ class TestFileTypeConfigs:
         assert was_cached is False, "a fetch that reached the network is not a cache hit"
         assert out is not None
         # The note is on data_type (what content refines), not on the four others.
-        cls = out["classifications"]
+        cls = out.classifications
         noted = [f for f in cls if any(e["rule_id"] == "fetch_failed" for e in cls[f]["evidence"])]
         assert noted == ["data_type"]
 

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -2,8 +2,10 @@
 
 import pytest
 
-from meta_disco.records import ClassifierRecord, InvalidRecord
+from meta_disco.records import ClassifierRecord, InvalidRecord, OutputRecord
 from tests.metadata_fixtures import valid_record
+
+_ENVELOPE_KEYS = {"file_name", "md5sum", "file_size", "file_format", "dataset_title", "classifications", "entry_id"}
 
 
 class TestClassifierRecord:
@@ -65,3 +67,59 @@ class TestInvalidRecord:
         assert inv.file_name == "7"
         assert inv.file_md5sum == "z"
         assert inv.reasons == ["file_size: expected an integer"]
+
+
+class TestOutputRecord:
+    def test_from_work_item_echoes_identity_and_maps_md5sum(self):
+        item = ClassifierRecord.from_record(
+            valid_record(
+                file_name="a.bam",
+                file_format=".bam",
+                file_size=42,
+                file_md5sum="a" * 32,
+                dataset_title="T",
+                entry_id="e1",
+            )
+        )
+        rec = OutputRecord.from_work_item(item, {"data_modality": {"value": "genomic"}})
+        # file_md5sum on the work item becomes md5sum on the envelope.
+        assert rec.md5sum == "a" * 32
+        assert rec.file_name == "a.bam"
+        assert rec.file_format == ".bam"
+        assert rec.file_size == 42
+        assert rec.dataset_title == "T"
+        assert rec.entry_id == "e1"
+        assert rec.classifications == {"data_modality": {"value": "genomic"}}
+
+    def test_from_work_item_passes_drifted_invalid_identity_through(self):
+        # An InvalidRecord may carry drifted (non-string) md5/size; the envelope echoes them.
+        item = InvalidRecord.from_record({"file_name": 7, "file_md5sum": ["x"], "file_size": "big"}, ["r"])
+        rec = OutputRecord.from_work_item(item, {})
+        assert rec.file_name == "7"  # coerced by InvalidRecord
+        assert rec.md5sum == ["x"]
+        assert rec.file_size == "big"
+
+    def test_from_single_nulls_dataset_title_and_entry_id(self):
+        rec = OutputRecord.from_single(
+            md5sum="b" * 32, file_name="s.vcf", file_size=None, file_format=".vcf", classifications={}
+        )
+        assert rec.dataset_title is None
+        assert rec.entry_id is None
+        assert rec.md5sum == "b" * 32
+
+    def test_to_dict_has_the_seven_envelope_keys(self):
+        rec = OutputRecord.from_single(
+            md5sum="c" * 32, file_name="x", file_size=1, file_format=".test", classifications={"k": "v"}
+        )
+        d = rec.to_dict()
+        assert set(d) == _ENVELOPE_KEYS
+        assert d["md5sum"] == "c" * 32
+        assert d["classifications"] == {"k": "v"}
+
+    def test_both_paths_produce_the_same_key_set(self):
+        item = ClassifierRecord.from_record(valid_record())
+        batch = OutputRecord.from_work_item(item, {}).to_dict()
+        single = OutputRecord.from_single(
+            md5sum="d" * 32, file_name="x", file_size=1, file_format=".test", classifications={}
+        ).to_dict()
+        assert set(batch) == set(single) == _ENVELOPE_KEYS


### PR DESCRIPTION
Closes #204. Part of epic #203 (type the unconstructed record-dicts).

## What changed

The per-file output envelope was built as a bare `dict` by two producers that had **drifted**: `pipeline._build_record` (batch path) emitted 7 keys, while `classify_single` (single-file path) emitted only 5 (omitting `dataset_title`/`entry_id`). Introduce an `OutputRecord` frozen dataclass that both paths construct and serialize through one `to_dict()`, so the shape can't drift again.

- **`records.py`** — `OutputRecord` with `from_work_item` (batch, reads the 6 identity attrs both work-item streams expose; renames `file_md5sum`→`md5sum`), `from_single` (single-file, nulls `dataset_title`/`entry_id`), and `to_dict`. `to_dict` is **derived from the dataclass fields** (a shallow copy), so it emits every field automatically and can't drift from the field list; field order is the serialized envelope order.
- **`pipeline.py`** — `_build_record` returns `OutputRecord`; `RecordOutcome.result: OutputRecord`; `writer.write(outcome.result.to_dict())`; `classify_single` returns `OutputRecord.from_single(...).to_dict()` — now the canonical 7-key envelope.
- **`models.py`** — one-line note that pipeline output now guarantees `_field_entry`'s per-field layout; the nested/flat fallbacks remain for other producers (e.g. `classify_index_files` label dicts).

## Why

A `dict` gives no guarantee of shape, so the two producers silently diverged and `models._field_entry` had to tolerate three record layouts. Making the envelope a type (the epic's thesis) closes the drift at construction. Same move as the merged #172/#155.

## Assumptions I made

- **`classify_single`'s output grows 5→7 keys** — it now emits `dataset_title`/`entry_id` as `null` (there's no source record on the single-file path). This is the point of the fix (one canonical shape); no known consumer asserts a 5-key set. Confirmed acceptable with the maintainer.
- **Identity fields are echoed as carried, not coerced** — `file_name: str`, `file_format: str | None` (the single-file arg is optional), the rest `Any`. `OutputRecord` does no string ops on them (only `to_dict` echoes), and the classifiable path's guarantee already lives upstream in `ClassifierRecord`; re-coercing here would re-introduce the defensive shaping the epic removes.
- **Kept the dataclass over a shared dict-builder function** — the record is write-only in production, but the epic's goal is to *type* the record (and `RecordOutcome.result`), keeping symmetry with the typed input records.

## How to verify

Definition of done:
- [x] **Typed envelope is the only thing both paths build** — `grep -n "OutputRecord" src/meta_disco/pipeline.py`: `_build_record` and `classify_single` both go through it.
- [x] **`RecordOutcome.result` typed** — now `OutputRecord`; `writer.write(outcome.result.to_dict())`.
- [x] **`classify_single` drift closed** — `uv run pytest tests/test_pipeline.py -k classify_single -q` asserts the canonical 7-key set with `dataset_title`/`entry_id` null.
- [x] **`_field_entry` note** — read `src/meta_disco/models.py`.
- [x] **`OutputRecord` covered** — `uv run pytest tests/test_records.py::TestOutputRecord -q` (both constructors, `md5sum`←`file_md5sum` mapping, drifted-identity passthrough, 7-key `to_dict`, both-paths-same-keys).
- [x] **Batch output byte-identical** — `test_output_shape.py` (the golden fixture) unchanged; `make test-all` green.
- [x] **Suite/quality** — `make test-all` (629 root + 10 schema), `make lint`, `make format-check`, `make type` (0 errors) all green.
