### PR TITLE
Unify per-fetcher cached-evidence dicts into a typed record (#206)

### DIFF
--- a/src/meta_disco/evidence.py
+++ b/src/meta_disco/evidence.py
@@ -9,8 +9,8 @@ fetcher wrote, the per-type element count was named three different ways
 cache-hit read was a bespoke silently-defaulting probe over a per-type payload key —
 a key mismatch just missed the cache and re-fetched.
 
-:class:`CachedEvidence` is the shared core (identity + fetch provenance + the
-save/load persistence boundary); each subclass adds its one typed payload field and
+:class:`CachedEvidence` is the shared core (the ``md5sum`` cache key + fetch provenance
++ the save/load persistence boundary); each subclass adds its one typed payload field and
 names it via the ``PAYLOAD_KEY`` classvar, which drives both the ``.payload`` accessor
 and the on-disk key. The element count is a derived :pyattr:`~CachedEvidence.count`
 property, no longer persisted, so the three-way count-key drift is gone by
@@ -48,17 +48,22 @@ def _timestamp() -> str:
 
 @dataclass(frozen=True, kw_only=True)
 class CachedEvidence:
-    """Shared core of a fetcher's cached evidence: identity, provenance, persistence.
+    """Shared core of a fetcher's cached evidence: the cache key, provenance, persistence.
 
     Subclasses add exactly one typed payload field and set :pyattr:`PAYLOAD_KEY` to
     its name; that classvar is the single source of the on-disk payload key and backs
     the :pyattr:`payload` accessor, so no consumer hard-codes a per-type key.
 
-    ``raw_bytes_fetched`` is the size of the byte range a range-request fetcher read;
-    it is ``None`` for BAM, whose ``samtools`` stream has no such count. ``source_url``
-    is recorded only when the fetch used a direct URL rather than the S3 mirror.
-    ``fetch_timestamp`` defaults to now at construction and is preserved verbatim on a
-    round-trip through :meth:`from_json`.
+    The cache is keyed by ``md5sum`` alone (the on-disk path is ``md5[:2]/md5.json``);
+    a hit needs only ``md5sum`` plus a payload. ``file_name`` is echoed *audit*
+    metadata — no consumer reads it back (the fetcher returns the payload) — so a file
+    missing it still hits rather than forcing an expensive re-fetch over a non-key
+    field. ``raw_bytes_fetched`` is the size of the byte range a range-request fetcher
+    read; it is ``None`` for BAM, whose ``samtools`` stream has no such count.
+    ``source_url`` is recorded only when the fetch used a direct URL rather than the S3
+    mirror. ``fetch_timestamp`` defaults to now at construction and is preserved
+    verbatim on a round-trip through :meth:`from_json`; a file that lacks it loads with
+    ``""`` (unknown fetch time), never a fabricated current timestamp.
     """
 
     # Set by each subclass to its payload field name; also the on-disk key.
@@ -116,11 +121,12 @@ class CachedEvidence:
 
         Structural validation of an external artifact at the cache boundary — not a
         defensive default over our own inputs. Returns ``None`` (the fetcher then
-        re-fetches) when the top-level JSON is not an object, the required identity or
-        payload key is absent, or the payload is empty for a type that never persists
-        an empty one (``_EMPTY_IS_MISS``). Payload *value types* are not checked;
-        optional provenance is read with ``.get``, and a dropped count key (pre-#206
-        files) is simply not read.
+        re-fetches) when the top-level JSON is not an object, the required ``md5sum``
+        (the cache key) or payload key is absent, or the payload is empty for a type
+        that never persists an empty one (``_EMPTY_IS_MISS``). ``file_name`` and the
+        provenance fields are non-key audit metadata, read with ``.get`` and absent-
+        tolerant, so a file missing them still hits; payload *value types* are not
+        checked, and a dropped count key (pre-#206 files) is simply not read.
         """
         if not isinstance(data, dict) or "md5sum" not in data or cls.PAYLOAD_KEY not in data:
             return None

--- a/src/meta_disco/evidence.py
+++ b/src/meta_disco/evidence.py
@@ -145,7 +145,7 @@ class CachedEvidence:
         """Write this evidence to its cache path under ``evidence_dir``."""
         path = get_evidence_path(evidence_dir, self.md5sum)
         path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("w") as f:
+        with path.open("w", encoding="utf-8") as f:
             json.dump(self.to_json(), f, indent=2)
 
     @classmethod
@@ -160,7 +160,7 @@ class CachedEvidence:
         if not path.exists():
             return None
         try:
-            with path.open() as f:
+            with path.open(encoding="utf-8") as f:
                 data = json.load(f)
         except (OSError, json.JSONDecodeError, UnicodeDecodeError):
             return None

--- a/src/meta_disco/evidence.py
+++ b/src/meta_disco/evidence.py
@@ -1,0 +1,232 @@
+"""Typed cached-evidence records the fetchers persist to the local evidence cache.
+
+Each fetcher reads a header/metadata sample from a file on S3 and caches what it
+found under ``evidence_dir/<md5[:2]>/<md5>.json`` for resumability and audit. The
+cache used to be five hand-rolled ``dict`` builders in ``fetchers.py`` whose shapes
+had already drifted apart (#206): BAM omitted the ``raw_bytes_fetched`` every other
+fetcher wrote, the per-type element count was named three different ways
+(``header_line_count`` / ``contig_count`` / ``tagged_segment_count``), and each
+cache-hit read was a bespoke silently-defaulting probe over a per-type payload key —
+a key mismatch just missed the cache and re-fetched.
+
+:class:`CachedEvidence` is the shared core (identity + fetch provenance + the
+save/load persistence boundary); each subclass adds its one typed payload field and
+names it via the ``PAYLOAD_KEY`` classvar, which drives both the ``.payload`` accessor
+and the on-disk key. The element count is a derived :pyattr:`~CachedEvidence.count`
+property, no longer persisted, so the three-way count-key drift is gone by
+construction. ``raw_bytes_fetched`` is ``int | None`` and stays ``None`` for BAM,
+which reads a samtools stream and has no byte-range count to report — modeled, not
+fabricated.
+
+On-disk format is backward-readable: payload keys keep their names, so an evidence
+file written before #206 loads fine — :meth:`~CachedEvidence.from_json` reads the
+required keys and ``.get``-optional provenance, and simply ignores the dropped count.
+This is not a compatibility shim: it parses the current schema and ignores audit
+extras it no longer stores.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, ClassVar
+
+
+def get_evidence_path(evidence_dir: Path, md5sum: str) -> Path:
+    """Get path for cached evidence file.
+
+    Uses first 2 chars of MD5 as subdirectory to avoid too many files in one dir.
+    """
+    return evidence_dir / md5sum[:2] / f"{md5sum}.json"
+
+
+def _timestamp() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+@dataclass(frozen=True, kw_only=True)
+class CachedEvidence:
+    """Shared core of a fetcher's cached evidence: identity, provenance, persistence.
+
+    Subclasses add exactly one typed payload field and set :pyattr:`PAYLOAD_KEY` to
+    its name; that classvar is the single source of the on-disk payload key and backs
+    the :pyattr:`payload` accessor, so no consumer hard-codes a per-type key.
+
+    ``raw_bytes_fetched`` is the size of the byte range a range-request fetcher read;
+    it is ``None`` for BAM, whose ``samtools`` stream has no such count. ``source_url``
+    is recorded only when the fetch used a direct URL rather than the S3 mirror.
+    ``fetch_timestamp`` defaults to now at construction and is preserved verbatim on a
+    round-trip through :meth:`from_json`.
+    """
+
+    # Set by each subclass to its payload field name; also the on-disk key.
+    PAYLOAD_KEY: ClassVar[str]
+
+    md5sum: str
+    file_name: str
+    raw_bytes_fetched: int | None = None
+    source_url: str | None = None
+    fetch_timestamp: str = field(default_factory=_timestamp)
+
+    @property
+    def payload(self) -> Any:
+        """The typed per-type payload (e.g. header text, read names, segment tags)."""
+        return getattr(self, self.PAYLOAD_KEY)
+
+    @property
+    def count(self) -> int:
+        """Number of payload elements — list length for the list payloads.
+
+        Overridden for the text payloads (BAM/VCF), where the meaningful count is
+        header lines, not characters.
+        """
+        return len(self.payload)
+
+    def to_json(self) -> dict:
+        """Serialize to the cached JSON dict: identity, payload, and present provenance.
+
+        ``raw_bytes_fetched``/``source_url`` are omitted when ``None`` (BAM never
+        records bytes; a mirror fetch records no source URL), matching the old
+        conditional-insert behavior.
+        """
+        data: dict = {
+            "md5sum": self.md5sum,
+            "file_name": self.file_name,
+            self.PAYLOAD_KEY: self.payload,
+            "fetch_timestamp": self.fetch_timestamp,
+        }
+        if self.raw_bytes_fetched is not None:
+            data["raw_bytes_fetched"] = self.raw_bytes_fetched
+        if self.source_url is not None:
+            data["source_url"] = self.source_url
+        return data
+
+    @classmethod
+    def from_json(cls, data: object) -> Any:
+        """Build from a cached JSON dict, or return ``None`` for a cache miss.
+
+        Returns ``None`` when the top-level JSON is not an object, or when the
+        required identity or payload key is absent — a drifted, partial, or
+        wrong-type file is treated as a miss (the fetcher then re-fetches), which is
+        boundary tolerance over an external artifact, not a defensive default over our
+        own inputs. Optional provenance is read with ``.get``; a dropped count key
+        (pre-#206 files) is simply not read.
+        """
+        if not isinstance(data, dict) or "md5sum" not in data or cls.PAYLOAD_KEY not in data:
+            return None
+        return cls(
+            md5sum=data["md5sum"],
+            file_name=data.get("file_name", ""),
+            raw_bytes_fetched=data.get("raw_bytes_fetched"),
+            source_url=data.get("source_url"),
+            fetch_timestamp=data.get("fetch_timestamp", ""),
+            **{cls.PAYLOAD_KEY: data[cls.PAYLOAD_KEY]},
+        )
+
+    def save(self, evidence_dir: Path) -> None:
+        """Write this evidence to its cache path under ``evidence_dir``."""
+        path = get_evidence_path(evidence_dir, self.md5sum)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w") as f:
+            json.dump(self.to_json(), f, indent=2)
+
+    @classmethod
+    def load(cls, evidence_dir: Path, md5sum: str) -> Any:
+        """Load cached evidence for ``md5sum``, or ``None`` on any miss.
+
+        A missing file, an unreadable/undecodable file, or a file lacking this type's
+        required keys all yield ``None`` so the caller re-fetches — the cache is an
+        optimization, never a trusted source.
+        """
+        path = get_evidence_path(evidence_dir, md5sum)
+        if not path.exists():
+            return None
+        try:
+            with path.open() as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None
+        return cls.from_json(data)
+
+
+@dataclass(frozen=True, kw_only=True)
+class _TextEvidence(CachedEvidence):
+    """Shared core of the two header-text payloads (BAM/VCF).
+
+    Their payload is a header *string*, so the meaningful :pyattr:`count` is header
+    lines rather than the base's element count, and both name their payload
+    ``header_text``. That shared trio (payload field, key, count) lives here so the
+    two subclasses don't each re-declare it.
+    """
+
+    PAYLOAD_KEY: ClassVar[str] = "header_text"
+
+    header_text: str
+
+    @property
+    def count(self) -> int:
+        """Header line count (the meaningful tally for a text payload)."""
+        return len(self.header_text.splitlines())
+
+
+@dataclass(frozen=True, kw_only=True)
+class BamEvidence(_TextEvidence):
+    """Cached SAM header text from a BAM/CRAM read. ``raw_bytes_fetched`` is always None."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class VcfEvidence(_TextEvidence):
+    """Cached VCF header text, plus the optional per-chromosome max-position audit map.
+
+    ``max_positions`` is written for audit when the fetcher extracted it; it is not
+    read back from the cache (the returned payload is the header text), so it is an
+    optional provenance extra rather than part of :pyattr:`payload`.
+    """
+
+    max_positions: dict | None = None
+
+    def to_json(self) -> dict:
+        data = super().to_json()
+        if self.max_positions:
+            data["max_positions"] = self.max_positions
+        return data
+
+    @classmethod
+    def from_json(cls, data: object) -> Any:
+        # Delegate the shared identity/payload/provenance parse (and the cache-miss
+        # guard) to the base, then graft on the one Vcf-only audit field, so a new
+        # base provenance field can't silently miss this subclass on load.
+        base = super().from_json(data)
+        if base is None:
+            return None
+        assert isinstance(data, dict)  # base returned non-None ⇒ data parsed as a dict
+        return replace(base, max_positions=data.get("max_positions"))
+
+
+@dataclass(frozen=True, kw_only=True)
+class FastqEvidence(CachedEvidence):
+    """Cached FASTQ read-name lines."""
+
+    PAYLOAD_KEY: ClassVar[str] = "read_names"
+
+    read_names: list[str]
+
+
+@dataclass(frozen=True, kw_only=True)
+class FastaEvidence(CachedEvidence):
+    """Cached FASTA contig names. An empty list is a valid hit (a head with no contig line)."""
+
+    PAYLOAD_KEY: ClassVar[str] = "contig_names"
+
+    contig_names: list[str]
+
+
+@dataclass(frozen=True, kw_only=True)
+class GfaEvidence(CachedEvidence):
+    """Cached rGFA segment tags. An empty list is a valid hit (a plain GFA carries none)."""
+
+    PAYLOAD_KEY: ClassVar[str] = "gfa_segment_tags"
+
+    gfa_segment_tags: list[dict]

--- a/src/meta_disco/evidence.py
+++ b/src/meta_disco/evidence.py
@@ -63,6 +63,13 @@ class CachedEvidence:
 
     # Set by each subclass to its payload field name; also the on-disk key.
     PAYLOAD_KEY: ClassVar[str]
+    # When True, an empty payload is a cache miss, not a hit: BAM/VCF/FASTQ never
+    # persist an empty payload (they raise FetchError instead), so an empty one on
+    # disk is a corrupt artifact and the fetcher must re-fetch. FASTA/GFA leave this
+    # False — an empty list is a valid read (a plain GFA has no tags; a head may hold
+    # no contig line). This restores the per-type truthiness the pre-#206 cache-hit
+    # guards had.
+    _EMPTY_IS_MISS: ClassVar[bool] = False
 
     md5sum: str
     file_name: str
@@ -107,14 +114,17 @@ class CachedEvidence:
     def from_json(cls, data: object) -> Any:
         """Build from a cached JSON dict, or return ``None`` for a cache miss.
 
-        Returns ``None`` when the top-level JSON is not an object, or when the
-        required identity or payload key is absent — a drifted, partial, or
-        wrong-type file is treated as a miss (the fetcher then re-fetches), which is
-        boundary tolerance over an external artifact, not a defensive default over our
-        own inputs. Optional provenance is read with ``.get``; a dropped count key
-        (pre-#206 files) is simply not read.
+        Structural validation of an external artifact at the cache boundary — not a
+        defensive default over our own inputs. Returns ``None`` (the fetcher then
+        re-fetches) when the top-level JSON is not an object, the required identity or
+        payload key is absent, or the payload is empty for a type that never persists
+        an empty one (``_EMPTY_IS_MISS``). Payload *value types* are not checked;
+        optional provenance is read with ``.get``, and a dropped count key (pre-#206
+        files) is simply not read.
         """
         if not isinstance(data, dict) or "md5sum" not in data or cls.PAYLOAD_KEY not in data:
+            return None
+        if cls._EMPTY_IS_MISS and not data[cls.PAYLOAD_KEY]:
             return None
         return cls(
             md5sum=data["md5sum"],
@@ -136,9 +146,9 @@ class CachedEvidence:
     def load(cls, evidence_dir: Path, md5sum: str) -> Any:
         """Load cached evidence for ``md5sum``, or ``None`` on any miss.
 
-        A missing file, an unreadable/undecodable file, or a file lacking this type's
-        required keys all yield ``None`` so the caller re-fetches — the cache is an
-        optimization, never a trusted source.
+        A missing file, an unreadable file, one that is not valid UTF-8 or not valid
+        JSON, or one lacking this type's required keys all yield ``None`` so the caller
+        re-fetches — the cache is an optimization, never a trusted source.
         """
         path = get_evidence_path(evidence_dir, md5sum)
         if not path.exists():
@@ -146,7 +156,7 @@ class CachedEvidence:
         try:
             with path.open() as f:
                 data = json.load(f)
-        except (OSError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
             return None
         return cls.from_json(data)
 
@@ -162,6 +172,7 @@ class _TextEvidence(CachedEvidence):
     """
 
     PAYLOAD_KEY: ClassVar[str] = "header_text"
+    _EMPTY_IS_MISS: ClassVar[bool] = True  # a valid BAM/VCF always has header lines
 
     header_text: str
 
@@ -207,9 +218,10 @@ class VcfEvidence(_TextEvidence):
 
 @dataclass(frozen=True, kw_only=True)
 class FastqEvidence(CachedEvidence):
-    """Cached FASTQ read-name lines."""
+    """Cached FASTQ read-name lines. Empty is a miss — the fetcher raises without any."""
 
     PAYLOAD_KEY: ClassVar[str] = "read_names"
+    _EMPTY_IS_MISS: ClassVar[bool] = True
 
     read_names: list[str]
 

--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -1,21 +1,22 @@
-"""Header fetchers and evidence cache for biological data files.
+"""Header fetchers for biological data files.
 
 Each fetcher retrieves header/metadata from files on S3 (via range requests
 or samtools) and caches the results locally for resumability and audit.
 
-Shared evidence cache helpers are parameterized by evidence_dir so the
-same logic works for all file types.
+The cache records themselves — path layout, save/load, and the per-type
+:class:`~meta_disco.evidence.CachedEvidence` shapes — live in ``evidence.py``;
+each fetcher constructs its typed evidence subclass and calls ``.save``/``.load``.
 """
 
 import functools
-import json
 import shutil
 import subprocess
-import time
 import zlib
 from pathlib import Path
 
 import requests
+
+from .evidence import BamEvidence, FastaEvidence, FastqEvidence, GfaEvidence, VcfEvidence
 
 S3_MIRROR_URL = "https://anvilproject.s3.amazonaws.com/file"
 
@@ -82,40 +83,13 @@ def wrap_as_fetch_error(label: str, passthrough: tuple[type[BaseException], ...]
 
 
 # =============================================================================
-# SHARED EVIDENCE CACHE
+# SHARED FETCH HELPERS
 # =============================================================================
-
-
-def get_evidence_path(evidence_dir: Path, md5sum: str) -> Path:
-    """Get path for cached evidence file.
-
-    Uses first 2 chars of MD5 as subdirectory to avoid too many files in one dir.
-    """
-    return evidence_dir / md5sum[:2] / f"{md5sum}.json"
-
-
-def load_cached_evidence(evidence_dir: Path, md5sum: str) -> dict | None:
-    """Load cached evidence JSON if it exists."""
-    path = get_evidence_path(evidence_dir, md5sum)
-    if path.exists():
-        try:
-            with path.open() as f:
-                return json.load(f)
-        except (OSError, json.JSONDecodeError):
-            return None
-    return None
-
-
-def save_evidence(evidence_dir: Path, md5sum: str, evidence: dict) -> None:
-    """Save evidence dict to cache."""
-    path = get_evidence_path(evidence_dir, md5sum)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w") as f:
-        json.dump(evidence, f, indent=2)
-
-
-def _timestamp() -> str:
-    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+#
+# The evidence cache itself — its path layout, save/load, and the per-type record
+# shapes — now lives in ``evidence.py`` as :class:`~meta_disco.evidence.CachedEvidence`
+# and its subclasses (#206). ``get_evidence_path`` moved there too; import it from
+# ``meta_disco.evidence``.
 
 
 def _fetch_range(md5sum: str, end_byte: int, timeout: int = 60, url: str | None = None) -> bytes:
@@ -213,9 +187,9 @@ def fetch_bam_header(
     rather than masquerading as unreadable content.
     """
     if use_cache:
-        cached = load_cached_evidence(evidence_dir, md5sum)
-        if cached and cached.get("header_text"):
-            return cached["header_text"]
+        cached = BamEvidence.load(evidence_dir, md5sum)
+        if cached is not None:
+            return cached.payload
 
     fetch_url = url or f"{S3_MIRROR_URL}/{md5sum}.md5"
     result = subprocess.run(
@@ -231,16 +205,9 @@ def fetch_bam_header(
     if not header_text:
         raise FetchError("samtools returned an empty SAM header")
 
-    evidence = {
-        "md5sum": md5sum,
-        "file_name": file_name,
-        "header_text": header_text,
-        "header_line_count": len(header_text.splitlines()),
-        "fetch_timestamp": _timestamp(),
-    }
-    if url:
-        evidence["source_url"] = url
-    save_evidence(evidence_dir, md5sum, evidence)
+    # raw_bytes_fetched stays None: samtools reads a stream, so there is no
+    # byte-range count to report for a BAM/CRAM (evidence.py models this).
+    BamEvidence(md5sum=md5sum, file_name=file_name, header_text=header_text, source_url=url).save(evidence_dir)
 
     return header_text
 
@@ -297,9 +264,9 @@ def fetch_vcf_header(
     as a ``not_classified`` row instead of vanishing (#155).
     """
     if use_cache:
-        cached = load_cached_evidence(evidence_dir, md5sum)
-        if cached and cached.get("header_text"):
-            return cached["header_text"]
+        cached = VcfEvidence.load(evidence_dir, md5sum)
+        if cached is not None:
+            return cached.payload
 
     content = _fetch_range(md5sum, 1048576, timeout=60, url=url)  # 1MB
     raw_bytes = len(content)
@@ -319,19 +286,14 @@ def fetch_vcf_header(
     if header_lines:
         header_text = "\n".join(header_lines)
         max_positions = extract_max_positions(variant_lines) if variant_lines else None
-        evidence = {
-            "md5sum": md5sum,
-            "file_name": file_name,
-            "header_text": header_text,
-            "header_line_count": len(header_lines),
-            "raw_bytes_fetched": raw_bytes,
-            "fetch_timestamp": _timestamp(),
-        }
-        if max_positions:
-            evidence["max_positions"] = max_positions
-        if url:
-            evidence["source_url"] = url
-        save_evidence(evidence_dir, md5sum, evidence)
+        VcfEvidence(
+            md5sum=md5sum,
+            file_name=file_name,
+            header_text=header_text,
+            max_positions=max_positions,
+            raw_bytes_fetched=raw_bytes,
+            source_url=url,
+        ).save(evidence_dir)
         return header_text
 
     raise FetchError("no VCF header lines (no '#' lines) in first 1MB")
@@ -361,9 +323,9 @@ def fetch_fastq_reads(
     is kept as a ``not_classified`` row instead of vanishing (#155).
     """
     if use_cache:
-        cached = load_cached_evidence(evidence_dir, md5sum)
-        if cached and cached.get("read_names"):
-            return cached["read_names"]
+        cached = FastqEvidence.load(evidence_dir, md5sum)
+        if cached is not None:
+            return cached.payload
 
     content = _fetch_range(md5sum, 262144, timeout=60, url=url)  # 256KB
     raw_bytes = len(content)
@@ -383,16 +345,9 @@ def fetch_fastq_reads(
             i += 1
 
     if read_names:
-        evidence = {
-            "md5sum": md5sum,
-            "file_name": file_name,
-            "read_names": read_names,
-            "raw_bytes_fetched": raw_bytes,
-            "fetch_timestamp": _timestamp(),
-        }
-        if url:
-            evidence["source_url"] = url
-        save_evidence(evidence_dir, md5sum, evidence)
+        FastqEvidence(
+            md5sum=md5sum, file_name=file_name, read_names=read_names, raw_bytes_fetched=raw_bytes, source_url=url
+        ).save(evidence_dir)
         return read_names
 
     raise FetchError("no FASTQ read names (no '@' lines) in first 256KB")
@@ -422,9 +377,9 @@ def fetch_fasta_headers(
     is kept as a ``not_classified`` row instead of vanishing (#155).
     """
     if use_cache:
-        cached = load_cached_evidence(evidence_dir, md5sum)
-        if cached and "contig_names" in cached:
-            return cached["contig_names"]
+        cached = FastaEvidence.load(evidence_dir, md5sum)
+        if cached is not None:
+            return cached.payload
 
     content = _fetch_range(md5sum, 262144, timeout=60, url=url)  # 256KB
     raw_bytes = len(content)
@@ -440,17 +395,9 @@ def fetch_fasta_headers(
             if name:
                 contig_names.append(name)
 
-    evidence = {
-        "md5sum": md5sum,
-        "file_name": file_name,
-        "contig_names": contig_names,
-        "contig_count": len(contig_names),
-        "raw_bytes_fetched": raw_bytes,
-        "fetch_timestamp": _timestamp(),
-    }
-    if url:
-        evidence["source_url"] = url
-    save_evidence(evidence_dir, md5sum, evidence)
+    FastaEvidence(
+        md5sum=md5sum, file_name=file_name, contig_names=contig_names, raw_bytes_fetched=raw_bytes, source_url=url
+    ).save(evidence_dir)
 
     return contig_names
 
@@ -551,9 +498,9 @@ def fetch_gfa_segment_tags(
     small complete rGFA keeps its last segment's tags.
     """
     if use_cache:
-        cached = load_cached_evidence(evidence_dir, md5sum)
-        if cached and "gfa_segment_tags" in cached:
-            return cached["gfa_segment_tags"]
+        cached = GfaEvidence.load(evidence_dir, md5sum)
+        if cached is not None:
+            return cached.payload
 
     # end_byte is inclusive, so 262143 fetches exactly HEAD_BYTES. A read/parse
     # failure — including a programming error in parse_gfa_segment_tags — is wrapped
@@ -572,16 +519,8 @@ def fetch_gfa_segment_tags(
 
     segment_tags = parse_gfa_segment_tags(text, truncated=not (got_whole_file and stream_complete))
 
-    evidence = {
-        "md5sum": md5sum,
-        "file_name": file_name,
-        "gfa_segment_tags": segment_tags,
-        "tagged_segment_count": len(segment_tags),
-        "raw_bytes_fetched": raw_bytes,
-        "fetch_timestamp": _timestamp(),
-    }
-    if url:
-        evidence["source_url"] = url
-    save_evidence(evidence_dir, md5sum, evidence)
+    GfaEvidence(
+        md5sum=md5sum, file_name=file_name, gfa_segment_tags=segment_tags, raw_bytes_fetched=raw_bytes, source_url=url
+    ).save(evidence_dir)
 
     return segment_tags

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -377,7 +377,7 @@ class ClassifyPipeline:
         """
         if not isinstance(md5sum, str) or not _MD5_RE.match(md5sum):
             return False
-        from .fetchers import get_evidence_path
+        from .evidence import get_evidence_path
 
         return get_evidence_path(self.evidence_dir, md5sum).exists()
 

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,0 +1,169 @@
+"""Tests for the typed cached-evidence records the fetchers persist (#206)."""
+
+from meta_disco.evidence import (
+    BamEvidence,
+    FastaEvidence,
+    FastqEvidence,
+    GfaEvidence,
+    VcfEvidence,
+    get_evidence_path,
+)
+
+
+class TestGetEvidencePath:
+    def test_shards_by_first_two_md5_chars(self, tmp_path):
+        p = get_evidence_path(tmp_path, "ab" + "c" * 30)
+        assert p == tmp_path / "ab" / f"{'ab' + 'c' * 30}.json"
+
+
+class TestRoundTrip:
+    def test_bam_round_trips_and_omits_bytes(self, tmp_path):
+        ev = BamEvidence(md5sum="a" * 32, file_name="x.bam", header_text="@HD\tVN:1.6\n@SQ\tSN:chr1")
+        ev.save(tmp_path)
+        loaded = BamEvidence.load(tmp_path, "a" * 32)
+        assert isinstance(loaded, BamEvidence)
+        assert loaded.payload == "@HD\tVN:1.6\n@SQ\tSN:chr1"
+        assert loaded.count == 2  # header line count, not char count
+        assert loaded.raw_bytes_fetched is None  # samtools stream: no byte count
+        # None aux keys are not written to disk.
+        on_disk = get_evidence_path(tmp_path, "a" * 32).read_text()
+        assert "raw_bytes_fetched" not in on_disk
+        assert "source_url" not in on_disk
+
+    def test_vcf_round_trips_with_max_positions_and_source_url(self, tmp_path):
+        ev = VcfEvidence(
+            md5sum="b" * 32,
+            file_name="x.vcf.gz",
+            header_text="##fileformat=VCFv4.2\n#CHROM\tPOS",
+            max_positions={"1": 1000, "2": 2000},
+            raw_bytes_fetched=4096,
+            source_url="https://example/x.vcf.gz",
+        )
+        ev.save(tmp_path)
+        loaded = VcfEvidence.load(tmp_path, "b" * 32)
+        assert isinstance(loaded, VcfEvidence)
+        assert loaded.payload == "##fileformat=VCFv4.2\n#CHROM\tPOS"
+        assert loaded.count == 2
+        assert loaded.max_positions == {"1": 1000, "2": 2000}
+        assert loaded.raw_bytes_fetched == 4096
+        assert loaded.source_url == "https://example/x.vcf.gz"
+
+    def test_vcf_without_max_positions_omits_the_key(self, tmp_path):
+        VcfEvidence(md5sum="c" * 32, file_name="x.vcf", header_text="#CHROM").save(tmp_path)
+        assert "max_positions" not in get_evidence_path(tmp_path, "c" * 32).read_text()
+        assert VcfEvidence.load(tmp_path, "c" * 32).max_positions is None
+
+    def test_fastq_round_trips(self, tmp_path):
+        ev = FastqEvidence(md5sum="d" * 32, file_name="x.fastq.gz", read_names=["@r1", "@r2"], raw_bytes_fetched=256)
+        ev.save(tmp_path)
+        loaded = FastqEvidence.load(tmp_path, "d" * 32)
+        assert loaded.payload == ["@r1", "@r2"]
+        assert loaded.count == 2
+
+    def test_fasta_round_trips(self, tmp_path):
+        FastaEvidence(md5sum="e" * 32, file_name="x.fa", contig_names=["chr1", "chr2", "chrM"]).save(tmp_path)
+        loaded = FastaEvidence.load(tmp_path, "e" * 32)
+        assert loaded.payload == ["chr1", "chr2", "chrM"]
+        assert loaded.count == 3
+
+    def test_gfa_round_trips(self, tmp_path):
+        tags = [{"SN": "chr1", "SR": "0"}, {"SN": "chr1", "SR": "1"}]
+        GfaEvidence(md5sum="f" * 32, file_name="x.gfa.gz", gfa_segment_tags=tags).save(tmp_path)
+        loaded = GfaEvidence.load(tmp_path, "f" * 32)
+        assert loaded.payload == tags
+        assert loaded.count == 2
+
+
+class TestEmptyPayloadIsAHit:
+    def test_fasta_empty_contig_list_loads_as_a_hit(self, tmp_path):
+        # A head with no contig line is a valid readable result, not a miss.
+        FastaEvidence(md5sum="a" * 32, file_name="x.fa", contig_names=[]).save(tmp_path)
+        loaded = FastaEvidence.load(tmp_path, "a" * 32)
+        assert loaded is not None
+        assert loaded.payload == []
+        assert loaded.count == 0
+
+    def test_gfa_empty_tag_list_loads_as_a_hit(self, tmp_path):
+        # A plain GFA carries no rGFA tags — an empty list is a successful read.
+        GfaEvidence(md5sum="b" * 32, file_name="x.gfa", gfa_segment_tags=[]).save(tmp_path)
+        loaded = GfaEvidence.load(tmp_path, "b" * 32)
+        assert loaded is not None
+        assert loaded.payload == []
+
+
+class TestCacheMiss:
+    def test_missing_file_is_a_miss(self, tmp_path):
+        assert BamEvidence.load(tmp_path, "a" * 32) is None
+
+    def test_undecodable_file_is_a_miss(self, tmp_path):
+        path = get_evidence_path(tmp_path, "a" * 32)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{ not json")
+        assert BamEvidence.load(tmp_path, "a" * 32) is None
+
+    def test_missing_payload_key_is_a_miss(self, tmp_path):
+        # An empty dict (or a file lacking this type's payload key) is not a hit.
+        path = get_evidence_path(tmp_path, "a" * 32)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}")
+        assert FastaEvidence.load(tmp_path, "a" * 32) is None
+        assert FastaEvidence.from_json({}) is None
+
+    def test_missing_md5_key_is_a_miss(self):
+        assert BamEvidence.from_json({"header_text": "@HD"}) is None
+
+    def test_non_dict_top_level_json_is_a_miss(self, tmp_path):
+        # A cache file whose top-level JSON is not an object must not raise out of
+        # load() — the contract is "any miss -> None", so the fetcher re-fetches.
+        for raw in ("5", "true", "null", '"header_text"', "[1, 2]"):
+            path = get_evidence_path(tmp_path, "a" * 32)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(raw)
+            assert BamEvidence.load(tmp_path, "a" * 32) is None, raw
+        assert BamEvidence.from_json(5) is None
+        assert BamEvidence.from_json(["header_text"]) is None
+
+
+class TestLegacyFileLoad:
+    def test_legacy_bam_file_loads_without_refetch(self, tmp_path):
+        # Pre-#206 BAM evidence: carries the dropped header_line_count, no
+        # raw_bytes_fetched. It must load, ignore the stale count, and expose
+        # the right payload/count — no re-fetch.
+        path = get_evidence_path(tmp_path, "a" * 32)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            '{"md5sum": "%s", "file_name": "old.bam", "header_text": "@HD\\n@SQ\\n@SQ", '
+            '"header_line_count": 3, "fetch_timestamp": "2020-01-01T00:00:00Z"}' % ("a" * 32)
+        )
+        loaded = BamEvidence.load(tmp_path, "a" * 32)
+        assert isinstance(loaded, BamEvidence)
+        assert loaded.payload == "@HD\n@SQ\n@SQ"
+        assert loaded.count == 3  # derived from payload, not the stale stored key
+        assert loaded.raw_bytes_fetched is None
+        assert loaded.fetch_timestamp == "2020-01-01T00:00:00Z"
+
+    def test_legacy_fasta_file_with_contig_count_loads(self, tmp_path):
+        path = get_evidence_path(tmp_path, "b" * 32)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            '{"md5sum": "%s", "file_name": "old.fa", "contig_names": ["chr1", "chr2"], '
+            '"contig_count": 2, "raw_bytes_fetched": 100, "fetch_timestamp": "2020-01-01T00:00:00Z"}' % ("b" * 32)
+        )
+        loaded = FastaEvidence.load(tmp_path, "b" * 32)
+        assert loaded.payload == ["chr1", "chr2"]
+        assert loaded.count == 2
+        assert loaded.raw_bytes_fetched == 100
+
+
+class TestPayloadKeyIsTheOnDiskKey:
+    def test_each_subclass_writes_its_named_payload_key(self):
+        cases = [
+            (BamEvidence(md5sum="a" * 32, file_name="f", header_text="@HD"), "header_text"),
+            (VcfEvidence(md5sum="a" * 32, file_name="f", header_text="#C"), "header_text"),
+            (FastqEvidence(md5sum="a" * 32, file_name="f", read_names=["@r"]), "read_names"),
+            (FastaEvidence(md5sum="a" * 32, file_name="f", contig_names=["c"]), "contig_names"),
+            (GfaEvidence(md5sum="a" * 32, file_name="f", gfa_segment_tags=[{"SN": "c"}]), "gfa_segment_tags"),
+        ]
+        for ev, key in cases:
+            assert key == ev.PAYLOAD_KEY
+            assert key in ev.to_json()

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,5 +1,7 @@
 """Tests for the typed cached-evidence records the fetchers persist (#206)."""
 
+import json
+
 from meta_disco.evidence import (
     BamEvidence,
     FastaEvidence,
@@ -89,6 +91,38 @@ class TestEmptyPayloadIsAHit:
         loaded = GfaEvidence.load(tmp_path, "b" * 32)
         assert loaded is not None
         assert loaded.payload == []
+
+
+class TestEmptyPayloadIsAMissForTextAndReads:
+    # BAM/VCF/FASTQ never persist an empty payload (they raise FetchError), so an
+    # empty one on disk is corrupt and must re-fetch — matching the pre-#206 truthy
+    # cache-hit guards, not the bare key-presence check.
+    def _write(self, tmp_path, md5, key, value):
+        path = get_evidence_path(tmp_path, md5)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"md5sum": md5, "file_name": "x", key: value}))
+
+    def test_empty_bam_header_text_is_a_miss(self, tmp_path):
+        self._write(tmp_path, "a" * 32, "header_text", "")
+        assert BamEvidence.load(tmp_path, "a" * 32) is None
+
+    def test_empty_vcf_header_text_is_a_miss(self, tmp_path):
+        self._write(tmp_path, "b" * 32, "header_text", "")
+        assert VcfEvidence.load(tmp_path, "b" * 32) is None
+
+    def test_empty_fastq_read_names_is_a_miss(self, tmp_path):
+        self._write(tmp_path, "c" * 32, "read_names", [])
+        assert FastqEvidence.load(tmp_path, "c" * 32) is None
+
+
+class TestUndecodableUnicodeIsAMiss:
+    def test_invalid_utf8_file_is_a_miss(self, tmp_path):
+        # A cache file with invalid UTF-8 bytes must not leak UnicodeDecodeError out
+        # of load() — the contract is "any miss -> None".
+        path = get_evidence_path(tmp_path, "a" * 32)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b'{"md5sum": "\xff\xfe not utf-8"}')
+        assert BamEvidence.load(tmp_path, "a" * 32) is None
 
 
 class TestCacheMiss:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -286,7 +286,7 @@ class TestPipelineRun:
         """skip_cached must not drop validation_failed records (they are never cached)
         and must not crash on an InvalidRecord whose md5 drifted to an unhashable
         type — only classifiable records are skip-filtered against the cached set."""
-        from meta_disco.fetchers import get_evidence_path
+        from meta_disco.evidence import get_evidence_path
 
         cached_md5 = "a" * 32
         valid = _valid_record(file_md5sum=cached_md5, file_name="v.test", file_format=".test")
@@ -352,7 +352,7 @@ class TestPipelineRun:
     def test_preflight_skipped_when_all_cached(self, tmp_path):
         """An all-cached resume run invokes no fetcher, so the preflight must not fire
         — the case CI hit (cached/stubbed run with no samtools installed)."""
-        from meta_disco.fetchers import get_evidence_path
+        from meta_disco.evidence import get_evidence_path
 
         def _boom():
             raise RuntimeError("samtools not found")
@@ -609,7 +609,8 @@ class TestFileTypeConfigs:
         still be reported unreadable rather than tallied under 'From cache'."""
         import dataclasses
 
-        from meta_disco.fetchers import FetchError, get_evidence_path
+        from meta_disco.evidence import get_evidence_path
+        from meta_disco.fetchers import FetchError
         from meta_disco.file_types import FILE_TYPE_REGISTRY
         from meta_disco.pipeline import ClassifyPipeline
 
@@ -631,8 +632,8 @@ class TestFileTypeConfigs:
             workers=1,
             resume=True,
         )
-        # A corrupt evidence file: _is_cached() sees it, load_cached_evidence() cannot
-        # read it, so the fetcher re-fetches and fails.
+        # A corrupt evidence file: _is_cached() sees it, GfaEvidence.load() cannot
+        # read it (returns None), so the fetcher re-fetches and fails.
         stale = get_evidence_path(pipeline.evidence_dir, "d" * 32)
         stale.parent.mkdir(parents=True, exist_ok=True)
         stale.write_text("{ not json")


### PR DESCRIPTION
## What changed
Replaced the five hand-rolled cached-evidence `dict` builders in `fetchers.py` with a typed `CachedEvidence` hierarchy in a new `src/meta_disco/evidence.py`:
- A frozen `CachedEvidence` base owns identity (`md5sum`, `file_name`), fetch provenance (`raw_bytes_fetched: int|None`, `source_url`, `fetch_timestamp`), and the persistence boundary (`to_json`/`from_json`/`save`/`load`). A `PAYLOAD_KEY` classvar drives both the `.payload` accessor and the on-disk key; `count` is a derived property (no longer persisted).
- A `_TextEvidence` intermediate shares the header-text payload + line-count `count` between `BamEvidence` and `VcfEvidence`. `VcfEvidence` adds an optional write-only `max_positions` audit map. `FastqEvidence`/`FastaEvidence`/`GfaEvidence` carry their typed list payloads.
- `get_evidence_path` and `_timestamp` moved to `evidence.py`; `save_evidence`/`load_cached_evidence` deleted. `pipeline._is_cached` and 3 `test_pipeline.py` sites now import `get_evidence_path` from `meta_disco.evidence`.

## Why
The dicts had already drifted (the MEDIUM the issue flags): BAM omitted the `raw_bytes_fetched` every other fetcher wrote; the element count was named three ways (`header_line_count` / `contig_count` / `tagged_segment_count`); and each cache-hit read was a bespoke silently-defaulting probe over a per-type key, so a key mismatch silently missed the cache and re-fetched. A typed record with one `PAYLOAD_KEY` and a derived `count` removes all three by construction.

## Assumptions I made
- **`raw_bytes_fetched` is `None` for BAM** — samtools reads a stream, so there is no byte-range count. Modeled as `int|None` and omitted from JSON, not fabricated.
- **`count` dropped from disk, exposed as a derived property.** Nothing in `src/` reads it today; it is kept as a natural audit accessor (DoD lists it). The three-way count-key drift is eliminated because the count is no longer stored.
- **`max_positions` is a write-only audit extra** — it is persisted for VCF but never read back from the cache (the returned payload is the header text), so it is a `VcfEvidence`-only optional field, not part of `.payload`.
- **`load()` returns `None` on any miss** — missing file, undecodable JSON, non-dict top-level JSON, or a file lacking this type's payload key. The cache is an optimization, never a trusted source (CLAUDE.md: validate at the trust boundary; a corrupt cache file re-fetches rather than raising).
- **On-disk backward-readable, no re-fetch** — payload keys keep their names; only the derived counts are dropped; `from_json` reads required keys and `.get`-optional provenance, ignoring the stale count. Not a compat shim — it parses the current schema and ignores audit extras.
- **Cache-hit guard change is behavior-equivalent** — BAM/VCF/FASTQ never persist an empty payload (they raise `FetchError`), so the old truthy guard and the new `load() is not None` agree; FASTA/GFA empty-list-is-a-hit is preserved (payload key present).
- `data/evidence/` is gitignored/local/regenerable; no golden or test asserts the evidence-dict shape.

## How to verify
Definition of done (from #206):
- [x] `CachedEvidence` base + 5 subclasses (typed payload, `count` property, `to_json`/`from_json`/`save`/`load`) → `src/meta_disco/evidence.py`
- [x] all 5 build + read sites migrated → `src/meta_disco/fetchers.py`
- [x] `save_evidence`/`load_cached_evidence` deleted; `get_evidence_path` signature unchanged (moved to `evidence.py`)
- [x] legacy files load without re-fetch (test) → `tests/test_evidence.py::TestLegacyFileLoad`
- [x] round-trip + empty-hit tests; `make test-all` green

Steps:
1. `make test-all` → 652 root + 10 schema pass. `make type` / `make lint` / `make format-check` clean.
2. `uv run pytest tests/test_evidence.py -v` → per-subclass round-trips, empty-payload-is-a-hit (fasta/gfa), cache-miss cases (missing / undecodable / non-dict / keyless), and legacy-file loads (old shape with `header_line_count`, no `raw_bytes_fetched` → loads, correct `.payload`/`.count`, no re-fetch).
3. Live spot check: `make classify-gfa` (or any type) with a warm `data/evidence/` cache → confirm cache hits still return the same payload; delete an evidence file and re-run → confirm it re-fetches and rewrites a `<md5>.json` whose payload key matches its type.

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
