### PR TITLE
Add ExtendedClassificationResult.add_claim + shared _make_claim (#150)

### DIFF
--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -533,26 +533,22 @@ def classify_from_gfa_segment_tags(
         contigs = sorted({t.sn for t in rank0 if t.sn})
         preview = ", ".join(contigs[:3])
         phrase = "segment carries" if len(rank0) == 1 else "segments carry"
-        # Appended as a tier-3 claim, not assigned over the list, so the tier-1
-        # `pangenome_graph` claim survives and the derivation chain reads the same
-        # as the engine-resolved `-mc-` case. The tier matters: evaluate_claims
-        # defaults a missing tier to 0, which would lose to the tier-1 `pangenome`
-        # claim and undo this refinement once #150 resolves this path from claims.
-        result.field_evidence["data_type"].append(
-            {
-                "rule_id": "rgfa_stable_rank_reference",
-                "tier": 3,
-                "reason": (
-                    f"{len(rank0)} rGFA {phrase} stable rank 0 "
-                    f"(SR:i:0) on {preview} — graph defines a reference "
-                    f"coordinate system"
-                ),
-                "value": "pangenome.reference",
-            }
+        # Appended as a tier-3 claim (not assigned over the list) so the engine's
+        # tier-1 `pangenome_graph` claim survives and the derivation chain reads the
+        # same as the engine-resolved `-mc-` case; add_claim re-resolves from the
+        # full list so the refinement wins on its own. (See add_claim / _make_claim
+        # for the derive-from-claims and required-tier invariants.)
+        result.add_claim(
+            "data_type",
+            rule_id="rgfa_stable_rank_reference",
+            tier=3,
+            reason=(
+                f"{len(rank0)} rGFA {phrase} stable rank 0 "
+                f"(SR:i:0) on {preview} — graph defines a reference "
+                f"coordinate system"
+            ),
+            value="pangenome.reference",
         )
-        # Still set imperatively rather than resolved from the claims above;
-        # conflict detection for data_type is bypassed here (see #150).
-        result.set_field("data_type", "pangenome.reference")
 
     return result.to_output_dict()
 

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -83,7 +83,7 @@ def _make_claim(
     the silent default that let the #151 rGFA near-miss resolve to the wrong
     value). Shared construction site for ``_apply_rule`` and
     ``ExtendedClassificationResult.add_claim`` (other producers still hand-build
-    claims until they migrate to ``add_claim`` — see #150).
+    claims until they migrate to ``add_claim`` — see #227).
 
     A ``status`` claim declares a non-classified sentinel only
     (``not_applicable`` / ``not_classified`` — the authorable statuses, never
@@ -179,7 +179,7 @@ class ExtendedClassificationResult:
         stays correct, but this method neither removes that stale marker nor
         appends a fresh one — it only re-sets the field. Cleaning up prior markers
         and emitting them on incremental adds is a follow-up (the ``rule_engine``
-        placeholder-filter revisit under #150).
+        placeholder-filter revisit under #228).
         """
         self._require_field(fld)
         claim = _make_claim(rule_id=rule_id, reason=reason, tier=tier, value=value, status=status)

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -84,11 +84,22 @@ def _make_claim(
     value). Shared construction site for ``_apply_rule`` and
     ``ExtendedClassificationResult.add_claim`` (other producers still hand-build
     claims until they migrate to ``add_claim`` — see #150).
+
+    A ``status`` claim declares a non-classified sentinel only
+    (``not_applicable`` / ``not_classified`` — the authorable statuses, never
+    ``classified``, which is expressed as a ``value`` claim). An unknown status
+    raises here; otherwise ``evaluate_claims`` would read the stray string as a
+    real value and resolve the field CLASSIFIED to it — a silent wrong answer.
     """
     if (value is None) == (status is None):
         raise ValueError(
             f"claim for rule {rule_id!r} must declare exactly one of value/status "
             f"(got value={value!r}, status={status!r})"
+        )
+    if status is not None and status not in (NOT_APPLICABLE, NOT_CLASSIFIED):
+        raise ValueError(
+            f"claim for rule {rule_id!r} has unknown status {status!r} "
+            f"(expected {NOT_APPLICABLE!r} or {NOT_CLASSIFIED!r})"
         )
     claim = {"rule_id": rule_id, "reason": reason, "tier": tier}
     if value is not None:

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -65,6 +65,39 @@ class ExtendedFileInfo:
         )
 
 
+def _make_claim(
+    *,
+    rule_id: str,
+    reason: str,
+    tier: int,
+    value: str | None = None,
+    status: str | None = None,
+) -> dict:
+    """Construct one claim dict for ``field_evidence``, enforcing value-xor-status.
+
+    A claim declares exactly one of a real ``value`` or a ``status`` (the same
+    invariant ``rule_loader`` enforces for a rule's ``then`` vs ``then.status`` —
+    epic #116 / #136); declaring both or neither raises rather than silently
+    picking one. ``tier`` is a required keyword so a claim can never reach
+    ``evaluate_claims`` without one and fall back to its tier-0 default (#150 —
+    the silent default that let the #151 rGFA near-miss resolve to the wrong
+    value). Shared construction site for ``_apply_rule`` and
+    ``ExtendedClassificationResult.add_claim`` (other producers still hand-build
+    claims until they migrate to ``add_claim`` — see #150).
+    """
+    if (value is None) == (status is None):
+        raise ValueError(
+            f"claim for rule {rule_id!r} must declare exactly one of value/status "
+            f"(got value={value!r}, status={status!r})"
+        )
+    claim = {"rule_id": rule_id, "reason": reason, "tier": tier}
+    if value is not None:
+        claim["value"] = value
+    else:
+        claim["status"] = status
+    return claim
+
+
 @dataclass
 class ExtendedClassificationResult:
     """Extended classification result with additional fields.
@@ -108,6 +141,40 @@ class ExtendedClassificationResult:
         _assert_coherent(value, status)  # single coherence definition (models)
         setattr(self, fld, value if status == CLASSIFIED else None)
         self.field_status[fld] = status
+
+    def add_claim(
+        self,
+        fld: str,
+        *,
+        rule_id: str,
+        reason: str,
+        tier: int,
+        value: str | None = None,
+        status: str | None = None,
+    ) -> None:
+        """Append a claim to a field and re-resolve the field's value from all its claims.
+
+        The claim is built through ``_make_claim`` (value-xor-status, required
+        ``tier``), appended to ``field_evidence[fld]``, and the field is then set
+        from ``evaluate_claims`` over the full list — so the field's value is
+        *derived* from its claims, never written alongside them (#150). A
+        same-tier disagreement therefore resolves to ``not_classified`` here,
+        rather than the last writer silently winning.
+
+        Callers use this *after* ``classify_extended`` has run, so
+        ``_finalize_result`` may already have appended a synthetic
+        ``not_classified`` / conflict marker to the list. ``evaluate_claims``
+        ignores the ``"not_classified"`` placeholder when resolving, so the value
+        stays correct, but this method neither removes that stale marker nor
+        appends a fresh one — it only re-sets the field. Cleaning up prior markers
+        and emitting them on incremental adds is a follow-up (the ``rule_engine``
+        placeholder-filter revisit under #150).
+        """
+        self._require_field(fld)
+        claim = _make_claim(rule_id=rule_id, reason=reason, tier=tier, value=value, status=status)
+        self.field_evidence[fld].append(claim)
+        evaluation = evaluate_claims(self.field_evidence[fld])
+        self.set_field(fld, evaluation.value, evaluation.status)
 
     def _require_field(self, fld: str) -> None:
         """Raise ValueError for an unknown classification field, so every accessor
@@ -616,18 +683,18 @@ class RuleEngine:
         """
         then = rule.then
         then_status = rule.then_status
-        evidence_entry = {
-            "rule_id": rule.id,
-            "reason": rule.rationale or "",
-            "tier": rule.tier,
-        }
+        reason = rule.rationale or ""
         for fld in result._CLASSIFICATION_FIELDS:
             value = then.get(fld)
             status = then_status.get(fld) if then_status else None
             if value is not None:
-                result.field_evidence[fld].append({**evidence_entry, "value": value})
+                result.field_evidence[fld].append(
+                    _make_claim(rule_id=rule.id, reason=reason, tier=rule.tier, value=value)
+                )
             elif status is not None:
-                result.field_evidence[fld].append({**evidence_entry, "status": status})
+                result.field_evidence[fld].append(
+                    _make_claim(rule_id=rule.id, reason=reason, tier=rule.tier, status=status)
+                )
 
     def infer_assay_type(self, result: ExtendedClassificationResult, file_info: ExtendedFileInfo) -> None:
         """Infer assay type from other classification signals.

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -217,6 +217,16 @@ class TestMakeClaim:
         with pytest.raises(TypeError):
             _make_claim(rule_id="r", reason="x", value="genomic")  # type: ignore[call-arg]
 
+    def test_rejects_unknown_status(self):
+        # A status claim declares a non-classified sentinel only; a typo would
+        # otherwise be read as a real value and resolve the field CLASSIFIED to it.
+        with pytest.raises(ValueError, match="unknown status"):
+            _make_claim(rule_id="r", reason="x", tier=1, status="not_classifed")  # typo
+
+    def test_rejects_classified_as_status(self):
+        with pytest.raises(ValueError, match="unknown status"):
+            _make_claim(rule_id="r", reason="x", tier=1, status=CLASSIFIED)
+
 
 class TestAddClaim:
     """add_claim's own wiring: append accumulates, then the field re-derives from

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -15,6 +15,7 @@ from meta_disco.rule_engine import (
     ExtendedFileInfo,
     ResolutionReason,
     RuleEngine,
+    _make_claim,
     evaluate_claims,
 )
 
@@ -189,6 +190,65 @@ class TestSetFieldValidation:
         result = ExtendedClassificationResult()
         with pytest.raises(ValueError, match="unknown classification field"):
             getattr(result, accessor)("platfrom")
+
+
+class TestMakeClaim:
+    """_make_claim enforces value-xor-status and a required tier."""
+
+    def test_value_claim_shape(self):
+        claim = _make_claim(rule_id="r", reason="because", tier=2, value="genomic")
+        assert claim == {"rule_id": "r", "reason": "because", "tier": 2, "value": "genomic"}
+        assert "status" not in claim
+
+    def test_status_claim_shape(self):
+        claim = _make_claim(rule_id="r", reason="n/a", tier=1, status=NOT_APPLICABLE)
+        assert claim == {"rule_id": "r", "reason": "n/a", "tier": 1, "status": NOT_APPLICABLE}
+        assert "value" not in claim
+
+    def test_rejects_both_value_and_status(self):
+        with pytest.raises(ValueError, match="exactly one of value/status"):
+            _make_claim(rule_id="r", reason="x", tier=1, value="genomic", status=NOT_APPLICABLE)
+
+    def test_rejects_neither_value_nor_status(self):
+        with pytest.raises(ValueError, match="exactly one of value/status"):
+            _make_claim(rule_id="r", reason="x", tier=1)
+
+    def test_tier_is_required(self):
+        with pytest.raises(TypeError):
+            _make_claim(rule_id="r", reason="x", value="genomic")  # type: ignore[call-arg]
+
+
+class TestAddClaim:
+    """add_claim's own wiring: append accumulates, then the field re-derives from
+    the full list. The tier/unanimity/conflict resolution itself is owned by
+    TestEvaluateClaims — add_claim forwards the whole list to it unchanged, so
+    these test the wrapper, not the resolution rules."""
+
+    def test_single_claim_appends_and_sets_value(self):
+        result = ExtendedClassificationResult()
+        result.add_claim("data_type", rule_id="r1", reason="x", tier=1, value="reads")
+        assert result.data_type == "reads"
+        assert result.status_of("data_type") == CLASSIFIED
+        assert result.field_evidence["data_type"] == [{"rule_id": "r1", "reason": "x", "tier": 1, "value": "reads"}]
+
+    def test_second_claim_accumulates_and_re_resolves(self):
+        # Two calls accumulate (append, not replace) and the field re-derives from
+        # the full list — here a same-tier disagreement resolves to not_classified,
+        # the semantics the wholesale-site migrations will later adopt (not
+        # last-writer-wins). The resolution rule itself is TestEvaluateClaims' job.
+        result = ExtendedClassificationResult()
+        result.add_claim("reference_assembly", rule_id="a", reason="x", tier=2, value="GRCh38")
+        result.add_claim("reference_assembly", rule_id="b", reason="y", tier=2, value="GRCh37")
+        assert len(result.field_evidence["reference_assembly"]) == 2
+        assert result.reference_assembly is None
+        assert result.status_of("reference_assembly") == NOT_CLASSIFIED
+
+    def test_rejects_unknown_field_before_appending(self):
+        # add_claim delegates field validation to _require_field and raises rather
+        # than appending a claim under a typo'd field.
+        result = ExtendedClassificationResult()
+        with pytest.raises(ValueError, match="unknown classification field"):
+            result.add_claim("data_typo", rule_id="a", reason="x", tier=1, value="reads")
 
 
 class TestDerivativeFiles:


### PR DESCRIPTION
Closes #150. Part of epic #203 (parse-don't-validate typed-record sweep).

## What changed

Adds the claim-construction abstraction the imperative content classifiers lack, in `src/meta_disco/rule_engine.py`:

- **`_make_claim(*, rule_id, reason, tier, value=None, status=None)`** — the single/shared constructor for a claim dict. Enforces value-xor-status loudly (declaring both or neither raises `ValueError`) and makes `tier` a required keyword, so a claim can never reach `evaluate_claims` and fall back to its silent tier-0 default.
- **`ExtendedClassificationResult.add_claim(fld, *, ...)`** — appends a claim, then re-resolves the field from *all* its claims via `evaluate_claims` and `set_field`. The field's value is derived from its claims, never written alongside them (one source of truth). A same-tier disagreement resolves to `not_classified` rather than the last writer silently winning.
- **`_apply_rule`** now builds its claims through `_make_claim` (output-identical).

And migrates the one already-correct site in `src/meta_disco/header_classifier.py`:

- **gfa `rgfa_stable_rank_reference`** collapses from `field_evidence["data_type"].append({...})` + imperative `set_field(...)` into one `add_claim(...)`.

Tests: new `TestMakeClaim` + `TestAddClaim` in `tests/test_rule_engine.py`.

## Why

The claim dict appended to `field_evidence[fld]` had no constructor — its schema lived only in the consumers that read it, and its one required field with a silent default (`tier`, via `.get("tier", 0)`) was exactly the field that silently changes the resolved answer. In #151 the first draft omitted `tier` from the appended rGFA claim; `evaluate_claims` would have defaulted it to 0, lost to the tier-1 `pangenome` claim, and resolved to `pangenome` — contradicting the `pangenome.reference` written by the adjacent `set_field`. It only stayed hidden because nothing re-ran resolution on that path. `add_claim` removes that whole class of two-sources-of-truth bug by deriving the value from the claims.

## Assumptions I made

- **Phased scope, agreed at the plan gate.** This PR delivers the API + `_apply_rule` sharing + the one gfa site only. The other 17 hand-rolled `field_evidence[fld] = [...]` sites (BAM/VCF/FASTA/BED) are **not** migrated here, because they currently *replace* the engine's claim list and win definitively, whereas `add_claim` appends and re-resolves by tier — and `reference_assembly`/`data_type`/`data_modality` all have tier-3 engine rules, so preserving each site's resolved value needs a per-site "definitive content out-ranks tier 3" tiering decision. That decision + the migrations + the `evaluate_claims` `claim["tier"]` tightening are filed as **#226 / #227 / #228** and #150 is re-scoped (see its latest comment).
- **The gfa migration is output-identical**, not a behavior change: the engine's tier-1 `pangenome_graph` claim is already in the list, the tier-3 claim wins re-resolution via `higher_specificity_override`, and the golden already pins both claims. `test_output_shape` + the gfa eval prove this.
- **`add_claim` intentionally does not emit** the `conflict`/`not_classified` evidence markers that `_finalize_result` appends, nor clean stale ones it finds (callers run it after `classify_extended`). Harmless at the one migrated site (data_type has a real tier-1 claim, no marker to go stale); the marker handling is part of #228.
- `_make_claim`'s value-xor-status raise is a construction invariant (parse-don't-validate), not defensive internal null-checking — it mirrors what `rule_loader` enforces for a rule's `then` vs `then.status`.

## How to verify

Definition of done for this PR (the re-scoped #150 API slice; full task list on #150, migration/tightening moved to #226/#227/#228):

1. **`add_claim` with required tier + value-xor-status** — run `uv run pytest tests/test_rule_engine.py -k "MakeClaim or AddClaim" -v`. Expect: `_make_claim` raises on both-set and neither-set and on a missing `tier`; `add_claim` appends + re-resolves, and a same-tier disagreement yields `not_classified`.
2. **`_apply_rule` shares the constructor, output unchanged** — run `uv run pytest tests/test_output_shape.py tests/test_evals.py -q`. Expect all green (the golden is unchanged in this PR).
3. **The gfa site is migrated and output-identical** — `git show HEAD -- src/meta_disco/header_classifier.py` shows the `add_claim` call replacing the append+set_field pair; `tests/fixtures/golden/expected_output.json` is **not** modified in this PR, and the gfa `data_type` evidence still shows both the tier-1 `pangenome_graph` and tier-3 `rgfa_stable_rank_reference` claims resolving to `pangenome.reference`.
4. **Full gate** — `make test-all && make lint-all && make format-check` all pass.
