### PR TITLE
Type the evaluate_claims resolution record as ClaimResolution (#212)

### DIFF
--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -237,8 +237,8 @@ class ResolutionReason(str, Enum):
 class ClaimResolution:
     """The resolved outcome of ``evaluate_claims`` for one classification field.
 
-    ``competing_values`` is set only for a conflict; ``is_conflict`` derives from
-    it, so the two can never disagree.
+    ``competing_values`` is non-None only for a conflict (``None`` otherwise);
+    ``is_conflict`` derives from it, so the two can never disagree.
     """
 
     value: str | None
@@ -289,7 +289,7 @@ def evaluate_claims(claims: list[dict]) -> ClaimResolution:
 
     Returns:
         ClaimResolution with: value (real or None), status, reason, is_conflict,
-        competing_values (present iff conflict).
+        competing_values (non-None iff conflict).
     """
     # Drop the synthetic not_classified placeholder and empty claims, but keep
     # rule-authored not_classified declarations (e.g., fastq_modality_unknown).

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -227,6 +227,11 @@ class ResolutionReason(str, Enum):
     NOT_APPLICABLE_TERMINAL = "not_applicable_terminal"
     CONFLICT = "conflict"
 
+    def __str__(self) -> str:
+        # Render as the underlying value ("no_claims"), not "ResolutionReason.NO_CLAIMS",
+        # so str()/f-string formatting stays wire-compatible across Python versions.
+        return self.value
+
 
 @dataclass(frozen=True)
 class ClaimResolution:

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -2,6 +2,7 @@
 
 import re
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -215,23 +216,54 @@ def _claim_declaration(claim: dict) -> str | None:
     return value if value is not None else claim.get("status")
 
 
-def _resolved(declaration: str | None, reason: str, is_conflict: bool = False, competing: list | None = None) -> dict:
-    """Package a winning declaration as ``{value, status, ...}``: a real declaration
+class ResolutionReason(str, Enum):
+    """Why ``evaluate_claims`` reached its result. ``str``-backed so the value is
+    wire-compatible with the pre-#212 magic strings (e.g. ``"no_claims"``)."""
+
+    NO_CLAIMS = "no_claims"
+    SINGLE_CLAIM = "single_claim"
+    UNANIMOUS = "unanimous"
+    HIGHER_SPECIFICITY_OVERRIDE = "higher_specificity_override"
+    NOT_APPLICABLE_TERMINAL = "not_applicable_terminal"
+    CONFLICT = "conflict"
+
+
+@dataclass(frozen=True)
+class ClaimResolution:
+    """The resolved outcome of ``evaluate_claims`` for one classification field.
+
+    ``competing_values`` is set only for a conflict; ``is_conflict`` derives from
+    it, so the two can never disagree.
+    """
+
+    value: str | None
+    status: str
+    reason: ResolutionReason
+    competing_values: list[str] | None = None
+
+    @property
+    def is_conflict(self) -> bool:
+        return self.competing_values is not None
+
+
+def _resolved(
+    declaration: str | None,
+    reason: ResolutionReason,
+    competing: list[str] | None = None,
+) -> ClaimResolution:
+    """Package a winning declaration as a ``ClaimResolution``: a real declaration
     becomes value with status CLASSIFIED; a status declaration becomes that status
     with value None — so a sentinel never lands in ``value``."""
     status = status_for_value(declaration)
-    out = {
-        "value": declaration if status == CLASSIFIED else None,
-        "status": status,
-        "reason": reason,
-        "is_conflict": is_conflict,
-    }
-    if competing is not None:
-        out["competing_values"] = competing
-    return out
+    return ClaimResolution(
+        value=declaration if status == CLASSIFIED else None,
+        status=status,
+        reason=reason,
+        competing_values=competing,
+    )
 
 
-def evaluate_claims(claims: list[dict]) -> dict:
+def evaluate_claims(claims: list[dict]) -> ClaimResolution:
     """Evaluate competing claims for a single classification field.
 
     Each claim *declares* either a real value or a status (not_applicable /
@@ -251,8 +283,8 @@ def evaluate_claims(claims: list[dict]) -> dict:
                 optionally ``tier`` / ``rule_id`` / ``reason``.
 
     Returns:
-        Dict with: value (real or None), status, reason, is_conflict,
-        competing_values (if conflict).
+        ClaimResolution with: value (real or None), status, reason, is_conflict,
+        competing_values (present iff conflict).
     """
     # Drop the synthetic not_classified placeholder and empty claims, but keep
     # rule-authored not_classified declarations (e.g., fastq_modality_unknown).
@@ -263,19 +295,25 @@ def evaluate_claims(claims: list[dict]) -> dict:
     assertive_claims = [c for c in real_claims if _claim_declaration(c) != NOT_CLASSIFIED]
 
     if not real_claims:
-        return _resolved(NOT_CLASSIFIED, "no_claims")
+        return _resolved(NOT_CLASSIFIED, ResolutionReason.NO_CLAIMS)
 
     # Only not_classified declarations present → resolve as not_classified
     # (the rule's rationale is preserved in field_evidence, not in this return value)
     if not assertive_claims:
-        return _resolved(NOT_CLASSIFIED, "single_claim" if len(real_claims) == 1 else "unanimous")
+        return _resolved(
+            NOT_CLASSIFIED,
+            ResolutionReason.SINGLE_CLAIM if len(real_claims) == 1 else ResolutionReason.UNANIMOUS,
+        )
 
     # Check if all assertive declarations agree
     declarations = {_claim_declaration(c) for c in assertive_claims}
 
     if len(declarations) == 1:
         # Unanimous — every assertive claim declares the same value
-        return _resolved(next(iter(declarations)), "unanimous" if len(assertive_claims) > 1 else "single_claim")
+        return _resolved(
+            next(iter(declarations)),
+            ResolutionReason.UNANIMOUS if len(assertive_claims) > 1 else ResolutionReason.SINGLE_CLAIM,
+        )
 
     # Assertive declarations disagree — check tiers
     max_tier = max(c.get("tier", 0) for c in assertive_claims)
@@ -288,14 +326,14 @@ def evaluate_claims(claims: list[dict]) -> dict:
     # at the same tier without triggering a conflict (e.g., text_stats
     # setting not_applicable shouldn't conflict with filename_ref patterns)
     if NOT_APPLICABLE in top_tier_decls:
-        return _resolved(NOT_APPLICABLE, "not_applicable_terminal")
+        return _resolved(NOT_APPLICABLE, ResolutionReason.NOT_APPLICABLE_TERMINAL)
 
     if len(top_tier_decls) == 1:
         # Highest tier is unanimous — override lower tiers
-        return _resolved(top_tier_decls.pop(), "higher_specificity_override")
+        return _resolved(top_tier_decls.pop(), ResolutionReason.HIGHER_SPECIFICITY_OVERRIDE)
 
     # Same tier, different values — conflict
-    return _resolved(NOT_CLASSIFIED, "conflict", is_conflict=True, competing=sorted(top_tier_decls))
+    return _resolved(NOT_CLASSIFIED, ResolutionReason.CONFLICT, competing=sorted(top_tier_decls))
 
 
 class RuleEngine:
@@ -386,19 +424,19 @@ class RuleEngine:
         for fld in result._CLASSIFICATION_FIELDS:
             claims = result.field_evidence.get(fld, [])
             evaluation = evaluate_claims(claims)
-            result.set_field(fld, evaluation["value"], evaluation["status"])
+            result.set_field(fld, evaluation.value, evaluation.status)
 
-            if evaluation["is_conflict"]:
+            if evaluation.is_conflict:
                 result.field_evidence[fld].append(
                     {
                         "rule_id": f"conflicting_{fld}_rules",
-                        "reason": (f"Conflicting {fld}: {evaluation['competing_values']} — ambiguous"),
+                        "reason": (f"Conflicting {fld}: {evaluation.competing_values} — ambiguous"),
                         "status": NOT_CLASSIFIED,
-                        "competing_values": evaluation["competing_values"],
+                        "competing_values": evaluation.competing_values,
                         "is_conflict": True,
                     }
                 )
-            elif evaluation["reason"] == "no_claims":
+            elif evaluation.reason == ResolutionReason.NO_CLAIMS:
                 result.field_evidence[fld].append(
                     {
                         "rule_id": "not_classified",

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -507,7 +507,7 @@ class TestRgfaContentClassification:
         content = next(c for c in claims if c["rule_id"] == "rgfa_stable_rank_reference")
         assert content["tier"] == 3
         # Resolving the claim list independently must reach the same value.
-        assert evaluate_claims(claims)["value"] == "pangenome.reference"
+        assert evaluate_claims(claims).value == "pangenome.reference"
 
     def test_nonzero_rank_only_stays_pangenome(self):
         """Non-reference haplotype segments (rank >= 1) do not make a reference graph."""

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -13,6 +13,7 @@ from meta_disco.models import (
 from meta_disco.rule_engine import (
     ExtendedClassificationResult,
     ExtendedFileInfo,
+    ResolutionReason,
     RuleEngine,
     evaluate_claims,
 )
@@ -421,10 +422,10 @@ class TestEvaluateClaims:
     def test_no_claims(self):
         """No claims → not_classified (status), no value."""
         result = evaluate_claims([])
-        assert result["status"] == NOT_CLASSIFIED
-        assert result["value"] is None
-        assert result["is_conflict"] is False
-        assert result["reason"] == "no_claims"
+        assert result.status == NOT_CLASSIFIED
+        assert result.value is None
+        assert result.is_conflict is False
+        assert result.reason == ResolutionReason.NO_CLAIMS
 
     def test_single_claim(self):
         """Single claim → use it."""
@@ -433,9 +434,9 @@ class TestEvaluateClaims:
                 {"rule_id": "r1", "value": "genomic", "tier": 2},
             ]
         )
-        assert result["value"] == "genomic"
-        assert result["reason"] == "single_claim"
-        assert result["is_conflict"] is False
+        assert result.value == "genomic"
+        assert result.reason == ResolutionReason.SINGLE_CLAIM
+        assert result.is_conflict is False
 
     def test_two_claims_agree(self):
         """Two claims with same value → unanimous."""
@@ -445,8 +446,8 @@ class TestEvaluateClaims:
                 {"rule_id": "r2", "value": "genomic", "tier": 3},
             ]
         )
