### PR TITLE
Type the BED signals dict as BedSignals (#211)

### DIFF
--- a/scripts/classify_bed_files.py
+++ b/scripts/classify_bed_files.py
@@ -92,7 +92,9 @@ def classify_bed_files(metadata_path: Path, output_path: Path):
         # coordinate inference (has_chr_prefix=False is never read when
         # max_coordinates is empty).
         raw_signals = ref_evidence.get(md5, {}).get("signals") if md5 else None
-        signals = BedSignals.from_evidence(raw_signals) if raw_signals else BedSignals.empty()
+        # None/absent -> genuine no-evidence (filename-only). A present-but-malformed
+        # record goes through from_evidence so its missing keys fail loud.
+        signals = BedSignals.from_evidence(raw_signals) if raw_signals is not None else BedSignals.empty()
 
         # Classify using unified classifier (rule engine + coordinate detection)
         classifications = classify_from_bed_signals(

--- a/scripts/classify_bed_files.py
+++ b/scripts/classify_bed_files.py
@@ -16,7 +16,7 @@ import json
 from pathlib import Path
 
 # Add project root to path for imports
-from meta_disco.header_classifier import classify_from_bed_signals
+from meta_disco.header_classifier import BedSignals, classify_from_bed_signals
 from meta_disco.models import CLASSIFIED, field_label, field_status
 
 EVIDENCE_DIR = Path("data/evidence/anvil/bed")
@@ -87,8 +87,12 @@ def classify_bed_files(metadata_path: Path, output_path: Path):
         md5 = f.get("file_md5sum")
         stats["total"] += 1
 
-        # Get coordinate signals from cached evidence
-        signals = ref_evidence.get(md5, {}).get("signals", {}) if md5 else {}
+        # Get coordinate signals from cached evidence (a file-content boundary).
+        # No evidence -> empty signals: filename-only classification, no
+        # coordinate inference (has_chr_prefix=False is never read when
+        # max_coordinates is empty).
+        raw_signals = ref_evidence.get(md5, {}).get("signals") if md5 else None
+        signals = BedSignals.from_evidence(raw_signals) if raw_signals else BedSignals.empty()
 
         # Classify using unified classifier (rule engine + coordinate detection)
         classifications = classify_from_bed_signals(

--- a/scripts/fetch_bed_headers.py
+++ b/scripts/fetch_bed_headers.py
@@ -82,7 +82,7 @@ def fetch_bed_signals(md5sum: str, is_gzipped: bool = True, file_size: int | Non
         file_size: Known file size in bytes (used to pick fetch size)
 
     Returns:
-        Signals dict or None on failure
+        BedSignals or None on failure
     """
     # Adaptive fetch size: small files get fetched whole, large ones get 10MB
     # HTTP Range end offset is inclusive, so bytes=0-N fetches N+1 bytes

--- a/scripts/fetch_bed_headers.py
+++ b/scripts/fetch_bed_headers.py
@@ -16,13 +16,14 @@ import time
 import zlib
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict
 from pathlib import Path
 from threading import Lock
 
 # Add project root to path
 import requests
 
-from meta_disco.header_classifier import classify_from_bed_signals
+from meta_disco.header_classifier import BedSignals, classify_from_bed_signals
 from meta_disco.models import field_label
 
 S3_MIRROR_URL = "https://anvilproject.s3.amazonaws.com/file"
@@ -63,7 +64,7 @@ def save_evidence(md5sum: str, file_name: str, evidence: dict):
         json.dump(evidence, f, indent=2)
 
 
-def fetch_bed_signals(md5sum: str, is_gzipped: bool = True, file_size: int | None = None) -> dict | None:
+def fetch_bed_signals(md5sum: str, is_gzipped: bool = True, file_size: int | None = None) -> BedSignals | None:
     """Fetch BED data from S3 and extract reference signals in one pass.
 
     Instead of storing all lines, we stream through and track only:
@@ -133,11 +134,11 @@ def fetch_bed_signals(md5sum: str, is_gzipped: bool = True, file_size: int | Non
         return None
 
 
-def extract_bed_signals(lines: list[str]) -> dict:
+def extract_bed_signals(lines: list[str]) -> BedSignals:
     """Extract reference assembly signals from BED lines.
 
-    Returns dict with:
-        - chromosomes: set of chromosome names seen
+    Returns a BedSignals with:
+        - chromosomes: sorted chromosome names seen
         - has_chr_prefix: whether chromosomes use 'chr' prefix
         - max_coordinates: dict of chrom -> max end coordinate
         - line_count: number of lines analyzed
@@ -168,12 +169,12 @@ def extract_bed_signals(lines: list[str]) -> dict:
 
     has_chr_prefix = any(c.startswith("chr") for c in chromosomes)
 
-    return {
-        "chromosomes": sorted(chromosomes),
-        "has_chr_prefix": has_chr_prefix,
-        "max_coordinates": dict(max_coords),
-        "line_count": line_count,
-    }
+    return BedSignals(
+        chromosomes=sorted(chromosomes),
+        has_chr_prefix=has_chr_prefix,
+        max_coordinates=dict(max_coords),
+        line_count=line_count,
+    )
 
 
 def classify_bed_file(
@@ -196,7 +197,7 @@ def classify_bed_file(
     if use_cache:
         cached = load_cached_evidence(md5sum)
         if cached and cached.get("signals"):
-            signals = cached["signals"]
+            signals = BedSignals.from_evidence(cached["signals"])
             from_cache = True
         else:
             signals = None
@@ -206,9 +207,12 @@ def classify_bed_file(
     # Fetch if not cached
     if signals is None:
         signals = fetch_bed_signals(md5sum, is_gzipped=is_gzipped, file_size=file_size)
-        if not signals:
+        if signals is None:
             return None
-        save_evidence(md5sum, file_name, {"signals": signals})
+        signals_dict = asdict(signals)
+        save_evidence(md5sum, file_name, {"signals": signals_dict})
+    else:
+        signals_dict = asdict(signals)
 
     # Classify using the unified classifier
     classifications = classify_from_bed_signals(
@@ -222,7 +226,7 @@ def classify_bed_file(
         "md5sum": md5sum,
         "file_size": file_size,
         "classifications": classifications,
-        "signals": signals,
+        "signals": signals_dict,
         "from_cache": from_cache,
     }
 

--- a/scripts/fetch_bed_headers.py
+++ b/scripts/fetch_bed_headers.py
@@ -196,7 +196,9 @@ def classify_bed_file(
     from_cache = False
     if use_cache:
         cached = load_cached_evidence(md5sum)
-        if cached and cached.get("signals"):
+        # Test key presence, not truthiness: a present-but-malformed "signals"
+        # goes through from_evidence and fails loud rather than silently refetching.
+        if cached and "signals" in cached:
             signals = BedSignals.from_evidence(cached["signals"])
             from_cache = True
         else:

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -782,7 +782,49 @@ def classify_from_fasta_header(
 _STANDARD_CHROM_PATTERN = re.compile(r"^(chr)?(\d{1,2}|X|Y|M|MT)$", re.IGNORECASE)
 
 
-def _infer_bed_reference(signals: dict) -> tuple[str | None, str]:
+@dataclass(frozen=True)
+class BedSignals:
+    """Reference-assembly signals extracted from a BED file's coordinate lines.
+
+    The three logic fields are required: a missing ``has_chr_prefix`` used to
+    default to ``True`` via ``.get``, silently asserting chr-prefixed naming and
+    flipping the GRCh37 reference call. Requiring it makes an absent signal raise
+    at the boundary instead. ``line_count`` is diagnostic only — never read for
+    classification — and is retained so ``dataclasses.asdict`` reproduces the
+    persisted evidence JSON shape unchanged.
+    """
+
+    chromosomes: list[str]
+    has_chr_prefix: bool
+    max_coordinates: dict[str, int]
+    line_count: int = 0
+
+    @classmethod
+    def from_evidence(cls, raw: dict) -> "BedSignals":
+        """Parse cached evidence JSON into typed signals (file-content boundary).
+
+        Reads required keys directly so a malformed or truncated evidence record
+        raises here rather than silently defaulting downstream.
+        """
+        return cls(
+            chromosomes=raw["chromosomes"],
+            has_chr_prefix=raw["has_chr_prefix"],
+            max_coordinates=raw["max_coordinates"],
+            line_count=raw["line_count"],
+        )
+
+    @classmethod
+    def empty(cls) -> "BedSignals":
+        """Signals for a BED file with no coordinate evidence (never fetched).
+
+        Yields filename-only classification: with empty ``max_coordinates`` the
+        coordinate block is skipped, so ``has_chr_prefix`` here is an unread
+        placeholder and is never consulted.
+        """
+        return cls(chromosomes=[], has_chr_prefix=False, max_coordinates={})
+
+
+def _infer_bed_reference(signals: BedSignals) -> tuple[str | None, str]:
     """Infer reference assembly from BED coordinate signals.
 
     Uses max coordinates to rule out references where coordinates exceed
@@ -791,13 +833,13 @@ def _infer_bed_reference(signals: dict) -> tuple[str | None, str]:
     Returns:
         Tuple of (assembly, rationale)
     """
-    max_coords = signals.get("max_coordinates", {})
-    has_chr_prefix = signals.get("has_chr_prefix", True)
+    max_coords = signals.max_coordinates
+    has_chr_prefix = signals.has_chr_prefix
 
     if not max_coords:
         return None, "No coordinates found"
 
-    standard_chroms = [c for c in signals.get("chromosomes", []) if _STANDARD_CHROM_PATTERN.match(c)]
+    standard_chroms = [c for c in signals.chromosomes if _STANDARD_CHROM_PATTERN.match(c)]
 
     if not standard_chroms:
         return None, ("Non-standard chromosome names — likely de novo assembly, not aligned to a standard reference")
@@ -843,7 +885,7 @@ def _infer_bed_reference(signals: dict) -> tuple[str | None, str]:
 
 
 def classify_from_bed_signals(
-    signals: dict,
+    signals: BedSignals,
     *,
     file_name: str | None = None,
     file_size: int | None = None,
@@ -855,7 +897,7 @@ def classify_from_bed_signals(
     coordinate-based reference detection (elimination algorithm).
 
     Args:
-        signals: Dict with keys: chromosomes, max_coordinates, has_chr_prefix
+        signals: Typed BED coordinate signals
         file_name: Filename for pattern matching
         file_size: Optional file size in bytes
         dataset_title: Optional dataset title for context rules
@@ -866,7 +908,7 @@ def classify_from_bed_signals(
     from .rule_engine import ExtendedFileInfo
 
     filename = file_name or "sample.bed"
-    max_coordinates = signals.get("max_coordinates", {})
+    max_coordinates = signals.max_coordinates
 
     file_info = ExtendedFileInfo(
         filename=filename,

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -818,8 +818,8 @@ class BedSignals:
         """Signals for a BED file with no coordinate evidence (never fetched).
 
         Yields filename-only classification: with empty ``max_coordinates`` the
-        coordinate block is skipped, so ``has_chr_prefix`` here is an unread
-        placeholder and is never consulted.
+        coordinate block that would read ``has_chr_prefix`` is skipped, so its
+        value here is an unread placeholder.
         """
         return cls(chromosomes=[], has_chr_prefix=False, max_coordinates={})
 

--- a/tests/test_bed_classification.py
+++ b/tests/test_bed_classification.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from meta_disco.header_classifier import classify_from_bed_signals
+from meta_disco.header_classifier import BedSignals, classify_from_bed_signals
 from meta_disco.models import (
     NOT_APPLICABLE,
     NOT_CLASSIFIED,
@@ -274,44 +274,46 @@ class TestBedCoordinateClassification:
 
     def test_grch38_coordinates(self):
         """GRCh38 coordinates with chr prefix should detect GRCh38."""
-        signals = {
-            "chromosomes": ["chr1", "chr2", "chr3"],
-            "has_chr_prefix": True,
+        signals = BedSignals(
+            chromosomes=["chr1", "chr2", "chr3"],
+            has_chr_prefix=True,
             # GRCh38 chr1=248956422; use a value close but under
-            "max_coordinates": {"chr1": 248956000, "chr2": 242193000},
-        }
+            max_coordinates={"chr1": 248956000, "chr2": 242193000},
+        )
         result = classify_from_bed_signals(signals, file_name="sample.regions.bed.gz")
         ref = _get_val(result, "reference_assembly")
         assert ref in ("GRCh38", "CHM13"), f"Expected GRCh38 or CHM13, got {ref}"
 
     def test_no_chr_prefix_grch37(self):
         """No chr prefix on standard chroms -> GRCh37."""
-        signals = {
-            "chromosomes": ["1", "2", "3"],
-            "has_chr_prefix": False,
-            "max_coordinates": {"1": 200000000},
-        }
+        signals = BedSignals(
+            chromosomes=["1", "2", "3"],
+            has_chr_prefix=False,
+            max_coordinates={"1": 200000000},
+        )
         result = classify_from_bed_signals(signals, file_name="sample.bed")
         assert _get_val(result, "reference_assembly") == "GRCh37"
 
     def test_nonstandard_chroms_not_applicable(self):
         """Non-standard chromosome names -> reference is not_applicable."""
-        signals = {
-            "chromosomes": ["HG01106#1#JAHAMC010000001.1", "HG01106#1#JAHAMC010000002.1"],
-            "has_chr_prefix": False,
-            "max_coordinates": {"HG01106#1#JAHAMC010000001.1": 92310948},
-        }
+        signals = BedSignals(
+            chromosomes=["HG01106#1#JAHAMC010000001.1", "HG01106#1#JAHAMC010000002.1"],
+            has_chr_prefix=False,
+            max_coordinates={"HG01106#1#JAHAMC010000001.1": 92310948},
+        )
         result = classify_from_bed_signals(signals, file_name="sample.bed")
         assert field_status(result, "reference_assembly") == NOT_APPLICABLE
 
     def test_empty_signals_preserves_filename_classification(self):
         """Empty signals still returns rule engine classification from filename."""
-        result = classify_from_bed_signals({}, file_name="sample.modbam2bed.cpg.bed")
+        signals = BedSignals.empty()
+        result = classify_from_bed_signals(signals, file_name="sample.modbam2bed.cpg.bed")
         assert _get_val(result, "data_modality") == "epigenomic.methylation"
 
     def test_empty_signals_no_reference(self):
         """Empty signals should leave reference as not_classified."""
-        result = classify_from_bed_signals({}, file_name="sample.bed")
+        signals = BedSignals.empty()
+        result = classify_from_bed_signals(signals, file_name="sample.bed")
         assert field_status(result, "reference_assembly") == NOT_CLASSIFIED
 
     def test_coordinates_exceeding_grch38_rule_it_out(self):
@@ -319,21 +321,46 @@ class TestBedCoordinateClassification:
         # CHM13 chr8=146259331, GRCh38 chr8=145138636, GRCh37 chr8=146364022
         # A coordinate of 145500000 exceeds GRCh38 but not CHM13 or GRCh37
         # chr prefix rules out GRCh37
-        signals = {
-            "chromosomes": ["chr8"],
-            "has_chr_prefix": True,
-            "max_coordinates": {"chr8": 145500000},
-        }
+        signals = BedSignals(
+            chromosomes=["chr8"],
+            has_chr_prefix=True,
+            max_coordinates={"chr8": 145500000},
+        )
         result = classify_from_bed_signals(signals, file_name="sample.bed")
         ref = _get_val(result, "reference_assembly")
         assert ref != "GRCh38", f"GRCh38 should be ruled out, got {ref}"
 
     def test_no_coordinates_no_crash(self):
         """Signals with empty max_coordinates should not crash."""
-        signals = {
-            "chromosomes": ["chr1"],
-            "has_chr_prefix": True,
-            "max_coordinates": {},
-        }
+        signals = BedSignals(
+            chromosomes=["chr1"],
+            has_chr_prefix=True,
+            max_coordinates={},
+        )
         result = classify_from_bed_signals(signals, file_name="sample.bed")
         assert field_status(result, "reference_assembly") == NOT_CLASSIFIED
+
+
+class TestBedSignalsFromEvidence:
+    """Test the cached-evidence boundary parse."""
+
+    def test_parses_full_evidence(self):
+        raw = {
+            "chromosomes": ["chr1"],
+            "has_chr_prefix": True,
+            "max_coordinates": {"chr1": 248956000},
+            "line_count": 3,
+        }
+        assert BedSignals.from_evidence(raw) == BedSignals(
+            chromosomes=["chr1"],
+            has_chr_prefix=True,
+            max_coordinates={"chr1": 248956000},
+            line_count=3,
+        )
+
+    def test_missing_has_chr_prefix_raises(self):
+        # The #211 hazard: a missing has_chr_prefix used to default to True and
+        # flip the reference call. It must now raise at the boundary instead.
+        raw = {"chromosomes": ["1"], "max_coordinates": {"1": 200000000}, "line_count": 1}
+        with pytest.raises(KeyError):
+            BedSignals.from_evidence(raw)


### PR DESCRIPTION
Closes #211. Last item in Lane 3 of epic #203 (parse-don't-validate sweep).

## What changed
- New `BedSignals` frozen dataclass in `header_classifier.py` — three **required** logic fields (`chromosomes`, `has_chr_prefix`, `max_coordinates`) plus a defaulted diagnostic `line_count`.
  - `from_evidence(raw)` parses cached JSON evidence at the file-content boundary, reading required keys so a malformed/truncated record raises here instead of defaulting downstream.
  - `empty()` names the "no coordinate evidence" state (filename-only classification).
- Read sites (`_infer_bed_reference`, `classify_from_bed_signals`) use typed attributes — **every `.get(..., default)` removed**.
- `extract_bed_signals` returns `BedSignals`; the cached-hit path parses via `from_evidence`; both serialization points use `dataclasses.asdict`.
- `classify_bed_files.py` no-evidence case constructs `BedSignals.empty()` instead of `{}`.
- Tests migrated to `BedSignals(...)`; the two `{}` cases now state `has_chr_prefix` explicitly (the regression guard); new `TestBedSignalsFromEvidence` covers the boundary raise.

## Why
`_infer_bed_reference` read `signals.get("has_chr_prefix", True)` — a **missing/misspelled key silently asserted chr-prefixed naming and flipped the GRCh37 reference call** (`if not has_chr_prefix: return "GRCh37"`). Every access was a silently-defaulting `.get`. Typing the record makes an absent signal a loud failure at the boundary rather than a silent wrong answer, consistent with CLAUDE.md's "validate at trust boundaries" philosophy.

## Assumptions I made
- **`line_count` kept as a field.** The producer `extract_bed_signals` emits a 4th key `line_count`, persisted into both the cached evidence JSON and the output `"signals"` echo but never read for classification. The issue's design comment listed only 3 fields yet also promised "evidence JSON shape preserved via `asdict`" — a contradiction. I kept `line_count` so `asdict` reproduces the persisted shape byte-for-byte (the epic's standing output-unchanged invariant). Confirmed with Dave at the plan gate.
- **No-evidence case is a real value, not `None`.** Declined a review suggestion to make the signature `BedSignals | None`; CLAUDE.md forbids internal null-checks, and `empty()` models "no coordinate data" as a real state whose placeholder `has_chr_prefix` is provably never read (guarded by `if max_coordinates:`).
- **Existing caches load fine.** All 11,368 on-disk `data/evidence/anvil/bed/*.json` records already carry `line_count`, so `from_evidence`'s required-key parse does not break resume (verified during review).
- **BED stays out of `CachedEvidence` for now.** `BedSignals` is colocated with its consumers rather than folded into `evidence.py`'s `CachedEvidence` family; filed as follow-up #223.

## How to verify
DoD checklist from #211:
- [ ] **`BedSignals` + `from_evidence` boundary parse** — read `header_classifier.py`; run `uv run pytest tests/test_bed_classification.py::TestBedSignalsFromEvidence -v` — `test_missing_has_chr_prefix_raises` proves a missing key raises `KeyError` instead of defaulting.
- [ ] **producer returns it; cached load parses through it; `asdict` serialization** — read `scripts/fetch_bed_headers.py`: `extract_bed_signals -> BedSignals`, cached hit → `BedSignals.from_evidence(cached["signals"])`, save/return via `asdict`. Confirm on-disk evidence JSON keys unchanged: `python -c "import json,glob; f=glob.glob('data/evidence/anvil/bed/**/*.json',recursive=True)[0]; print(list(json.load(open(f))['signals']))"` → `['chromosomes','has_chr_prefix','max_coordinates','line_count']`.
- [ ] **readers use typed attrs, no `.get` defaults; silent `has_chr_prefix=True` gone** — `grep -n "signals.get(" src/meta_disco/header_classifier.py` returns nothing.
- [ ] **tests migrated (incl. `{}` cases); `make test-all` green** — run `make test-all` (693 root + 10 schema pass) and `make lint-all` (pyright 0 errors).