### PR TITLE
Type GFA segment-tag dicts as SegmentTag (#207)

### DIFF
--- a/src/meta_disco/evidence.py
+++ b/src/meta_disco/evidence.py
@@ -241,10 +241,73 @@ class FastaEvidence(CachedEvidence):
     contig_names: list[str]
 
 
+@dataclass(frozen=True)
+class SegmentTag:
+    """The rGFA stable-sequence tags on one GFA segment (S) line (#207).
+
+    In rGFA each segment carries a stable rank ``SR`` naming which sequence it came
+    from — rank ``"0"`` is the reference backbone — and ``SN`` names its contig. Both
+    are kept as the strings they are on disk: ``sr`` is compared as ``"0"`` and ``sn``
+    is sorted as text, so coercing ``sr`` to ``int`` would break the comparison and
+    change the JSON. Either may be absent (``None``); ``parse_gfa_segment_tags`` only
+    emits a tag when at least one is present.
+
+    :pyattr:`is_reference_backbone` moves the "rank 0 ⇒ reference backbone" semantics —
+    which used to live only in the reader — onto the type.
+    """
+
+    sn: str | None = None
+    sr: str | None = None
+
+    @property
+    def is_reference_backbone(self) -> bool:
+        """True when this segment is a named rank-0 (reference-backbone) segment.
+
+        ``bool(self.sn)`` (not ``sn is not None``) preserves the reader's original
+        truthy ``t.get("SN")`` test: a blank ``SN:Z:`` (empty-string name) does not
+        anchor a reference claim, exactly as before #207.
+        """
+        return self.sr == "0" and bool(self.sn)
+
+    def to_json(self) -> dict:
+        """Serialize to the on-disk tag dict, omitting absent keys (``SN`` before ``SR``).
+
+        Reproduces the exact dict ``parse_gfa_segment_tags`` used to build, so the
+        cached ``gfa_segment_tags`` array is byte-identical to the pre-#207 format.
+        """
+        data: dict = {}
+        if self.sn is not None:
+            data["SN"] = self.sn
+        if self.sr is not None:
+            data["SR"] = self.sr
+        return data
+
+    @classmethod
+    def from_json(cls, data: dict) -> SegmentTag:
+        """Build from an on-disk tag dict (absent ``SN``/``SR`` become ``None``)."""
+        return cls(sn=data.get("SN"), sr=data.get("SR"))
+
+
 @dataclass(frozen=True, kw_only=True)
 class GfaEvidence(CachedEvidence):
     """Cached rGFA segment tags. An empty list is a valid hit (a plain GFA carries none)."""
 
     PAYLOAD_KEY: ClassVar[str] = "gfa_segment_tags"
 
-    gfa_segment_tags: list[dict]
+    gfa_segment_tags: list[SegmentTag]
+
+    def to_json(self) -> dict:
+        # The payload is typed SegmentTags; serialize each to its on-disk dict.
+        data = super().to_json()
+        data[self.PAYLOAD_KEY] = [tag.to_json() for tag in self.gfa_segment_tags]
+        return data
+
+    @classmethod
+    def from_json(cls, data: object) -> Any:
+        # Delegate identity/provenance parse + the cache-miss guard to the base, then
+        # rebuild the payload as typed SegmentTags (base built it as raw dicts).
+        base = super().from_json(data)
+        if base is None:
+            return None
+        assert isinstance(data, dict)  # base returned non-None ⇒ data parsed as a dict
+        return replace(base, gfa_segment_tags=[SegmentTag.from_json(x) for x in data[cls.PAYLOAD_KEY]])

--- a/src/meta_disco/evidence.py
+++ b/src/meta_disco/evidence.py
@@ -270,10 +270,14 @@ class SegmentTag:
         return self.sr == "0" and bool(self.sn)
 
     def to_json(self) -> dict:
-        """Serialize to the on-disk tag dict, omitting absent keys (``SN`` before ``SR``).
+        """Serialize to the on-disk tag dict, omitting absent keys, ``SN`` before ``SR``.
 
-        Reproduces the exact dict ``parse_gfa_segment_tags`` used to build, so the
-        cached ``gfa_segment_tags`` array is byte-identical to the pre-#207 format.
+        Emits the same ``{"SN":.., "SR":..}`` dict ``parse_gfa_segment_tags`` used to
+        build. The key order here is canonical ``SN``-then-``SR``; for spec-compliant
+        rGFA (S-line tags ordered ``SN, SO, SR``) that matches the pre-#207 dict, whose
+        keys followed the tags' physical order in the line. A non-conformant line with
+        ``SR`` before ``SN`` would have produced the opposite key order before — a
+        difference in JSON key order only, not in the cached values or their meaning.
         """
         data: dict = {}
         if self.sn is not None:
@@ -310,4 +314,10 @@ class GfaEvidence(CachedEvidence):
         if base is None:
             return None
         assert isinstance(data, dict)  # base returned non-None ⇒ data parsed as a dict
-        return replace(base, gfa_segment_tags=[SegmentTag.from_json(x) for x in data[cls.PAYLOAD_KEY]])
+        payload = data[cls.PAYLOAD_KEY]
+        # This subclass parses each item (unlike the pass-through payloads), so a
+        # corrupt file whose tags are not a list of dicts is a cache miss, not a crash
+        # — keeping load()'s "any miss -> None" contract at the boundary.
+        if not isinstance(payload, list) or not all(isinstance(x, dict) for x in payload):
+            return None
+        return replace(base, gfa_segment_tags=[SegmentTag.from_json(x) for x in payload])

--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import requests
 
-from .evidence import BamEvidence, FastaEvidence, FastqEvidence, GfaEvidence, VcfEvidence
+from .evidence import BamEvidence, FastaEvidence, FastqEvidence, GfaEvidence, SegmentTag, VcfEvidence
 
 S3_MIRROR_URL = "https://anvilproject.s3.amazonaws.com/file"
 
@@ -407,13 +407,13 @@ def fetch_fasta_headers(
 # =============================================================================
 
 
-def parse_gfa_segment_tags(text: str, truncated: bool = True) -> list[dict]:
+def parse_gfa_segment_tags(text: str, truncated: bool = True) -> list[SegmentTag]:
     """Parse rGFA stable-sequence tags from the S (segment) lines of GFA text.
 
-    Returns one dict per segment that carries at least one of `SN:Z:` (stable
-    sequence name) and `SR:i:` (stable rank). Segments with neither — every
-    segment of a plain GFA, such as a minigraph-cactus graph — are omitted, so
-    a plain GFA yields an empty list.
+    Returns one :class:`~meta_disco.evidence.SegmentTag` per segment that carries at
+    least one of `SN:Z:` (stable sequence name) and `SR:i:` (stable rank). Segments
+    with neither — every segment of a plain GFA, such as a minigraph-cactus graph —
+    are omitted, so a plain GFA yields an empty list.
 
     The sequence column is not sliced out into its own string: in a real graph it
     holds the full segment sequence and dominates the line, while the tags follow
@@ -447,14 +447,14 @@ def parse_gfa_segment_tags(text: str, truncated: bool = True) -> list[dict]:
         if pos == -1:
             continue  # fewer than 4 columns — no tag columns follow the sequence
 
-        tags = {}
+        sn = sr = None
         for fld in line[pos + 1 :].rstrip("\r").split("\t"):
             if fld.startswith("SN:Z:"):
-                tags["SN"] = fld[5:]
+                sn = fld[5:]
             elif fld.startswith("SR:i:"):
-                tags["SR"] = fld[5:]
-        if tags:
-            segments.append(tags)
+                sr = fld[5:]
+        if sn is not None or sr is not None:
+            segments.append(SegmentTag(sn=sn, sr=sr))
     return segments
 
 
@@ -467,11 +467,11 @@ def fetch_gfa_segment_tags(
     use_cache: bool = True,
     url: str | None = None,
     **kwargs,
-) -> list[dict]:
+) -> list[SegmentTag]:
     """Read rGFA stable-sequence tags from the S lines at the head of a GFA file.
 
     If url is provided, fetches from that URL directly. Otherwise uses the AnVIL S3 mirror.
-    Returns a list of tag dicts, one per rGFA-tagged segment — empty for a plain
+    Returns a list of :class:`SegmentTag`s, one per rGFA-tagged segment — empty for a plain
     GFA, which is a successful read of a graph that carries no rGFA tags.
 
     Never returns None. A file that cannot be read or parsed raises FetchError,

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -13,6 +13,7 @@ from dataclasses import replace
 from functools import cache
 from typing import TYPE_CHECKING
 
+from .evidence import SegmentTag
 from .models import CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED, build_field_entry
 from .validators.read_name_parsers import (
     detect_paired_end_indicators,
@@ -445,7 +446,7 @@ def classify_without_content(
 
 
 def classify_from_gfa_segment_tags(
-    segment_tags: list[dict],
+    segment_tags: list[SegmentTag],
     *,
     file_name: str | None = None,
     file_size: int | None = None,
@@ -468,7 +469,7 @@ def classify_from_gfa_segment_tags(
     The assembly is left to the shared filename_ref_* rules.
 
     Args:
-        segment_tags: Per-segment tag dicts from fetchers.parse_gfa_segment_tags
+        segment_tags: Per-segment :class:`SegmentTag`s from fetchers.parse_gfa_segment_tags
         file_name: Optional filename for extension/filename rules
         file_format: Optional extension (e.g. ".rgfa.gz"), used to drive the
             extension rules when file_name carries no known extension
@@ -495,9 +496,11 @@ def classify_from_gfa_segment_tags(
     engine = _get_engine()
     result = engine.classify_extended(file_info, include_tier3=False)
 
-    rank0 = [t for t in segment_tags if t.get("SR") == "0" and t.get("SN")]
+    rank0 = [t for t in segment_tags if t.is_reference_backbone]
     if rank0:
-        contigs = sorted({t["SN"] for t in rank0})
+        # is_reference_backbone guarantees a non-empty sn; the `if t.sn` narrows the
+        # optional type for the checker without changing the runtime set.
+        contigs = sorted({t.sn for t in rank0 if t.sn})
         preview = ", ".join(contigs[:3])
         phrase = "segment carries" if len(rank0) == 1 else "segments carry"
         # Appended as a tier-3 claim, not assigned over the list, so the tier-1

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -22,6 +22,7 @@ from classify_fasta_files import classify_single_fasta as classify_fasta
 from classify_fastq_files import classify_single_fastq as classify_fastq
 from classify_vcf_files import classify_single_vcf as classify_vcf
 
+from meta_disco.evidence import SegmentTag
 from meta_disco.fetchers import parse_gfa_segment_tags
 from meta_disco.header_classifier import classify_from_gfa_segment_tags, filename_for_rules
 from meta_disco.models import (
@@ -469,7 +470,7 @@ class TestRgfaContentClassification:
 
     def test_rank0_segments_are_pangenome_reference(self):
         """The real signal: minigraph rGFA, all leading segments SR:i:0 on chr1."""
-        tags = [{"SN": "chr1", "SR": "0"} for _ in range(5)]
+        tags = [SegmentTag(sn="chr1", sr="0") for _ in range(5)]
         record = classify_from_gfa_segment_tags(tags, file_name="hprc-v1.0-minigraph-grch38.gfa.gz")
         assert get_val(record, "data_type") == "pangenome.reference"
         # reference_assembly still comes from the filename rules, not content
@@ -486,7 +487,7 @@ class TestRgfaContentClassification:
         exact-match assertion would fail for a change unrelated to this behavior.
         """
         record = classify_from_gfa_segment_tags(
-            [{"SN": "chr1", "SR": "0"}], file_name="hprc-v1.0-minigraph-grch38.gfa.gz"
+            [SegmentTag(sn="chr1", sr="0")], file_name="hprc-v1.0-minigraph-grch38.gfa.gz"
         )
         rules = [e["rule_id"] for e in record["data_type"]["evidence"]]
         assert "pangenome_graph" in rules, "the tier-1 claim was clobbered"