-        assert result["value"] == "genomic"
-        assert result["reason"] == "unanimous"
+        assert result.value == "genomic"
+        assert result.reason == ResolutionReason.UNANIMOUS
 
     def test_disagree_different_tiers(self):
         """Higher tier wins when claims disagree."""
@@ -456,9 +457,9 @@ class TestEvaluateClaims:
                 {"rule_id": "r2", "value": "assembly", "tier": 2},
             ]
         )
-        assert result["value"] == "assembly"
-        assert result["reason"] == "higher_specificity_override"
-        assert result["is_conflict"] is False
+        assert result.value == "assembly"
+        assert result.reason == ResolutionReason.HIGHER_SPECIFICITY_OVERRIDE
+        assert result.is_conflict is False
 
     def test_disagree_same_tier(self):
         """Same tier, different values → conflict (not_classified status, no value)."""
@@ -468,11 +469,12 @@ class TestEvaluateClaims:
                 {"rule_id": "r2", "value": "CHM13", "tier": 2},
             ]
         )
-        assert result["status"] == NOT_CLASSIFIED
-        assert result["value"] is None
-        assert result["is_conflict"] is True
-        assert result["reason"] == "conflict"
-        assert set(result["competing_values"]) == {"GRCh38", "CHM13"}
+        assert result.status == NOT_CLASSIFIED
+        assert result.value is None
+        assert result.is_conflict is True
+        assert result.reason == ResolutionReason.CONFLICT
+        assert result.competing_values is not None
+        assert set(result.competing_values) == {"GRCh38", "CHM13"}
 
     def test_three_claims_conflict_at_top_tier(self):
         """Lower tier agrees but top tier has conflict → conflict wins."""
