### PR TITLE
Type the VCF header-line _type/_value tagged-union (#210)

### DIFF
--- a/src/meta_disco/validators/__init__.py
+++ b/src/meta_disco/validators/__init__.py
@@ -15,6 +15,8 @@ from .contig_lengths import (
 from .header_extractors import (
     SAMHeader,
     VCFHeader,
+    VcfSimpleMeta,
+    VcfStructuredMeta,
     extract_sam_field,
     get_contig_lines,
     has_sam_section,
@@ -48,6 +50,8 @@ __all__ = [
     # Header extractors
     "SAMHeader",
     "VCFHeader",
+    "VcfSimpleMeta",
+    "VcfStructuredMeta",
     "parse_sam_header",
     "parse_vcf_header",
     "extract_sam_field",

--- a/src/meta_disco/validators/header_extractors.py
+++ b/src/meta_disco/validators/header_extractors.py
@@ -19,17 +19,48 @@ class SAMHeader:
     co: list[str] | None = None  # @CO comments
 
 
+@dataclass(frozen=True)
+class VcfSimpleMeta:
+    """A ``##key=value`` VCF header line (e.g. ``##fileformat``, ``##reference``).
+
+    ``type`` is the key; ``value`` is everything after the ``=``. Distinct from
+    ``VcfStructuredMeta`` so that ``parse_vcf_header`` can dispatch on the concrete
+    type instead of a reserved ``_type`` key sharing the field namespace.
+    """
+
+    type: str
+    value: str
+
+
+@dataclass(frozen=True)
+class VcfStructuredMeta:
+    """A ``##TYPE=<key=value,...>`` VCF header line (e.g. ``##contig``, ``##INFO``).
+
+    ``type`` is the discriminator (``contig``/``INFO``/``FORMAT``/``FILTER``);
+    ``fields`` holds the parsed inner key=value pairs. Keeping ``fields`` separate
+    from ``type`` isolates the open-ended VCF key space from the discriminator, so
+    readers no longer need to skip reserved keys.
+    """
+
+    type: str
+    fields: dict[str, str]
+
+
+# A single parsed ``##`` VCF header line: a key=value line or a structured ``<...>`` line.
+VcfHeaderLine = VcfSimpleMeta | VcfStructuredMeta
+
+
 @dataclass
 class VCFHeader:
     """Parsed VCF header."""
 
     fileformat: str | None = None  # ##fileformat
     reference: str | None = None  # ##reference
-    contigs: list[dict[str, str]] | None = None  # ##contig lines
+    contigs: list[VcfStructuredMeta] | None = None  # ##contig lines
     source: str | None = None  # ##source
-    info_fields: list[dict[str, str]] | None = None  # ##INFO fields
-    format_fields: list[dict[str, str]] | None = None  # ##FORMAT fields
-    filter_fields: list[dict[str, str]] | None = None  # ##FILTER fields
+    info_fields: list[VcfStructuredMeta] | None = None  # ##INFO fields
+    format_fields: list[VcfStructuredMeta] | None = None  # ##FORMAT fields
+    filter_fields: list[VcfStructuredMeta] | None = None  # ##FILTER fields
     other_meta: list[str] | None = None  # Other ## lines
 
 
@@ -183,15 +214,16 @@ def has_sam_section(header: SAMHeader, section: str) -> bool:
     return False
 
 
-def parse_vcf_header_line(line: str) -> dict[str, str] | None:
+def parse_vcf_header_line(line: str) -> VcfHeaderLine | None:
     """
-    Parse a VCF header line with ID=value,Description="..." format.
+    Parse a VCF header line into a typed simple or structured record.
 
     Args:
         line: A VCF header line like ##INFO=<ID=DP,Number=1,Type=Integer,...>
 
     Returns:
-        Dict of parsed fields or None if not parseable
+        A VcfStructuredMeta for ``##TYPE=<...>`` lines, a VcfSimpleMeta for simple
+        ``##key=value`` lines, or None if not parseable.
     """
     # Match ##TYPE=<...> format
     match = re.match(r"^##(\w+)=<(.*)>$", line)
@@ -199,14 +231,14 @@ def parse_vcf_header_line(line: str) -> dict[str, str] | None:
         # Handle simple key=value format like ##fileformat=VCFv4.2
         simple_match = re.match(r"^##(\w+)=(.*)$", line)
         if simple_match:
-            return {"_type": simple_match.group(1), "_value": simple_match.group(2)}
+            return VcfSimpleMeta(type=simple_match.group(1), value=simple_match.group(2))
         return None
 
     header_type = match.group(1)
     content = match.group(2)
 
     # Parse key=value pairs (handling quoted values)
-    fields = {"_type": header_type}
+    fields: dict[str, str] = {}
 
     # Pattern for key=value or key="value with spaces"
     pattern = r'(\w+)=("[^"]*"|[^,]*)'
@@ -216,7 +248,7 @@ def parse_vcf_header_line(line: str) -> dict[str, str] | None:
             value = value[1:-1]
         fields[key] = value
 
-    return fields
+    return VcfStructuredMeta(type=header_type, fields=fields)
 
 
 def parse_vcf_header(header_text: str) -> VCFHeader:
@@ -244,21 +276,22 @@ def parse_vcf_header(header_text: str) -> VCFHeader:
         if parsed is None:
             continue
 
-        header_type = parsed.get("_type", "")
-
-        if header_type == "fileformat":
-            header.fileformat = parsed.get("_value")
-        elif header_type == "reference":
-            header.reference = parsed.get("_value")
-        elif header_type == "source":
-            header.source = parsed.get("_value")
-        elif header_type == "contig":
+        if isinstance(parsed, VcfSimpleMeta):
+            if parsed.type == "fileformat":
+                header.fileformat = parsed.value
+            elif parsed.type == "reference":
+                header.reference = parsed.value
+            elif parsed.type == "source":
+                header.source = parsed.value
+            else:
+                other_meta.append(line)
+        elif parsed.type == "contig":
             contigs.append(parsed)
-        elif header_type == "INFO":
+        elif parsed.type == "INFO":
             info_fields.append(parsed)
-        elif header_type == "FORMAT":
+        elif parsed.type == "FORMAT":
             format_fields.append(parsed)
-        elif header_type == "FILTER":
+        elif parsed.type == "FILTER":
             filter_fields.append(parsed)
         else:
             other_meta.append(line)
@@ -298,20 +331,23 @@ def match_vcf_header_pattern(header: VCFHeader, header_type: str, pattern: str) 
     if header_type == "##contig" and header.contigs:
         for contig in header.contigs:
             # Check all fields in the contig line
-            for _key, value in contig.items():
-                if compiled.search(str(value)):
+            for value in contig.fields.values():
+                if compiled.search(value):
                     return True
     elif header_type == "##INFO" and header.info_fields:
         for info in header.info_fields:
-            if "ID" in info and compiled.search(info["ID"]):
+            info_id = info.fields.get("ID")
+            if info_id and compiled.search(info_id):
                 return True
     elif header_type == "##FORMAT" and header.format_fields:
         for fmt in header.format_fields:
-            if "ID" in fmt and compiled.search(fmt["ID"]):
+            fmt_id = fmt.fields.get("ID")
+            if fmt_id and compiled.search(fmt_id):
                 return True
     elif header_type == "##FILTER" and header.filter_fields:
         for flt in header.filter_fields:
-            if "ID" in flt and compiled.search(flt["ID"]):
+            flt_id = flt.fields.get("ID")
+            if flt_id and compiled.search(flt_id):
                 return True
     elif header.other_meta:
         # header_type already includes ## prefix (e.g., "##reference")
@@ -338,11 +374,7 @@ def get_contig_lines(header: VCFHeader) -> list[str]:
     lines = []
     for contig in header.contigs:
         # Reconstruct the line
-        parts = []
-        for key, value in contig.items():
-            if key.startswith("_"):
-                continue
-            parts.append(f"{key}={value}")
+        parts = [f"{key}={value}" for key, value in contig.fields.items()]
         lines.append(f"##contig=<{','.join(parts)}>")
 
     return lines

--- a/src/meta_disco/validators/header_extractors.py
+++ b/src/meta_disco/validators/header_extractors.py
@@ -316,7 +316,8 @@ def match_vcf_header_pattern(header: VCFHeader, header_type: str, pattern: str) 
 
     Args:
         header: Parsed VCFHeader object
-        header_type: Type of header line (##reference, ##source, ##contig, ##INFO, ##FORMAT)
+        header_type: Type of header line (##reference, ##source, ##contig, ##INFO,
+            ##FORMAT, ##FILTER)
         pattern: Regex pattern to match
 
     Returns:

--- a/tests/test_header_extractors.py
+++ b/tests/test_header_extractors.py
@@ -74,14 +74,22 @@ class TestMatchVcfHeaderPattern:
     HEADER = "\n".join(
         [
             "##reference=file:///GRCh38.fa",
+            "##source=MyCaller_v2",
             "##contig=<ID=chr1,length=248956422>",
             "##INFO=<ID=DP,Number=1,Type=Integer>",
+            "##FORMAT=<ID=GT,Number=1,Type=String>",
+            '##FILTER=<ID=LowQual,Description="Low quality">',
+            "##fileDate=20090805",
         ]
     )
 
     def test_reference_pattern_matches(self):
         header = parse_vcf_header(self.HEADER)
         assert match_vcf_header_pattern(header, "##reference", "GRCh38")
+
+    def test_source_pattern_matches(self):
+        header = parse_vcf_header(self.HEADER)
+        assert match_vcf_header_pattern(header, "##source", "MyCaller")
 
     def test_contig_value_pattern_matches(self):
         # Scans each contig field value individually, so this matches a bare
@@ -93,6 +101,20 @@ class TestMatchVcfHeaderPattern:
     def test_info_id_pattern_matches(self):
         header = parse_vcf_header(self.HEADER)
         assert match_vcf_header_pattern(header, "##INFO", "DP")
+
+    def test_format_id_pattern_matches(self):
+        header = parse_vcf_header(self.HEADER)
+        assert match_vcf_header_pattern(header, "##FORMAT", "GT")
+
+    def test_filter_id_pattern_matches(self):
+        header = parse_vcf_header(self.HEADER)
+        assert match_vcf_header_pattern(header, "##FILTER", "LowQual")
+
+    def test_other_meta_fallback_matches_raw_line(self):
+        # An unrecognized ## line lands in other_meta; the fallback branch
+        # matches on the raw line by its ## prefix.
+        header = parse_vcf_header(self.HEADER)
+        assert match_vcf_header_pattern(header, "##fileDate", "20090805")
 
     def test_no_match_returns_false(self):
         header = parse_vcf_header(self.HEADER)

--- a/tests/test_header_extractors.py
+++ b/tests/test_header_extractors.py
@@ -1,0 +1,111 @@
+"""Tests for VCF header extraction and its typed line records."""
+
+from meta_disco.validators.header_extractors import (
+    VcfSimpleMeta,
+    VcfStructuredMeta,
+    get_contig_lines,
+    match_vcf_header_pattern,
+    parse_vcf_header,
+    parse_vcf_header_line,
+)
+
+
+class TestParseVcfHeaderLine:
+    """Test parse_vcf_header_line's simple/structured/None dispatch."""
+
+    def test_simple_line_returns_simple_meta(self):
+        parsed = parse_vcf_header_line("##fileformat=VCFv4.2")
+        assert parsed == VcfSimpleMeta(type="fileformat", value="VCFv4.2")
+
+    def test_structured_line_returns_structured_meta(self):
+        parsed = parse_vcf_header_line("##contig=<ID=chr1,length=248956422>")
+        assert parsed == VcfStructuredMeta(type="contig", fields={"ID": "chr1", "length": "248956422"})
+
+    def test_structured_line_strips_quotes(self):
+        parsed = parse_vcf_header_line('##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">')
+        assert isinstance(parsed, VcfStructuredMeta)
+        assert parsed.fields["ID"] == "DP"
+        assert parsed.fields["Description"] == "Total Depth"
+
+    def test_unparseable_line_returns_none(self):
+        assert parse_vcf_header_line("#CHROM\tPOS\tID") is None
+
+
+class TestParseVcfHeader:
+    """Test parse_vcf_header building a typed VCFHeader."""
+
+    HEADER = "\n".join(
+        [
+            "##fileformat=VCFv4.2",
+            "##reference=file:///GRCh38.fa",
+            "##source=MyCaller",
+            "##contig=<ID=chr1,length=248956422>",
+            '##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">',
+            "##FORMAT=<ID=GT,Number=1,Type=String>",
+            '##FILTER=<ID=PASS,Description="All filters passed">',
+            "##fileDate=20090805",
+        ]
+    )
+
+    def test_simple_fields_extracted(self):
+        header = parse_vcf_header(self.HEADER)
+        assert header.fileformat == "VCFv4.2"
+        assert header.reference == "file:///GRCh38.fa"
+        assert header.source == "MyCaller"
+
+    def test_structured_fields_are_typed(self):
+        header = parse_vcf_header(self.HEADER)
+        assert header.contigs == [VcfStructuredMeta(type="contig", fields={"ID": "chr1", "length": "248956422"})]
+        assert header.info_fields is not None
+        assert header.info_fields[0].fields["ID"] == "DP"
+        assert header.format_fields is not None
+        assert header.format_fields[0].fields["ID"] == "GT"
+        assert header.filter_fields is not None
+        assert header.filter_fields[0].fields["ID"] == "PASS"
+
+    def test_unrecognized_simple_line_falls_to_other_meta(self):
+        header = parse_vcf_header(self.HEADER)
+        assert header.other_meta == ["##fileDate=20090805"]
+
+
+class TestMatchVcfHeaderPattern:
+    """Test match_vcf_header_pattern over the typed header."""
+
+    HEADER = "\n".join(
+        [
+            "##reference=file:///GRCh38.fa",
+            "##contig=<ID=chr1,length=248956422>",
+            "##INFO=<ID=DP,Number=1,Type=Integer>",
+        ]
+    )
+
+    def test_reference_pattern_matches(self):
+        header = parse_vcf_header(self.HEADER)
+        assert match_vcf_header_pattern(header, "##reference", "GRCh38")
+
+    def test_contig_value_pattern_matches(self):
+        # Scans each contig field value individually, so this matches a bare
+        # value. It does NOT exercise the shipped ``assembly=<name>`` contig
+        # rules, which can't match this scanner (see #221).
+        header = parse_vcf_header(self.HEADER)
+        assert match_vcf_header_pattern(header, "##contig", "248956422")
+
+    def test_info_id_pattern_matches(self):
+        header = parse_vcf_header(self.HEADER)
+        assert match_vcf_header_pattern(header, "##INFO", "DP")
+
+    def test_no_match_returns_false(self):
+        header = parse_vcf_header(self.HEADER)
+        assert not match_vcf_header_pattern(header, "##reference", "GRCh37")
+
+
+class TestGetContigLines:
+    """Test get_contig_lines reconstruction from typed contigs."""
+
+    def test_reconstructs_all_fields(self):
+        header = parse_vcf_header("##contig=<ID=chr1,length=248956422>")
+        assert get_contig_lines(header) == ["##contig=<ID=chr1,length=248956422>"]
+
+    def test_empty_when_no_contigs(self):
+        header = parse_vcf_header("##fileformat=VCFv4.2")
+        assert get_contig_lines(header) == []


### PR DESCRIPTION
Closes #210 · Part of #203 (Lane 3, Content inputs)

## What changed
Replaced the bare `dict[str,str]` VCF header-line record — which used reserved magic keys `_type`/`_value` alongside arbitrary VCF field names — with a typed discriminated union in `src/meta_disco/validators/header_extractors.py`:

- `VcfSimpleMeta(type, value)` for `##key=value` lines (fileformat/reference/source).
- `VcfStructuredMeta(type, fields)` for `##TYPE=<...>` lines (contig/INFO/FORMAT/FILTER); `fields` holds the inner key=value pairs.
- `VcfHeaderLine = VcfSimpleMeta | VcfStructuredMeta` alias.
- `parse_vcf_header_line -> VcfHeaderLine | None`; `parse_vcf_header` dispatches via `isinstance`; `VCFHeader.contigs/info_fields/format_fields/filter_fields` retyped `list[dict]` → `list[VcfStructuredMeta]`; `match_vcf_header_pattern` reads `.fields`; `get_contig_lines` drops the `if key.startswith("_")` skip (magic keys gone).
- Exported the two classes from `validators/__init__.py`.
- New `tests/test_header_extractors.py` (no prior unit coverage of this module).

## Why
Epic #203 ("parse, don't validate"): the `_type`/`_value` tagged-union was defined only by its readers, shared a namespace with real VCF field names, and forced the reserved-key skip in `get_contig_lines`. Two frozen dataclasses make the shape explicit and let the discriminator live outside the open VCF key space.

## Assumptions I made
- Chose `isinstance` dispatch over a `VcfLineKind` enum + `kind` field (the design listed both as alternatives). With two distinct payload shapes, the enum would be redundant state and reintroduce "which field is populated" ambiguity — dropped it.
- The old `match_vcf_header_pattern` contig branch scanned `contig.items()` values, which included the `_type`→`"contig"` pair. The new `.fields.values()` drops that token; verified no shipped `##contig` pattern contains the literal `"contig"`, so it's a harmless dedup.
- Output is unchanged: the records are internal to the rule engine, never serialized; the only external reader (`rule_engine._match_vcf_header`) calls `match_vcf_header_pattern` and never touches the record shape.
- Declined two malformed-input behavior differences (bracket-less contig line, empty `ID=""`) per CLAUDE.md error-handling philosophy — no defensive handling of malformed internal input.
- Review surfaced a **pre-existing** bug (not caused by this diff): the shipped `##contig` `assembly=(...)` rules can never match the value-splitting scanner. Filed as **#221**; left out of scope for this typing change.

## How to verify
DoD checklist from #210:
- [ ] `VcfSimpleMeta`/`VcfStructuredMeta` exist → see `header_extractors.py`; `grep -n "class Vcf" src/meta_disco/validators/header_extractors.py`.
- [ ] `parse_vcf_header_line -> VcfHeaderLine | None` → check the signature; `parse_vcf_header_line("##fileformat=VCFv4.2")` returns `VcfSimpleMeta(type="fileformat", value="VCFv4.2")`.
- [ ] readers use typed fields; `VCFHeader` retyped; `_`-skip removed; magic keys gone → `grep -n "_type\|_value\|startswith" src/meta_disco/validators/header_extractors.py` returns nothing.
- [ ] `make test-all` green → run it (697 root + 10 schema pass). Also `make lint-all` and `make format-check` pass; pyright clean.

Unit tests: `uv run pytest tests/test_header_extractors.py -v`.