@@ -500,7 +501,7 @@ class TestRgfaContentClassification:
         tier-1 `pangenome` claim. Pin the tier so resolving from claims agrees
         with the value set here."""
         record = classify_from_gfa_segment_tags(
-            [{"SN": "chr1", "SR": "0"}], file_name="hprc-v1.0-minigraph-grch38.gfa.gz"
+            [SegmentTag(sn="chr1", sr="0")], file_name="hprc-v1.0-minigraph-grch38.gfa.gz"
         )
         claims = record["data_type"]["evidence"]
         content = next(c for c in claims if c["rule_id"] == "rgfa_stable_rank_reference")
@@ -510,7 +511,7 @@ class TestRgfaContentClassification:
 
     def test_nonzero_rank_only_stays_pangenome(self):
         """Non-reference haplotype segments (rank >= 1) do not make a reference graph."""
-        tags = [{"SN": "HG002#1#chr1", "SR": "1"}]
+        tags = [SegmentTag(sn="HG002#1#chr1", sr="1")]
         record = classify_from_gfa_segment_tags(tags, file_name="some-graph.gfa.gz")
         assert get_val(record, "data_type") == "pangenome"
 
@@ -531,7 +532,7 @@ class TestRgfaContentClassification:
 
     def test_rank0_without_stable_name_is_not_a_reference_claim(self):
         """SR without SN is malformed rGFA — no contig to anchor the claim."""
-        record = classify_from_gfa_segment_tags([{"SR": "0"}], file_name="some-graph.gfa")
+        record = classify_from_gfa_segment_tags([SegmentTag(sr="0")], file_name="some-graph.gfa")
         assert get_val(record, "data_type") == "pangenome"
 
     def test_empty_file_name_falls_back_to_file_format(self):
@@ -629,7 +630,7 @@ class TestGfaContentClaimCoherence:
         the rGFA claim forced data_type=pangenome.reference on a record whose
         data_modality was not_classified."""
         record = classify_from_gfa_segment_tags(
-            [{"SN": "chr1", "SR": "0"}],
+            [SegmentTag(sn="chr1", sr="0")],
             file_name="hprc-graph.tar.gz",
             file_format=".gfa.gz",
         )