@@ -483,9 +485,9 @@ class TestEvaluateClaims:
                 {"rule_id": "r3", "value": "transcriptomic.bulk", "tier": 3},
             ]
         )
-        assert result["status"] == NOT_CLASSIFIED
-        assert result["value"] is None
-        assert result["is_conflict"] is True
+        assert result.status == NOT_CLASSIFIED
+        assert result.value is None
+        assert result.is_conflict is True
 
     def test_not_classified_claims_ignored(self):
         """Claims declaring not_classified (status) don't assert a value."""
@@ -495,8 +497,8 @@ class TestEvaluateClaims:
                 {"rule_id": "r2", "value": "genomic", "tier": 2},
             ]
         )
-        assert result["value"] == "genomic"
-        assert result["reason"] == "single_claim"
+        assert result.value == "genomic"
+        assert result.reason == ResolutionReason.SINGLE_CLAIM
 
     def test_not_applicable_status_declaration(self):
         """A not_applicable status claim resolves to status not_applicable, value None."""
@@ -505,9 +507,9 @@ class TestEvaluateClaims:
                 {"rule_id": "r1", "status": NOT_APPLICABLE, "tier": 1},
             ]
         )
-        assert result["status"] == NOT_APPLICABLE
-        assert result["value"] is None
-        assert result["reason"] == "single_claim"
+        assert result.status == NOT_APPLICABLE
+        assert result.value is None
+        assert result.reason == ResolutionReason.SINGLE_CLAIM
 
     def test_not_applicable_wins_over_real_value_same_tier(self):
         """NOT_APPLICABLE is a terminal declaration — wins without conflict."""
