### PR TITLE
Type read-name parser returns as frozen dataclasses (#208)

### DIFF
--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -314,17 +314,17 @@ def classify_from_fastq_header(
         # Try to parse as Illumina
         parsed = parse_illumina_read_name(read)
         if parsed:
-            instrument_model = parsed.get("instrument_model")
-            instrument_hint = parsed.get("instrument")
-            if parsed.get("archive_accession"):
-                archive_accession = parsed["archive_accession"]
-                archive_source = parsed["archive_source"]
+            instrument_model = parsed.instrument_model
+            instrument_hint = parsed.instrument
+            if parsed.archive_accession:
+                archive_accession = parsed.archive_accession
+                archive_source = parsed.archive_source
             break
 
         # Try to parse as PacBio
-        parsed = parse_pacbio_read_name(read)
-        if parsed:
-            instrument_model = parsed.get("instrument_model")
+        pacbio = parse_pacbio_read_name(read)
+        if pacbio:
+            instrument_model = pacbio.instrument_model
             break
 
     classifications = result.to_output_dict()

--- a/src/meta_disco/validators/__init__.py
+++ b/src/meta_disco/validators/__init__.py
@@ -24,6 +24,12 @@ from .header_extractors import (
     parse_vcf_header,
 )
 from .read_name_parsers import (
+    IlluminaFormat,
+    IlluminaReadName,
+    MgiReadName,
+    OntReadName,
+    PacBioFormat,
+    PacBioReadName,
     detect_paired_end_indicators,
     detect_platform_from_read_name,
     extract_archive_accession,
@@ -50,6 +56,12 @@ __all__ = [
     "has_sam_section",
     "get_contig_lines",
     # Read name parsers
+    "IlluminaFormat",
+    "IlluminaReadName",
+    "PacBioFormat",
+    "PacBioReadName",
+    "OntReadName",
+    "MgiReadName",
     "extract_archive_accession",
     "infer_illumina_instrument_model",
     "parse_illumina_read_name",

--- a/src/meta_disco/validators/read_name_parsers.py
+++ b/src/meta_disco/validators/read_name_parsers.py
@@ -2,9 +2,99 @@
 
 These functions parse FASTQ read names to extract platform-specific
 information like instrument ID, run number, flowcell, ZMW, etc.
+
+Each parser returns a frozen per-platform dataclass (or None if the read
+name does not match that platform), so the fields a branch produces are
+declared in one place instead of assembled ad hoc into a bare dict.
 """
 
+from __future__ import annotations
+
 import re
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class IlluminaFormat(Enum):
+    """Illumina read-name layout: modern (Casava 1.8+) or legacy."""
+
+    MODERN = "modern"
+    LEGACY = "legacy"
+
+
+class PacBioFormat(Enum):
+    """PacBio read-name layout: CCS/HiFi, CLR subread, or generic."""
+
+    CCS = "ccs"
+    CLR = "clr"
+    GENERIC = "generic"
+
+
+@dataclass(frozen=True)
+class IlluminaReadName:
+    """Parsed Illumina read name.
+
+    Covers both modern and legacy layouts in one type: ``run_number`` and
+    ``flowcell`` are modern-only and stay None for legacy reads; the second
+    modern block (``read``/``filtered``/``control``/``index``) is optional;
+    archive fields are set only for ENA/SRA/DDBJ-reformatted reads.
+    """
+
+    format: IlluminaFormat
+    instrument: str
+    instrument_model: str | None
+    lane: int
+    tile: int
+    x: int
+    y: int
+    run_number: int | None = None
+    flowcell: str | None = None
+    read: int | None = None
+    filtered: bool | None = None
+    control: int | None = None
+    index: str | None = None
+    archive_accession: str | None = None
+    archive_source: str | None = None
+
+
+@dataclass(frozen=True)
+class PacBioReadName:
+    """Parsed PacBio read name; ``start``/``end`` are CLR-only."""
+
+    format: PacBioFormat
+    movie: str
+    zmw: int
+    instrument_model: str | None
+    read_type: str | None = None
+    start: int | None = None
+    end: int | None = None
+
+
+@dataclass(frozen=True)
+class OntReadName:
+    """Parsed Oxford Nanopore read name.
+
+    ``uuid`` is the fixed spine; the arbitrary trailing ``key=value`` pairs
+    are kept under ``metadata`` rather than flattened onto attributes.
+    """
+
+    uuid: str
+    metadata: dict[str, str] = field(default_factory=dict)
+    format: str = "ont"
+
+
+@dataclass(frozen=True)
+class MgiReadName:
+    """Parsed MGI/BGI read name."""
+
+    flowcell: str
+    lane: int
+    column: int
+    row: int
+    read_number: int
+    pair: int | None = None
+    format: str = "mgi"
+
 
 # Illumina instrument ID prefix -> model name mapping
 # Order matters: more specific prefixes (A0, A1, VH) must come before less specific (A, N)
@@ -104,7 +194,7 @@ def detect_paired_end_indicators(text: str) -> bool:
     return any(re.search(p, text, re.IGNORECASE) for p in patterns)
 
 
-def parse_illumina_read_name(read_name: str) -> dict | None:
+def parse_illumina_read_name(read_name: str) -> IlluminaReadName | None:
     """
     Parse an Illumina read name into its components.
 
@@ -118,7 +208,7 @@ def parse_illumina_read_name(read_name: str) -> dict | None:
         read_name: FASTQ read name starting with @
 
     Returns:
-        Dict with parsed fields or None if not Illumina format
+        IlluminaReadName or None if not Illumina format
     """
     # Strip @ prefix if present
     name = read_name.lstrip("@")
@@ -137,30 +227,30 @@ def parse_illumina_read_name(read_name: str) -> dict | None:
     if match:
         groups = match.groups()
         instrument_id = groups[0]
-        result = {
-            "format": "modern",
-            "instrument": instrument_id,
-            "run_number": int(groups[1]),
-            "flowcell": groups[2],
-            "lane": int(groups[3]),
-            "tile": int(groups[4]),
-            "x": int(groups[5]),
-            "y": int(groups[6]),
-            "instrument_model": infer_illumina_instrument_model(instrument_id),
-        }
-        if groups[7]:  # Optional second part
-            result.update(
-                {
-                    "read": int(groups[7]),
-                    "filtered": groups[8] == "Y",
-                    "control": int(groups[9]),
-                    "index": groups[10],
-                }
-            )
-        if accession:
-            result["archive_accession"] = accession
-            result["archive_source"] = source
-        return result
+        # Optional second block: read:filtered:control:index
+        read = filtered = control = index = None
+        if groups[7]:
+            read = int(groups[7])
+            filtered = groups[8] == "Y"
+            control = int(groups[9])
+            index = groups[10]
+        return IlluminaReadName(
+            format=IlluminaFormat.MODERN,
+            instrument=instrument_id,
+            instrument_model=infer_illumina_instrument_model(instrument_id),
+            run_number=int(groups[1]),
+            flowcell=groups[2],
+            lane=int(groups[3]),
+            tile=int(groups[4]),
+            x=int(groups[5]),
+            y=int(groups[6]),
+            read=read,
+            filtered=filtered,
+            control=control,
+            index=index,
+            archive_accession=accession,
+            archive_source=source,
+        )
 
     # Legacy Illumina format: instrument:lane:tile:x:y#index/read
     legacy_pattern = re.compile(r"^([A-Z0-9-]+):(\d+):(\d+):(\d+):(\d+)#([^/]+)/(\d)$")
@@ -168,21 +258,19 @@ def parse_illumina_read_name(read_name: str) -> dict | None:
     if match:
         groups = match.groups()
         instrument_id = groups[0]
-        result = {
-            "format": "legacy",
-            "instrument": instrument_id,
-            "lane": int(groups[1]),
-            "tile": int(groups[2]),
-            "x": int(groups[3]),
-            "y": int(groups[4]),
-            "index": groups[5],
-            "read": int(groups[6]),
-            "instrument_model": infer_illumina_instrument_model(instrument_id),
-        }
-        if accession:
-            result["archive_accession"] = accession
-            result["archive_source"] = source
-        return result
+        return IlluminaReadName(
+            format=IlluminaFormat.LEGACY,
+            instrument=instrument_id,
+            instrument_model=infer_illumina_instrument_model(instrument_id),
+            lane=int(groups[1]),
+            tile=int(groups[2]),
+            x=int(groups[3]),
+            y=int(groups[4]),
+            index=groups[5],
+            read=int(groups[6]),
+            archive_accession=accession,
+            archive_source=source,
+        )
 
     return None
 
@@ -199,7 +287,7 @@ def _infer_pacbio_instrument_model(movie: str) -> str | None:
     return None
 
 
-def parse_pacbio_read_name(read_name: str) -> dict | None:
+def parse_pacbio_read_name(read_name: str) -> PacBioReadName | None:
     """
     Parse a PacBio read name into its components.
 
@@ -213,7 +301,7 @@ def parse_pacbio_read_name(read_name: str) -> dict | None:
         read_name: FASTQ read name starting with @
 
     Returns:
-        Dict with parsed fields or None if not PacBio format
+        PacBioReadName or None if not PacBio format
     """
     name = read_name.lstrip("@")
 
@@ -230,45 +318,45 @@ def parse_pacbio_read_name(read_name: str) -> dict | None:
     match = ccs_pattern.match(name)
     if match:
         movie = match.group(1)
-        return {
-            "format": "ccs",
-            "movie": movie,
-            "zmw": int(match.group(2)),
-            "read_type": "CCS",
-            "instrument_model": _infer_pacbio_instrument_model(movie),
-        }
+        return PacBioReadName(
+            format=PacBioFormat.CCS,
+            movie=movie,
+            zmw=int(match.group(2)),
+            read_type="CCS",
+            instrument_model=_infer_pacbio_instrument_model(movie),
+        )
 
     # CLR (subread) format: m64011_190830_220126/1234/0_5000
     clr_pattern = re.compile(rf"^({MOVIE_PATTERN})/(\d+)/(\d+)_(\d+)$")
     match = clr_pattern.match(name)
     if match:
         movie = match.group(1)
-        return {
-            "format": "clr",
-            "movie": movie,
-            "zmw": int(match.group(2)),
-            "start": int(match.group(3)),
-            "end": int(match.group(4)),
-            "read_type": "CLR",
-            "instrument_model": _infer_pacbio_instrument_model(movie),
-        }
+        return PacBioReadName(
+            format=PacBioFormat.CLR,
+            movie=movie,
+            zmw=int(match.group(2)),
+            start=int(match.group(3)),
+            end=int(match.group(4)),
+            read_type="CLR",
+            instrument_model=_infer_pacbio_instrument_model(movie),
+        )
 
     # Generic PacBio: m64011_190830_220126/1234
     generic_pattern = re.compile(rf"^({MOVIE_PATTERN})/(\d+)$")
     match = generic_pattern.match(name)
     if match:
         movie = match.group(1)
-        return {
-            "format": "generic",
-            "movie": movie,
-            "zmw": int(match.group(2)),
-            "instrument_model": _infer_pacbio_instrument_model(movie),
-        }
+        return PacBioReadName(
+            format=PacBioFormat.GENERIC,
+            movie=movie,
+            zmw=int(match.group(2)),
+            instrument_model=_infer_pacbio_instrument_model(movie),
+        )
 
     return None
 
 
-def parse_ont_read_name(read_name: str) -> dict | None:
+def parse_ont_read_name(read_name: str) -> OntReadName | None:
     """
     Parse an Oxford Nanopore read name into its components.
 
@@ -279,7 +367,7 @@ def parse_ont_read_name(read_name: str) -> dict | None:
         read_name: FASTQ read name starting with @
 
     Returns:
-        Dict with parsed fields or None if not ONT format
+        OntReadName or None if not ONT format
     """
     name = read_name.lstrip("@")
 
@@ -287,22 +375,14 @@ def parse_ont_read_name(read_name: str) -> dict | None:
     uuid_pattern = re.compile(r"^([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\s*(.*)$")
     match = uuid_pattern.match(name)
     if match:
-        result = {
-            "format": "ont",
-            "uuid": match.group(1),
-        }
-        # Parse key=value pairs if present
-        metadata = match.group(2)
-        if metadata:
-            pairs = re.findall(r"(\w+)=([^\s]+)", metadata)
-            for key, value in pairs:
-                result[key] = value
-        return result
+        # Parse arbitrary key=value pairs if present
+        metadata = dict(re.findall(r"(\w+)=([^\s]+)", match.group(2)))
+        return OntReadName(uuid=match.group(1), metadata=metadata)
 
     return None
 
 
-def parse_mgi_read_name(read_name: str) -> dict | None:
+def parse_mgi_read_name(read_name: str) -> MgiReadName | None:
     """
     Parse an MGI/BGI read name into its components.
 
@@ -313,7 +393,7 @@ def parse_mgi_read_name(read_name: str) -> dict | None:
         read_name: FASTQ read name starting with @
 
     Returns:
-        Dict with parsed fields or None if not MGI format
+        MgiReadName or None if not MGI format
     """
     name = read_name.lstrip("@")
 
@@ -322,17 +402,14 @@ def parse_mgi_read_name(read_name: str) -> dict | None:
     match = mgi_pattern.match(name)
     if match:
         groups = match.groups()
-        result = {
-            "format": "mgi",
-            "flowcell": groups[0],
-            "lane": int(groups[1]),
-            "column": int(groups[2]),
-            "row": int(groups[3]),
-            "read_number": int(groups[4]),
-        }
-        if groups[5]:
-            result["pair"] = int(groups[5])
-        return result
+        return MgiReadName(
+            flowcell=groups[0],
+            lane=int(groups[1]),
+            column=int(groups[2]),
+            row=int(groups[3]),
+            read_number=int(groups[4]),
+            pair=int(groups[5]) if groups[5] else None,
+        )
 
     return None
 

--- a/tests/test_header_classifier.py
+++ b/tests/test_header_classifier.py
@@ -36,6 +36,7 @@ from meta_disco.header_classifier import (
     parse_ont_read_name,
     parse_pacbio_read_name,
 )
+from meta_disco.validators.read_name_parsers import IlluminaFormat, PacBioFormat
 
 # =============================================================================
 # HELPER FUNCTION TESTS
@@ -169,40 +170,40 @@ class TestParseIlluminaReadName:
         """Parse modern Illumina format with all fields."""
         result = parse_illumina_read_name("@A00297:44:HFKH3DSXX:2:1354:30508:28839 1:N:0:ATCACG")
         assert result is not None
-        assert result["format"] == "modern"
-        assert result["instrument"] == "A00297"
-        assert result["run_number"] == 44
-        assert result["flowcell"] == "HFKH3DSXX"
-        assert result["lane"] == 2
-        assert result["tile"] == 1354
-        assert result["read"] == 1
-        assert result["filtered"] is False
-        assert result["index"] == "ATCACG"
+        assert result.format is IlluminaFormat.MODERN
+        assert result.instrument == "A00297"
+        assert result.run_number == 44
+        assert result.flowcell == "HFKH3DSXX"
+        assert result.lane == 2
+        assert result.tile == 1354
+        assert result.read == 1
+        assert result.filtered is False
+        assert result.index == "ATCACG"
 
     def test_modern_format_minimal(self):
         """Parse modern format without optional second part."""
         result = parse_illumina_read_name("@A00297:44:HFKH3DSXX:2:1354:30508:28839")
         assert result is not None
-        assert result["instrument"] == "A00297"
-        assert "read" not in result
+        assert result.instrument == "A00297"
+        assert result.read is None
 
     def test_legacy_format(self):
         """Parse legacy Illumina format."""
         result = parse_illumina_read_name("@HWUSI-EAS100R:6:73:941:1973#ATCACG/1")
         assert result is not None
-        assert result["format"] == "legacy"
-        assert result["instrument"] == "HWUSI-EAS100R"
-        assert result["lane"] == 6
-        assert result["index"] == "ATCACG"
-        assert result["read"] == 1
+        assert result.format is IlluminaFormat.LEGACY
+        assert result.instrument == "HWUSI-EAS100R"
+        assert result.lane == 6
+        assert result.index == "ATCACG"
+        assert result.read == 1
 
     def test_archive_reformatted(self):
         """Parse archive-reformatted Illumina read."""
         result = parse_illumina_read_name("@ERR3242571.1 A00297:44:HFKH3DSXX:2:1354:30508:28839")
         assert result is not None
-        assert result["archive_accession"] == "ERR3242571"
-        assert result["archive_source"] == "ENA"
-        assert result["instrument"] == "A00297"
+        assert result.archive_accession == "ERR3242571"
+        assert result.archive_source == "ENA"
+        assert result.instrument == "A00297"
 
     def test_non_illumina(self):
         """Return None for non-Illumina format."""
@@ -217,34 +218,34 @@ class TestParsePacbioReadName:
         """Parse CCS/HiFi read name."""
         result = parse_pacbio_read_name("@m64011_190830_220126/1/ccs")
         assert result is not None
-        assert result["format"] == "ccs"
-        assert result["movie"] == "m64011_190830_220126"
-        assert result["zmw"] == 1
-        assert result["read_type"] == "CCS"
+        assert result.format is PacBioFormat.CCS
+        assert result.movie == "m64011_190830_220126"
+        assert result.zmw == 1
+        assert result.read_type == "CCS"
 
     def test_clr_format(self):
         """Parse CLR subread name."""
         result = parse_pacbio_read_name("@m64011_190830_220126/1234/0_5000")
         assert result is not None
-        assert result["format"] == "clr"
-        assert result["movie"] == "m64011_190830_220126"
-        assert result["zmw"] == 1234
-        assert result["start"] == 0
-        assert result["end"] == 5000
-        assert result["read_type"] == "CLR"
+        assert result.format is PacBioFormat.CLR
+        assert result.movie == "m64011_190830_220126"
+        assert result.zmw == 1234
+        assert result.start == 0
+        assert result.end == 5000
+        assert result.read_type == "CLR"
 
     def test_generic_format(self):
         """Parse generic PacBio read name."""
         result = parse_pacbio_read_name("@m64011_190830_220126/1234")
         assert result is not None
-        assert result["format"] == "generic"
-        assert result["zmw"] == 1234
+        assert result.format is PacBioFormat.GENERIC
+        assert result.zmw == 1234
 
     def test_sequel_ii_movie(self):
         """Parse Sequel II movie name (with 'e' suffix)."""
         result = parse_pacbio_read_name("@m64011e_210101_120000/1/ccs")
         assert result is not None
-        assert result["movie"] == "m64011e_210101_120000"
+        assert result.movie == "m64011e_210101_120000"
 
     def test_non_pacbio(self):
         """Return None for non-PacBio format."""
@@ -258,17 +259,17 @@ class TestParseOntReadName:
         """Parse ONT UUID read name."""
         result = parse_ont_read_name("@a1b2c3d4-e5f6-7890-abcd-ef1234567890")
         assert result is not None
-        assert result["format"] == "ont"
-        assert result["uuid"] == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        assert result.format == "ont"
+        assert result.uuid == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
     def test_uuid_with_metadata(self):
         """Parse ONT read name with key=value metadata."""
         result = parse_ont_read_name("@a1b2c3d4-e5f6-7890-abcd-ef1234567890 runid=abc123 read=456 ch=789")
         assert result is not None
-        assert result["uuid"] == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-        assert result["runid"] == "abc123"
-        assert result["read"] == "456"
-        assert result["ch"] == "789"
+        assert result.uuid == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        assert result.metadata["runid"] == "abc123"
+        assert result.metadata["read"] == "456"
+        assert result.metadata["ch"] == "789"
 
     def test_non_ont(self):
         """Return None for non-ONT format."""


### PR DESCRIPTION
## What changed

The four read-name parsers in `validators/read_name_parsers.py`
(`parse_illumina/pacbio/ont/mgi_read_name`) now return typed **frozen
per-platform dataclasses** instead of bare `dict | None`:

- `IlluminaReadName` — one class covering modern and legacy, with an
  `IlluminaFormat` enum and modern-only / second-block fields defaulting `None`.
- `PacBioReadName` — `PacBioFormat` enum; CLR-only `start`/`end`.
- `OntReadName` — fixed `uuid`/`format` spine plus an open
  `metadata: dict[str, str]` for the arbitrary trailing `key=value` pairs.
- `MgiReadName`.

`classify_from_fastq_header` now reads attributes instead of dict keys; the
emitted `classifications` dict is unchanged. The dataclasses and enums are
exported from `meta_disco.validators`. Parser unit tests migrated from
subscript to attribute access.

## Why

Part of #203 (Lane 3, first item). The old returns were bare dicts whose shape
varied per branch (Illumina's legacy branch dropped `run_number`/`flowcell`;
ONT fused a fixed schema with arbitrary `key=value` keys), with no declared
schema and two consumer surfaces mixing `.get("x")` and `parsed["y"]` on
adjacent lines. A key rename in any branch silently yielded `None` at the
classifier. Typed dataclasses make the fields each branch produces explicit and
turn a rename into a type error.

## Assumptions I made

- **The rule-engine `validators:` registration is inert, so the return type is
  unconstrained.** `rule_engine.py` never reads `rules.validators`; FASTQ
  classifies purely via the `fastq_pattern` regex. The only runtime consumer of
  the parsed result is `classify_from_fastq_header`. I left the YAML
  registration unchanged.
- **These results are internal-only** — never serialized or persisted — so the
  dataclasses intentionally have no `to_dict`/`from_json` (unlike
  `records.py`/`evidence.py`, which serialize). No golden-output impact.
- **Illumina stays one class, not a modern/legacy union.** The sole consumer
  reads only `instrument`/`instrument_model`/`archive_accession`/`archive_source`
  (all shared); a union would force `isinstance` branching for no benefit.
- **ONT dynamic keys live under `.metadata`**, not flattened onto attributes —
  keeps the typed spine closed and the open part in one named field. As a side
  benefit, a `key=value` pair named `format`/`uuid` can no longer clobber the
  spine (the old dict-merge could).
- **`archive_accession`/`archive_source`/`pair` are now always set (to `None`
  when absent)** rather than conditionally present as dict keys. Every consumer
  uses truthiness or attribute access, so this is behaviorally equivalent.
- **`OntReadName.format`/`MgiReadName.format` stay plain `str` constants** (per
  the issue's design note) while Illumina/PacBio use enums for their real
  multi-variant distinction.

## How to verify

Definition of done (from #208), mapped to steps:

- [ ] **4 parsers return typed dataclasses (`| None` preserved)** — open
  `validators/read_name_parsers.py`; each `parse_*` is annotated
  `-> XReadName | None` and constructs the dataclass per branch.
- [ ] **`classify_from_fastq_header` reads attributes** — see
  `header_classifier.py` ~317–327: `parsed.instrument_model`,
  `parsed.archive_accession`, etc.
- [ ] **ONT dynamic keys under `.metadata`** — run:
  ```
  python -c "from meta_disco.validators import parse_ont_read_name as p; r=p('@a1b2c3d4-e5f6-7890-abcd-ef1234567890 runid=abc read=456'); print(r.uuid, r.metadata)"
  ```
  Expect the uuid and `{'runid': 'abc', 'read': '456'}`.
- [ ] **Dataclasses exported** —
  `python -c "from meta_disco.validators import IlluminaReadName, PacBioReadName, OntReadName, MgiReadName, IlluminaFormat, PacBioFormat; print('ok')"`.
- [ ] **`TestReadNameParsers` migrated; `make test-all` green** — run
  `make test-all` (671 root + 10 schema tests pass); `make type` is 0 errors;
  `make lint` and `make format-check` clean.

Closes #208
