### PR TITLE
Type the FASTQ classification result scalars (#209)

### DIFF
--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -9,7 +9,7 @@ The actual classification rules are defined in the bundled unified_rules.yaml
 """
 
 import re
-from dataclasses import replace
+from dataclasses import dataclass, fields, replace
 from functools import cache
 from typing import TYPE_CHECKING
 
@@ -32,6 +32,35 @@ if TYPE_CHECKING:
 # GFA_CONFIG.extensions is this same tuple — defined here so the classifier and
 # the config cannot disagree about which names it may trust.
 GRAPH_TEXT_EXTENSIONS = (".gfa", ".gfa.gz", ".rgfa", ".rgfa.gz")
+
+
+@dataclass(frozen=True)
+class FastqReadMetadata:
+    """FASTQ-specific scalar metadata spliced into a classification result.
+
+    The five per-read scalars ``classify_from_fastq_header`` derives from read
+    names (paired-end flag, Illumina instrument model/hint, ENA/SRA archive
+    accession and source). Both build sites in that function construct this and
+    call ``merge_into``, so the key set is declared in one place instead of two
+    literals that must be kept in sync.
+    """
+
+    is_paired_end: bool | None = None
+    instrument_model: str | None = None
+    instrument_hint: str | None = None
+    archive_accession: str | None = None
+    archive_source: str | None = None
+
+    def merge_into(self, classifications: dict) -> None:
+        """Splice the fields into ``classifications`` as flat scalar keys.
+
+        Mutates the passed dict (not ``self``). Keys are derived from the field
+        list, so the merged key set cannot drift from the declared fields (the
+        ``records.py`` ``to_dict`` convention). The scalars are stored flat — not
+        as ``{value, status, evidence}`` entries — because that is how
+        ``models.field_value`` reads them and what keeps the output byte-identical.
+        """
+        classifications.update({f.name: getattr(self, f.name) for f in fields(self)})
 
 
 @cache
@@ -237,18 +266,15 @@ def classify_from_fastq_header(
     # (reads are unaligned), matching the non-empty path (#131); the remaining
     # dimensions are not_classified.
     if not reads or not reads[0]:
-        return {
+        entries = {
             "data_modality": build_field_entry(None, status=NOT_CLASSIFIED),
             "data_type": build_field_entry("reads", status=CLASSIFIED),
             "platform": build_field_entry(None, status=NOT_CLASSIFIED),
             "reference_assembly": build_field_entry(None, status=NOT_APPLICABLE),
             "assay_type": build_field_entry(None, status=NOT_CLASSIFIED),
-            "is_paired_end": None,
-            "instrument_model": None,
-            "instrument_hint": None,
-            "archive_accession": None,
-            "archive_source": None,
         }
+        FastqReadMetadata().merge_into(entries)
+        return entries
 
     # Get first read for classification
     first_read = reads[0]
@@ -328,11 +354,13 @@ def classify_from_fastq_header(
             break
 
     classifications = result.to_output_dict()
-    classifications["is_paired_end"] = is_paired_end
-    classifications["instrument_model"] = instrument_model
-    classifications["instrument_hint"] = instrument_hint
-    classifications["archive_accession"] = archive_accession
-    classifications["archive_source"] = archive_source
+    FastqReadMetadata(
+        is_paired_end=is_paired_end,
+        instrument_model=instrument_model,
+        instrument_hint=instrument_hint,
+        archive_accession=archive_accession,
+        archive_source=archive_source,
+    ).merge_into(classifications)
     return classifications
 
 

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -38,10 +38,12 @@ GRAPH_TEXT_EXTENSIONS = (".gfa", ".gfa.gz", ".rgfa", ".rgfa.gz")
 class FastqReadMetadata:
     """FASTQ-specific scalar metadata spliced into a classification result.
 
-    The five per-read scalars ``classify_from_fastq_header`` derives from read
-    names (paired-end flag, Illumina instrument model/hint, ENA/SRA archive
-    accession and source). Both build sites in that function construct this and
-    call ``merge_into``, so the key set is declared in one place instead of two
+    The five scalars ``classify_from_fastq_header`` derives while inspecting a
+    file's reads: the paired-end flag (from read names, falling back to the
+    filename), the instrument model (from the Illumina or PacBio read-name
+    parse), the Illumina instrument hint, and the ENA/SRA archive accession and
+    source. Both build sites in that function construct this and call
+    ``merge_into``, so the key set is declared in one place instead of two
     literals that must be kept in sync.
     """
 

--- a/tests/test_header_classifier.py
+++ b/tests/test_header_classifier.py
@@ -288,13 +288,13 @@ class TestFastqReadMetadata:
     """Test the FastqReadMetadata merge into a classification result dict."""
 
     # The flat scalar keys FastqReadMetadata owns, in the order it writes them.
-    SCALAR_KEYS = [
+    SCALAR_KEYS = (
         "is_paired_end",
         "instrument_model",
         "instrument_hint",
         "archive_accession",
         "archive_source",
-    ]
+    )
 
     def test_empty_metadata_merges_all_none(self):
         """A default (all-None) instance splices five None-valued scalar keys."""

--- a/tests/test_header_classifier.py
+++ b/tests/test_header_classifier.py
@@ -323,17 +323,22 @@ class TestFastqReadMetadata:
             "archive_source": "ENA",
         }
 
-    def test_empty_input_path_produces_ten_keys(self):
-        """The empty-reads path returns the five entry keys plus the five scalars."""
+    def test_empty_input_path_produces_ten_keys_in_order(self):
+        """The empty-reads path returns the five entry keys then the five scalars.
+
+        Asserts insertion order, not just the key set: the output is json-dumped
+        to NDJSON and the PR's contract is byte-identical output, so key order is
+        part of what must not regress.
+        """
         result = classify_from_fastq_header([])
-        assert set(result.keys()) == {
+        assert list(result.keys()) == [
             "data_modality",
             "data_type",
             "platform",
             "reference_assembly",
             "assay_type",
             *self.SCALAR_KEYS,
-        }
+        ]
         for key in self.SCALAR_KEYS:
             assert result[key] is None
 

--- a/tests/test_header_classifier.py
+++ b/tests/test_header_classifier.py
@@ -24,6 +24,8 @@ def val(result: dict, field: str):
 
 
 from meta_disco.header_classifier import (
+    # Result models
+    FastqReadMetadata,
     # Classification functions
     classify_from_fastq_header,
     classify_from_header,
@@ -280,6 +282,60 @@ class TestParseOntReadName:
 # =============================================================================
 # FASTQ CLASSIFICATION TESTS
 # =============================================================================
+
+
+class TestFastqReadMetadata:
+    """Test the FastqReadMetadata merge into a classification result dict."""
+
+    # The flat scalar keys FastqReadMetadata owns, in the order it writes them.
+    SCALAR_KEYS = [
+        "is_paired_end",
+        "instrument_model",
+        "instrument_hint",
+        "archive_accession",
+        "archive_source",
+    ]
+
+    def test_empty_metadata_merges_all_none(self):
+        """A default (all-None) instance splices five None-valued scalar keys."""
+        entries = {"data_type": "reads"}
+        FastqReadMetadata().merge_into(entries)
+        assert list(entries.keys()) == ["data_type", *self.SCALAR_KEYS]
+        for key in self.SCALAR_KEYS:
+            assert entries[key] is None
+
+    def test_populated_metadata_merges_values(self):
+        """A populated instance splices its field values under the flat keys."""
+        entries = {"data_type": "reads"}
+        FastqReadMetadata(
+            is_paired_end=True,
+            instrument_model="NovaSeq 6000",
+            instrument_hint="A00297",
+            archive_accession="ERR3242571",
+            archive_source="ENA",
+        ).merge_into(entries)
+        assert entries == {
+            "data_type": "reads",
+            "is_paired_end": True,
+            "instrument_model": "NovaSeq 6000",
+            "instrument_hint": "A00297",
+            "archive_accession": "ERR3242571",
+            "archive_source": "ENA",
+        }
+
+    def test_empty_input_path_produces_ten_keys(self):
+        """The empty-reads path returns the five entry keys plus the five scalars."""
+        result = classify_from_fastq_header([])
+        assert set(result.keys()) == {
+            "data_modality",
+            "data_type",
+            "platform",
+            "reference_assembly",
+            "assay_type",
+            *self.SCALAR_KEYS,
+        }
+        for key in self.SCALAR_KEYS:
+            assert result[key] is None
 
 
 class TestFastqClassification:


### PR DESCRIPTION
Closes #209

## What changed
`classify_from_fastq_header` built its result at two sites — the empty-input literal and the populated path — that each independently listed the five flat scalar keys (`is_paired_end`, `instrument_model`, `instrument_hint`, `archive_accession`, `archive_source`) with no shared constructor. This adds a frozen `FastqReadMetadata` dataclass owning those five fields; both sites now construct it and call `merge_into(classifications)`, which writes the fields as flat scalar keys **derived from the field list** (`{f.name: getattr(self, f.name) for f in fields(self)}`, the `records.py` `to_dict` convention). Adds `TestFastqReadMetadata` (all-None merge, populated merge, empty-input ten-key result).

Part of epic #203 (parse-don't-validate sweep), Lane 3, following #208.

## Why
Two literals agreeing on a key set by hand is a drift hazard: add a sixth scalar and one path silently omits it. Declaring the key set once — as the dataclass field list — makes that class of bug unrepresentable. The `field_value` accessor indirection that partly masked this today was doing a typed record's job.

## Assumptions I made
- **Output must stay byte-identical**, and it does: the scalars remain flat scalar keys (not `{value,status,evidence}` entries) because that is how `models.field_value` reads them; `fields()` yields declaration order and `dict.update` appends, so keys, values, and insertion order are unchanged. No automated golden fixture references `fastq_classifications.json` (those are run artifacts), so this is a construction guarantee.
- **`FastqReadMetadata` lives in `header_classifier.py`**, its sole producer/consumer — not in `records.py` (whose charter is the pipeline load-boundary and write-side envelopes). `OutputRecord`'s own docstring already delegates "the fastq scalar hints" to live inside `classifications`, so this is standalone, not folded into the shared envelope.
- **The five per-field dimension entries stay the rule engine's `to_output_dict()` shape** (owned by epic #116) — out of scope here; only the FASTQ scalars are typed.
- `merge_into` mutates its **argument** dict (not `self`, which stays frozen); both call sites merge into a dict constructed one line earlier and returned on the next, so no aliasing concern.

## How to verify
Definition of done from #209:
- [ ] **`FastqReadMetadata` added; both build sites construct + merge it** → `src/meta_disco/header_classifier.py`: the dataclass near the top; the empty path builds `entries` then `FastqReadMetadata().merge_into(entries)`; the populated path builds `FastqReadMetadata(...).merge_into(classifications)`.
- [ ] **`fastq_classifications.json` unchanged** → run `make classify-fastq` on a corpus (network required for header fetches) and diff the emitted `fastq_classifications.json` against a pre-change run; expect no diff. Or trust the construction argument above (flat keys, declaration order, `update` appends).
- [ ] **`summaries` reads unchanged** → `src/meta_disco/summaries.py:print_fastq_summary` still reads via `field_value(c, "is_paired_end")` etc.; the merged dict keeps the same flat keys.
- [ ] **Merge unit test; `make test-all` green** → `uv run pytest tests/test_header_classifier.py -k FastqReadMetadata -v` (3 tests); full suite: `make test-all` (674 root + 10 schema passed locally). Also `make format-check` and `make type` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