@@ -642,7 +643,7 @@ class TestGfaContentClaimCoherence:
         assert get_val(record, "data_type") == "pangenome"
 
     def test_evidence_reason_is_singular_for_one_segment(self):
-        record = classify_from_gfa_segment_tags([{"SN": "chr1", "SR": "0"}], file_name="some-graph.gfa")
+        record = classify_from_gfa_segment_tags([SegmentTag(sn="chr1", sr="0")], file_name="some-graph.gfa")
         content = next(e for e in record["data_type"]["evidence"] if e["rule_id"] == "rgfa_stable_rank_reference")
         assert "1 rGFA segment carries" in content["reason"]
 
@@ -658,8 +659,8 @@ class TestGfaSegmentTagParsing:
             "L\ts1\t+\ts2\t+\t0M\n"
         )
         assert parse_gfa_segment_tags(text) == [
-            {"SN": "chr1", "SR": "0"},
-            {"SN": "chr1", "SR": "0"},
+            SegmentTag(sn="chr1", sr="0"),
+            SegmentTag(sn="chr1", sr="0"),
         ]
 
     def test_sequence_column_is_never_read_as_a_tag(self):
@@ -668,7 +669,7 @@ class TestGfaSegmentTagParsing:
         A parser that scanned every field would report SN=decoy here.
         """
         text = "S\ts1\tSN:Z:decoy\tSR:i:0\n"
-        assert parse_gfa_segment_tags(text) == [{"SR": "0"}]
+        assert parse_gfa_segment_tags(text) == [SegmentTag(sr="0")]
 
     def test_drops_truncated_trailing_line(self):
         """A byte-range cut leaves a partial final record — it must not be parsed.