@@ -517,10 +519,10 @@ class TestEvaluateClaims:
                 {"rule_id": "r2", "value": "genomic", "tier": 1},
             ]
         )
-        assert result["status"] == NOT_APPLICABLE
-        assert result["value"] is None
-        assert result["is_conflict"] is False
-        assert result["reason"] == "not_applicable_terminal"
+        assert result.status == NOT_APPLICABLE
+        assert result.value is None
+        assert result.is_conflict is False
+        assert result.reason == ResolutionReason.NOT_APPLICABLE_TERMINAL
 
     def test_rule_authored_not_classified_is_not_no_claims(self):
         """A rule that intentionally declares not_classified is a real claim, not no_claims."""
@@ -534,11 +536,11 @@ class TestEvaluateClaims:
                 },
             ]
         )
-        assert result["status"] == NOT_CLASSIFIED
-        assert result["value"] is None
-        assert result["reason"] == "single_claim"
+        assert result.status == NOT_CLASSIFIED
+        assert result.value is None
+        assert result.reason == ResolutionReason.SINGLE_CLAIM
         # The claim should NOT be treated as "no_claims"
-        assert result["reason"] != "no_claims"
+        assert result.reason != ResolutionReason.NO_CLAIMS
 
     def test_rule_authored_not_classified_does_not_conflict_with_real(self):
         """A rule's not_classified declaration shouldn't conflict with a real value claim."""
@@ -548,8 +550,8 @@ class TestEvaluateClaims:
                 {"rule_id": "some_rule", "value": "genomic", "tier": 3},
             ]
         )
-        assert result["value"] == "genomic"
-        assert result["is_conflict"] is False
+        assert result.value == "genomic"
+        assert result.is_conflict is False
 
     def test_rule_authored_not_classified_in_evidence(self, engine):
         """fastq_modality_unknown rationale should appear in evidence, not generic placeholder."""

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -553,6 +553,11 @@ class TestEvaluateClaims:
         assert result.value == "genomic"
         assert result.is_conflict is False
 
+    def test_reason_formats_as_wire_value(self):
+        """str()/f-string render the underlying value, not the Enum repr."""
+        assert str(ResolutionReason.NO_CLAIMS) == "no_claims"
+        assert f"{ResolutionReason.CONFLICT}" == "conflict"
+
     def test_rule_authored_not_classified_in_evidence(self, engine):
         """fastq_modality_unknown rationale should appear in evidence, not generic placeholder."""
         result = engine.classify_extended(FileInfo(filename="sample_R1.fastq.gz"), include_tier3=True)


