### PR TITLE
Type the run-metadata dict in _save_final (#205)

### DIFF
--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -20,7 +20,7 @@ from .metadata_schema import (
     classification_blocking_reasons,
     validation_failed_classifications,
 )
-from .records import ClassifierRecord, InvalidRecord, OutputRecord
+from .records import ClassifierRecord, InvalidRecord, OutputRecord, RunMetadata
 
 # A well-formed md5: lowercase hex, 32 chars — the same shape the input contract
 # (metadata.yaml file_md5sum) requires. Only such a value can key real cached
@@ -575,14 +575,9 @@ class ClassifyPipeline:
         one whose content was read, because a file type whose ``content_fields``
         is empty leaves no ``fetch_failed`` evidence behind.
 
-        ``errored`` (a worker raised, and the cause was printed) is the only way a
-        record now produces no row, so ``failed`` equals it. ``dropped`` is retired —
-        a fetch failure is written as a ``content_unreadable`` row, never dropped
-        (#155) — but the key is still emitted as ``0`` for output-schema stability.
-
-        ``validation_failed`` (the record failed the input contract, issue #161)
-        produced a row — every dimension ``not_classified`` — so it is counted
-        neither in ``successful`` nor in ``failed``; it is persisted on its own key.
+        The ``metadata`` block's derived tallies (``processed``, ``failed``,
+        ``dropped``) are computed in :meth:`RunMetadata.from_counts`, which documents
+        each invariant.
         """
         ndjson = self.output_path.with_suffix(".ndjson")
         classifications = []
@@ -596,21 +591,14 @@ class ClassifyPipeline:
         with self.output_path.open("w") as f:
             json.dump(
                 {
-                    "metadata": {
-                        "total_to_process": total,
-                        "processed": successful + errored + validation_failed,
-                        "successful": successful,
-                        # `failed` = every record that produced no row. A fetch failure
-                        # no longer drops a record (#155), so only a raising worker
-                        # (errored) does. `dropped` stays as a constant 0 for consumers.
-                        "failed": errored,
-                        "dropped": 0,
-                        "errored": errored,
-                        "validation_failed": validation_failed,
-                        "from_cache": from_cache,
-                        "content_unreadable": unreadable,
-                        "complete": True,
-                    },
+                    "metadata": RunMetadata.from_counts(
+                        total=total,
+                        successful=successful,
+                        from_cache=from_cache,
+                        content_unreadable=unreadable,
+                        errored=errored,
+                        validation_failed=validation_failed,
+                    ).to_dict(),
                     "classifications": classifications,
                 },
                 f,

--- a/src/meta_disco/records.py
+++ b/src/meta_disco/records.py
@@ -24,6 +24,11 @@ Both classes expose the same six identity attributes (``file_name``,
 ``file_format``, ``file_md5sum``, ``file_size``, ``dataset_title``, ``entry_id``),
 so ``_build_record`` and the work-list steps read them uniformly regardless of
 stream.
+
+The module also holds the two write-side dataclasses the pipeline serializes at
+its output boundary, which follow the same frozen / field-order-is-output-order /
+``to_dict`` discipline: :class:`OutputRecord`, the per-file output envelope (#204),
+and :class:`RunMetadata`, the per-run tally block (#205).
 """
 
 from __future__ import annotations
@@ -213,5 +218,80 @@ class OutputRecord:
         Derived from the dataclass fields (a shallow copy — ``classifications`` is not
         deep-copied), so every field is emitted, in declaration order, and ``to_dict``
         cannot drift from the field list.
+        """
+        return {f.name: getattr(self, f.name) for f in fields(self)}
+
+
+@dataclass(frozen=True)
+class RunMetadata:
+    """The per-run tally block written under ``"metadata"`` in the final JSON output.
+
+    The pipeline used to build this as a 10-key literal in ``_save_final`` whose
+    derived keys carried their invariants only in prose comments. :meth:`from_counts`
+    is now the single site that computes those derived tallies, so the invariants are
+    code, asserted in isolation by ``test_records.py`` (#205):
+
+    * ``dropped`` is retired — a fetch failure is written as a ``content_unreadable``
+      row, never dropped (#155) — but the key is still emitted as ``0`` for
+      output-schema stability.
+    * ``failed`` is every record that produced no row: ``dropped + errored``. Since
+      ``dropped`` is always ``0``, only a raising worker (``errored``) counts, so
+      ``failed == errored``.
+    * ``processed`` is ``successful + errored + validation_failed``: a
+      ``validation_failed`` row (failed the input contract, #161) is counted neither
+      in ``successful`` nor in ``failed``, so it is added in explicitly here.
+    """
+
+    # Field order is the serialized ``metadata`` key order — ``to_dict`` derives the
+    # output dict from these fields, so the two cannot drift. Every field name is also
+    # its output key.
+    total_to_process: int
+    processed: int
+    successful: int
+    failed: int
+    dropped: int
+    errored: int
+    validation_failed: int
+    from_cache: int
+    content_unreadable: int
+    complete: bool
+
+    @classmethod
+    def from_counts(
+        cls,
+        *,
+        total: int,
+        successful: int,
+        from_cache: int,
+        content_unreadable: int,
+        errored: int = 0,
+        validation_failed: int = 0,
+        complete: bool = True,
+    ) -> RunMetadata:
+        """Build a run's metadata from the raw counts, computing the derived tallies once.
+
+        The three derived keys (``dropped``, ``failed``, ``processed``) are computed
+        here and only here (see the class docstring for each invariant), so a caller
+        supplies only the counts it actually measured.
+        """
+        dropped = 0
+        return cls(
+            total_to_process=total,
+            processed=successful + errored + validation_failed,
+            successful=successful,
+            failed=dropped + errored,
+            dropped=dropped,
+            errored=errored,
+            validation_failed=validation_failed,
+            from_cache=from_cache,
+            content_unreadable=content_unreadable,
+            complete=complete,
+        )
+
+    def to_dict(self) -> dict:
+        """Serialize to the ``metadata`` dict (the ten-key shape written to JSON).
+
+        Derived from the dataclass fields, so every field is emitted, in declaration
+        order, and ``to_dict`` cannot drift from the field list.
         """
         return {f.name: getattr(self, f.name) for f in fields(self)}

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -2,10 +2,23 @@
 
 import pytest
 
-from meta_disco.records import ClassifierRecord, InvalidRecord, OutputRecord
+from meta_disco.records import ClassifierRecord, InvalidRecord, OutputRecord, RunMetadata
 from tests.metadata_fixtures import valid_record
 
 _ENVELOPE_KEYS = {"file_name", "md5sum", "file_size", "file_format", "dataset_title", "classifications", "entry_id"}
+
+_METADATA_KEYS = [
+    "total_to_process",
+    "processed",
+    "successful",
+    "failed",
+    "dropped",
+    "errored",
+    "validation_failed",
+    "from_cache",
+    "content_unreadable",
+    "complete",
+]
 
 
 class TestClassifierRecord:
@@ -123,3 +136,50 @@ class TestOutputRecord:
             md5sum="d" * 32, file_name="x", file_size=1, file_format=".test", classifications={}
         ).to_dict()
         assert set(batch) == set(single) == _ENVELOPE_KEYS
+
+
+class TestRunMetadata:
+    def test_dropped_is_always_zero(self):
+        # A fetch failure is written as a content_unreadable row, never dropped (#155);
+        # the key survives only for output-schema stability.
+        meta = RunMetadata.from_counts(
+            total=10, successful=6, from_cache=2, content_unreadable=1, errored=3, validation_failed=1
+        )
+        assert meta.dropped == 0
+
+    def test_failed_equals_dropped_plus_errored(self):
+        # Only a raising worker produces no row now, and dropped is 0, so failed == errored.
+        meta = RunMetadata.from_counts(
+            total=10, successful=6, from_cache=0, content_unreadable=0, errored=3, validation_failed=0
+        )
+        assert meta.failed == meta.dropped + meta.errored == 3
+
+    def test_processed_counts_successful_errored_and_validation_failed(self):
+        # A validation_failed row is neither successful nor failed, so it is added in here.
+        meta = RunMetadata.from_counts(
+            total=10, successful=6, from_cache=0, content_unreadable=0, errored=3, validation_failed=1
+        )
+        assert meta.processed == 6 + 3 + 1
+
+    def test_errored_and_validation_failed_default_to_zero(self):
+        meta = RunMetadata.from_counts(total=4, successful=4, from_cache=1, content_unreadable=0)
+        assert meta.errored == 0
+        assert meta.validation_failed == 0
+        assert meta.failed == 0
+        assert meta.processed == 4
+
+    def test_complete_defaults_true_and_counts_pass_through(self):
+        meta = RunMetadata.from_counts(
+            total=9, successful=5, from_cache=2, content_unreadable=1, errored=2, validation_failed=1
+        )
+        assert meta.complete is True
+        assert meta.total_to_process == 9
+        assert meta.successful == 5
+        assert meta.from_cache == 2
+        assert meta.content_unreadable == 1
+
+    def test_to_dict_has_the_ten_keys_in_emit_order(self):
+        d = RunMetadata.from_counts(
+            total=3, successful=2, from_cache=1, content_unreadable=0, errored=1, validation_failed=0
+        ).to_dict()
+        assert list(d) == _METADATA_KEYS


### PR DESCRIPTION
## What changed
Moved the 10-key run-metadata dict literal out of `_save_final` into a new `RunMetadata` frozen dataclass in `records.py`, alongside `OutputRecord` (#204). Its `from_counts(...)` classmethod is now the single site that computes the derived tallies, and `to_dict()` serializes the ten keys derived from the dataclass fields. `_save_final` builds `RunMetadata.from_counts(...).to_dict()`; its signature is unchanged.

## Why
The metadata block's derived keys carried their invariants only in prose comments inside `_save_final`:
- `dropped` — retired (a fetch failure is written as a `content_unreadable` row, never dropped, #155), but still emitted as `0` for output-schema stability;
- `failed` = `dropped + errored` (only a raising worker produces no row, so `failed == errored`);
- `processed` = `successful + errored + validation_failed` (a `validation_failed` row is neither successful nor failed, #161).

Making these code in one factory means they are computed once and unit-testable in isolation, and `to_dict` derived from `fields(self)` guarantees the key set and emit order can't drift — the same discipline `OutputRecord` established. This is the Lane 1 follow-on to #204 in epic #203.

## Assumptions I made
- **`_should_skip_complete`'s tolerant `.get` stays untyped.** It reads a *prior* run's metadata off disk (`existing.get("metadata", {}).get("complete")`) — a genuine trust boundary over possibly-older-schema data where only one key is needed. Per CLAUDE.md (validate at boundaries; don't reconstruct external data through an internal type), it is left as-is. No `from_dict` was added.
- **`dropped` stays in the output** as a constant `0` for output-schema stability, centralized in `from_counts`.
- **Output is byte-identical** — same keys, same values, same order. Confirmed by comparing `from_counts(...).to_dict()` against a verbatim copy of the old literal across 6 count-tuples (empty run, all-cached, mixed error/validation), and by the existing `test_pipeline.py` metadata assertions + schema `test_output_validation.py` still passing on real pipeline output.
- The `to_dict` one-liner is duplicated with `OutputRecord` (n=2); not extracted to a shared helper/mixin, per the repo's explicit-over-clever stance.

## How to verify
Definition of done (from #205):
- [x] `RunMetadata` with `from_counts`/`to_dict`, invariants computed once → `src/meta_disco/records.py`
- [x] `_save_final` builds via it; inline arithmetic/comments removed → `src/meta_disco/pipeline.py`
- [x] `test_records.py` invariant tests → `TestRunMetadata`
- [x] golden unchanged; `make test-all` green

Steps:
1. `make test-all` → 635 root + 10 schema tests pass.
2. `make type` / `make lint` / `make format-check` → clean.
3. `uv run pytest tests/test_records.py -k RunMetadata -v` → the invariant tests assert `dropped == 0`, `failed == dropped + errored`, `processed == successful + errored + validation_failed`, defaults, and the 10-key emit order.
4. Output-parity spot check: run a small classify (e.g. `make classify-gfa`) and confirm the `"metadata"` block in the output JSON still carries exactly `total_to_process, processed, successful, failed, dropped, errored, validation_failed, from_cache, content_unreadable, complete` in that order.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