@@ -677,7 +678,7 @@ class TestGfaSegmentTagParsing:
         parser would emit a segment whose tags are silently incomplete.
         """
         text = "S\ts1\tACGT\tSN:Z:chr1\tSR:i:0\nS\ts2\tACG\tSN:Z:chr1\tSR"
-        assert parse_gfa_segment_tags(text) == [{"SN": "chr1", "SR": "0"}]
+        assert parse_gfa_segment_tags(text) == [SegmentTag(sn="chr1", sr="0")]
 
     def test_keeps_unterminated_final_line_when_text_is_not_truncated(self):
         """A small complete rGFA with no trailing newline must keep its last segment.
@@ -688,7 +689,7 @@ class TestGfaSegmentTagParsing:
         """
         text = "H\tVN:Z:1.0\nS\ts1\tACGT\tSN:Z:chr1\tSR:i:0"
         assert parse_gfa_segment_tags(text, truncated=True) == []
-        assert parse_gfa_segment_tags(text, truncated=False) == [{"SN": "chr1", "SR": "0"}]
+        assert parse_gfa_segment_tags(text, truncated=False) == [SegmentTag(sn="chr1", sr="0")]
 
     def test_a_truncated_line_can_look_complete(self):
         """Why `truncated` cannot be inferred: this cut lands on a tag boundary."""
@@ -696,11 +697,11 @@ class TestGfaSegmentTagParsing:
         cut = full[: full.index("\tSO:i:5")]  # a clean, syntactically valid line
         assert cut == "S\ts1\tACGT\tSN:Z:chr1\tSR:i:0"
         # Indistinguishable from the complete line in the test above.
-        assert parse_gfa_segment_tags(cut, truncated=False) == [{"SN": "chr1", "SR": "0"}]
+        assert parse_gfa_segment_tags(cut, truncated=False) == [SegmentTag(sn="chr1", sr="0")]
 
     def test_keeps_complete_trailing_line_when_newline_terminated(self):
         text = "S\ts1\tACGT\tSN:Z:chr1\tSR:i:0\n"
-        assert parse_gfa_segment_tags(text) == [{"SN": "chr1", "SR": "0"}]
+        assert parse_gfa_segment_tags(text) == [SegmentTag(sn="chr1", sr="0")]
 
     def test_untagged_segments_are_omitted(self):
         """Plain GFA 1.0 (minigraph-cactus): segments with no optional tags."""

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -133,6 +133,26 @@ class TestUndecodableUnicodeIsAMiss:
         assert BamEvidence.load(tmp_path, "a" * 32) is None
 
 
+class TestMalformedGfaPayloadIsAMiss:
+    # GfaEvidence parses each tag item, so a corrupt file whose gfa_segment_tags is
+    # not a list of dicts must be a miss (re-fetch), not an AttributeError out of load().
+    def _write(self, tmp_path, md5, payload):
+        path = get_evidence_path(tmp_path, md5)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"md5sum": md5, "file_name": "x", "gfa_segment_tags": payload}))
+
+    @pytest.mark.parametrize("payload", ["oops", 5, {"SN": "chr1"}, ["not-a-dict"], [{"SN": "chr1"}, 7]])
+    def test_non_list_of_dicts_payload_is_a_miss(self, tmp_path, payload):
+        self._write(tmp_path, "a" * 32, payload)
+        assert GfaEvidence.load(tmp_path, "a" * 32) is None
+
+    def test_well_formed_list_of_dicts_still_loads(self, tmp_path):
+        self._write(tmp_path, "b" * 32, [{"SN": "chr1", "SR": "0"}])
+        loaded = GfaEvidence.load(tmp_path, "b" * 32)
+        assert loaded is not None
+        assert loaded.payload == [SegmentTag(sn="chr1", sr="0")]
+
+
 class TestCacheMiss:
     def test_missing_file_is_a_miss(self, tmp_path):
         assert BamEvidence.load(tmp_path, "a" * 32) is None

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -2,11 +2,14 @@
 
 import json
 
+import pytest
+
 from meta_disco.evidence import (
     BamEvidence,
     FastaEvidence,
     FastqEvidence,
     GfaEvidence,
+    SegmentTag,
     VcfEvidence,
     get_evidence_path,
 )
@@ -69,11 +72,16 @@ class TestRoundTrip:
         assert loaded.count == 3
 
     def test_gfa_round_trips(self, tmp_path):
-        tags = [{"SN": "chr1", "SR": "0"}, {"SN": "chr1", "SR": "1"}]
+        tags = [SegmentTag(sn="chr1", sr="0"), SegmentTag(sn="chr1", sr="1")]
         GfaEvidence(md5sum="f" * 32, file_name="x.gfa.gz", gfa_segment_tags=tags).save(tmp_path)
         loaded = GfaEvidence.load(tmp_path, "f" * 32)
         assert loaded.payload == tags
         assert loaded.count == 2
+        # On disk the tags are the same {"SN":..,"SR":..} dicts as before #207.
+        assert json.loads(get_evidence_path(tmp_path, "f" * 32).read_text())["gfa_segment_tags"] == [
+            {"SN": "chr1", "SR": "0"},
+            {"SN": "chr1", "SR": "1"},
+        ]
 
 
 class TestEmptyPayloadIsAHit:
@@ -196,8 +204,37 @@ class TestPayloadKeyIsTheOnDiskKey:
             (VcfEvidence(md5sum="a" * 32, file_name="f", header_text="#C"), "header_text"),
             (FastqEvidence(md5sum="a" * 32, file_name="f", read_names=["@r"]), "read_names"),
             (FastaEvidence(md5sum="a" * 32, file_name="f", contig_names=["c"]), "contig_names"),
-            (GfaEvidence(md5sum="a" * 32, file_name="f", gfa_segment_tags=[{"SN": "c"}]), "gfa_segment_tags"),
+            (GfaEvidence(md5sum="a" * 32, file_name="f", gfa_segment_tags=[SegmentTag(sn="c")]), "gfa_segment_tags"),
         ]
         for ev, key in cases:
             assert key == ev.PAYLOAD_KEY
             assert key in ev.to_json()
+
+
+class TestSegmentTag:
+    @pytest.mark.parametrize(
+        "sn,sr,expected",
+        [
+            ("chr1", "0", True),  # named rank-0 segment: the reference backbone
+            ("chr1", "1", False),  # rank 1: a sample haplotype, not the backbone
+            (None, "0", False),  # rank 0 but no name to anchor a contig
+            ("", "0", False),  # blank name (SN:Z: with no value) is not a name
+            ("chr1", None, False),  # no rank
+            (None, None, False),
+        ],
+    )
+    def test_is_reference_backbone(self, sn, sr, expected):
+        assert SegmentTag(sn=sn, sr=sr).is_reference_backbone is expected
+
+    def test_to_json_omits_absent_keys(self):
+        assert SegmentTag(sn="chr1", sr="0").to_json() == {"SN": "chr1", "SR": "0"}
+        assert SegmentTag(sn="chr1").to_json() == {"SN": "chr1"}
+        assert SegmentTag(sr="0").to_json() == {"SR": "0"}
+        assert SegmentTag().to_json() == {}
+
+    def test_from_json_round_trips(self):
+        for tag in (SegmentTag(sn="chr1", sr="0"), SegmentTag(sn="chr1"), SegmentTag(sr="0"), SegmentTag()):
+            assert SegmentTag.from_json(tag.to_json()) == tag
+
+    def test_from_json_missing_keys_become_none(self):
+        assert SegmentTag.from_json({}) == SegmentTag(sn=None, sr=None)

--- a/tests/test_output_shape.py
+++ b/tests/test_output_shape.py
@@ -53,6 +53,7 @@ from pathlib import Path
 import pytest
 
 from meta_disco import schema_vocab
+from meta_disco.evidence import SegmentTag
 from meta_disco.file_types import FILE_TYPE_REGISTRY
 from meta_disco.models import CLASSIFICATION_FIELDS, CLASSIFIED
 from meta_disco.pipeline import ClassifyPipeline
@@ -114,7 +115,7 @@ GOLDEN_INPUTS = {
 
 STUB_HEADER = "stub-header-no-network"
 # Real fetchers return str (bam/vcf header text), list[str] (fastq reads / fasta
-# contig names), or list[dict] (gfa segment tags) — see fetchers.py. The stub
+# contig names), or list[SegmentTag] (gfa segment tags) — see fetchers.py. The stub
 # honors each type's contract so the golden exercises realistic classifier input
 # and stays robust if a classifier later type-guards its argument.
 STUB_PAYLOADS = {
@@ -122,7 +123,7 @@ STUB_PAYLOADS = {
     "vcf": STUB_HEADER,
     "fastq": [STUB_HEADER],
     "fasta": [STUB_HEADER],
-    "gfa": [{"SN": "chr1", "SR": "0"}],
+    "gfa": [SegmentTag(sn="chr1", sr="0")],
 }
 EVIDENCE_KEYS = {"rule_id", "reason"}
 FIELD_KEYS = {"value", "status", "evidence"}


### PR DESCRIPTION
## What changed
Replaced the raw per-segment rGFA tag dict (`{"SN":.., "SR":..}`) with a typed `SegmentTag` frozen dataclass, threaded through the three sites that touch it:
- **`evidence.py`** — new `SegmentTag` (`sn: str|None`, `sr: str|None`, kept as strings) with an `is_reference_backbone` property (`sr == "0" and bool(sn)`) and `to_json`/`from_json`. `GfaEvidence.gfa_segment_tags` is now `list[SegmentTag]`; it overrides `to_json`/`from_json` (via `super()` + `dataclasses.replace`, the same pattern as `VcfEvidence`) to bridge to the on-disk dicts.
- **`fetchers.py`** — `parse_gfa_segment_tags` returns `list[SegmentTag]`; `fetch_gfa_segment_tags` return type updated.
- **`header_classifier.py`** — `classify_from_gfa_segment_tags` consumes `list[SegmentTag]`, using `t.is_reference_backbone` and `t.sn` (no more `.get("SR")` / `t["SN"]`).

## Why
The rGFA tag dict was built in `parse_gfa_segment_tags` and read in `classify_from_gfa_segment_tags` via `t.get("SR")` then `t["SN"]`, with the tag semantics (`SR == "0"` ⇒ reference backbone) living only in the reader. Typing it makes the shape explicit and moves the "rank-0 named segment ⇒ reference backbone" rule onto the type, so the reader stops re-deriving it from string keys. This is the Lane 2 follow-on to #206 (`GfaEvidence`) in epic #203.

## Assumptions I made
- **`sr`/`sn` stay `str | None`** — not coercing `sr` to `int`, which would break the `== "0"` comparison and change the JSON. The meaning is captured by `is_reference_backbone`, not the field type.
- **`is_reference_backbone` uses `bool(sn)`, not `sn is not None`** — this preserves the reader's original truthy `t.get("SN")` test exactly: a blank `SN:Z:` (empty-string name) does not anchor a reference claim, as before. (The issue's design text said `sn is not None`; I deliberately used `bool(sn)` to avoid a behavior change on that malformed-input edge — see the property docstring.)
- **On-disk JSON is byte-identical** — `SegmentTag.to_json` emits `{"SN":.., "SR":..}` with absent keys omitted, `SN` before `SR`. For spec-compliant rGFA (S-line tags ordered `SN, SO, SR`) this matches the old dict exactly; old evidence files load unchanged (no re-fetch). Purely an in-memory typed view.
- **`SegmentTag` lives in `evidence.py`** (stdlib-only, the lowest module), so both `fetchers.py` and `header_classifier.py` import it with no cycle — defining it in `fetchers.py` would create a `fetchers ↔ evidence` cycle.

## How to verify
Definition of done (from #207):
- [x] `SegmentTag` (`sn`/`sr: str|None`, `is_reference_backbone`, `to_json`/`from_json`) → `src/meta_disco/evidence.py`
- [x] parse returns / classify consumes `list[SegmentTag]` (no `.get("SR")`/`t["SN"]`) → `fetchers.py`, `header_classifier.py`
- [x] evidence round-trips it; JSON byte-identical (test) → `tests/test_evidence.py::TestRoundTrip::test_gfa_round_trips`
- [x] `test_evals.py` updated + backbone/round-trip tests; `make test-all` green

Steps:
1. `make test-all` → 665 root + 10 schema pass. `make type` / `make lint` / `make format-check` clean.
2. `uv run pytest tests/test_evidence.py -k SegmentTag -v` → `is_reference_backbone` truth table (incl. the blank-`SN` and no-`SR` edges), `to_json` omission, `from_json` round-trips.
3. `uv run pytest tests/test_evidence.py -k gfa_round_trips -v` → asserts the on-disk `gfa_segment_tags` array is the same `{"SN":..,"SR":..}` dicts as before #207.
4. Golden: `uv run pytest tests/test_output_shape.py` → the GFA record still classifies `data_type: pangenome.reference` (rule `rgfa_stable_rank_reference`) with byte-identical output.

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)