### PR DESCRIPTION
Closes #212. First item in Lane 4 of epic #203 (parse-don't-validate sweep); hands #150 a typed resolution contract to build `add_claim` on.

## What changed
- New `ResolutionReason(str, Enum)` in `rule_engine.py` (6 members) replacing the `"no_claims"`-style magic strings that coupled producer and consumers with no shared definition. `str`-backed, so the value stays wire-compatible.
- New `ClaimResolution` frozen dataclass (`value`, `status`, `reason`, `competing_values`). `is_conflict` is a **computed `@property`** (`competing_values is not None`) — so the "conflict" flag and the competing list can never disagree.
- `_resolved(...) -> ClaimResolution`; `evaluate_claims(claims: list[dict]) -> ClaimResolution`; its 6 call sites pass `ResolutionReason.*`.
- `_finalize_result` reads typed attributes and compares `reason == ResolutionReason.NO_CLAIMS`.
- Tests (`test_rule_engine.py::TestEvaluateClaims`, `test_evals.py`) migrated index→attribute; reason assertions use enum members.

## Why
The resolution record had two hazards: `reason` was a magic-string enum (`"no_claims"`) with no shared definition, and `competing_values` was present *only* on conflict, so every reader had to know out-of-band that it's gated by `is_conflict`. Typing the record removes the magic string and, by deriving `is_conflict` from `competing_values`, makes the inconsistent state unrepresentable rather than merely validated — epic #203's "parse, don't validate" goal.

## Assumptions I made
- **`evaluate_claims` input stays `list[dict]`.** Typing the *Claim* it consumes is a separate issue (#150); this PR types only the record it *produces*, giving #150 a clean output contract. `_claim_declaration` remains the one dict adapter.
- **`is_conflict` is a derived property, not a stored field.** The build plan originally proposed a stored `is_conflict` field plus a `__post_init__` gate to keep it in sync with `competing_values`. Local review flagged that as redundant state guarding an invariant a derived value makes unrepresentable; deriving it deletes the field, the constructor param, and the whole gate at zero cost to callers (a property returning `bool` satisfies every reader and the `is True`/`is False` identity asserts). More aligned with #203; chosen during review.
- **`competing_values` stays a `list`, not a tuple.** It's rendered into conflict evidence text (`f"Conflicting {fld}: {competing_values} — ambiguous"`) that lands in output; a tuple would change the rendered string. Output is byte-identical.
- **`status` stays a bare `str`.** It holds the `CLASSIFIED`/`NOT_APPLICABLE`/`NOT_CLASSIFIED` constants from `models.py`, woven through the whole status layer; enum-ifying it would be a cross-cutting change outside this issue's scope.
- **Types live in `rule_engine.py`**, colocated with their sole producer/consumer, not `models.py`. `#154` (fact model) may relocate them.

## How to verify
DoD checklist from #212:
- [ ] **`ResolutionReason` + `ClaimResolution`** — read `rule_engine.py`; `ClaimResolution` has no `is_conflict` field, only the `@property`.
- [ ] **`_resolved` returns it; `evaluate_claims` annotated; 6 calls use enum** — `grep -n "ResolutionReason\." src/meta_disco/rule_engine.py` shows 6 call sites; `grep -n '"no_claims"\|"unanimous"\|"conflict"' src/meta_disco/rule_engine.py` returns only the enum definitions, not call sites.
- [ ] **`_finalize_result` + tests attribute-access** — `grep -n 'evaluation\[' src/meta_disco/rule_engine.py` and `grep -n 'result\["' tests/test_rule_engine.py` both return nothing.
- [ ] **pyright clean @3.10; golden byte-identical; `make test-all` green** — run `make lint-all` (pyright 0 errors) and `make test-all` (703 tests pass). Conflict-output byte-identity is covered by `test_disagree_same_tier` / the `TestConflict*` assertions, which pass unchanged.