### PR TITLE
Reserve CONTENT_TIER (4) as the definitive content-read tier (#226)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,15 @@ evidence}` entry — plus the controlled vocabulary:
 - **Accuracy over efficiency**: Always prefer reading actual file content (headers, indices, range requests) over guessing from filenames. If there is an exact method to determine a classification — even if it requires downloading headers or running compute — use it.
 - **Accuracy over coverage**: It is better to leave a file as `not_classified` than to guess wrong. Only classify when evidence supports it.
 - **No speculation as fact**: Never confidently assert something unless you actually know it. If inferring or guessing, say "I think" or "it could be". This applies to root cause analysis, data interpretation, and codebase history.
+- **Claim tiers**: A classification field's value is resolved from competing
+  claims by tier (`evaluate_claims`, highest unique tier wins). Tiers 1–3 are
+  the rule tiers declared in `unified_rules.yaml` (extension / filename /
+  header). `CONTENT_TIER` (4, in `rule_engine.py`) is reserved for claims
+  *derived from reading file bytes* (contig lengths, VCF `##contig` lengths,
+  FASTA content, GFA segment tags) — the definitive signal from the accuracy
+  principle above, which must out-rank even a disagreeing tier-3 header rule.
+  Give any content-read claim `tier=CONTENT_TIER`, never a hard-coded number
+  (issue #226).
 
 ## Team roster
 

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -511,7 +511,7 @@ def classify_from_gfa_segment_tags(
     Returns:
         Per-field classification dict (same format as classify_from_fasta_header)
     """
-    from .rule_engine import ExtendedFileInfo
+    from .rule_engine import CONTENT_TIER, ExtendedFileInfo
 
     filename = filename_for_rules(
         file_name,
@@ -533,15 +533,17 @@ def classify_from_gfa_segment_tags(
         contigs = sorted({t.sn for t in rank0 if t.sn})
         preview = ", ".join(contigs[:3])
         phrase = "segment carries" if len(rank0) == 1 else "segments carry"
-        # Appended as a tier-3 claim (not assigned over the list) so the engine's
-        # tier-1 `pangenome_graph` claim survives and the derivation chain reads the
-        # same as the engine-resolved `-mc-` case; add_claim re-resolves from the
-        # full list so the refinement wins on its own. (See add_claim / _make_claim
-        # for the derive-from-claims and required-tier invariants.)
+        # Appended as a CONTENT_TIER claim (read from the segments' SR/SN tags, not
+        # assigned over the list) so the engine's tier-1 `pangenome_graph` claim
+        # survives and the derivation chain reads the same as the engine-resolved
+        # `-mc-` case; add_claim re-resolves from the full list so the refinement
+        # wins on its own. CONTENT_TIER (above the rule tiers) is the reserved level
+        # for byte-derived claims — see rule_engine (#226). (See add_claim /
+        # _make_claim for the derive-from-claims and required-tier invariants.)
         result.add_claim(
             "data_type",
             rule_id="rgfa_stable_rank_reference",
-            tier=3,
+            tier=CONTENT_TIER,
             reason=(
                 f"{len(rank0)} rGFA {phrase} stable rank 0 "
                 f"(SR:i:0) on {preview} — graph defines a reference "

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -23,6 +23,17 @@ if TYPE_CHECKING:
     from .validators.header_extractors import SAMHeader, VCFHeader
 
 
+# Tiers 1-3 are the rule tiers declared in ``unified_rules.yaml`` (extension /
+# filename / header). Tier 4 is reserved for claims *derived from reading file
+# bytes* (contig lengths, VCF ``##contig`` lengths, FASTA content, GFA segment
+# tags) — a definitive signal that must out-rank even a disagreeing tier-3
+# filename/header rule. ``evaluate_claims`` needs no special case for it: its
+# "highest unique tier wins" rule already lets a tier-4 content claim override
+# lower tiers (issue #226; the migration of the content sites onto ``add_claim``
+# at this tier is #227).
+CONTENT_TIER = 4
+
+
 @dataclass
 class ExtendedFileInfo:
     """Extended file information including header data for tier 3 rules."""
@@ -360,6 +371,13 @@ def evaluate_claims(claims: list[dict]) -> ClaimResolution:
     - Claims disagree, highest tier is unique → highest tier wins (override)
     - Claims disagree, NOT_APPLICABLE at top tier → not_applicable wins (terminal)
     - Claims disagree, same max tier → conflict (not_classified)
+
+    Tier ladder: tiers 1-3 are the rule tiers (extension / filename / header,
+    declared in ``unified_rules.yaml``); ``CONTENT_TIER`` (4) is reserved for
+    claims derived from reading file bytes. Because it is a unique tier above
+    every rule, the "highest unique tier wins" rule above makes a content claim
+    override a disagreeing tier-3 rule, and a content ``not_applicable`` win via
+    the terminal rule — no special case needed here (issue #226).
 
     Args:
         claims: List of evidence dicts, each with a ``value`` or a ``status`` and

--- a/src/meta_disco/schema/classification.yaml
+++ b/src/meta_disco/schema/classification.yaml
@@ -209,7 +209,7 @@ slots:
   reason:
     description: Human-readable rationale.
   tier:
-    description: The rule tier at which this evidence fired.
+    description: The tier at which this evidence fired.
     range: integer
   source_type:
     description: "Kind of source that produced this evidence (provenance, #90)."

--- a/tests/fixtures/golden/expected_output.json
+++ b/tests/fixtures/golden/expected_output.json
@@ -319,7 +319,7 @@
               {
                 "reason": "1 rGFA segment carries stable rank 0 (SR:i:0) on chr1 \u2014 graph defines a reference coordinate system",
                 "rule_id": "rgfa_stable_rank_reference",
-                "tier": 3,
+                "tier": 4,
                 "value": "pangenome.reference"
               }
             ],

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -32,7 +32,7 @@ from meta_disco.models import (
     field_status,
     field_value,
 )
-from meta_disco.rule_engine import RuleEngine, evaluate_claims
+from meta_disco.rule_engine import CONTENT_TIER, RuleEngine, evaluate_claims
 
 engine = RuleEngine()
 
@@ -496,16 +496,16 @@ class TestRgfaContentClassification:
             "the content claim must be appended after the base claim, not prepended"
         )
 
-    def test_content_claim_carries_tier_3(self):
-        """evaluate_claims defaults a missing tier to 0, which would lose to the
-        tier-1 `pangenome` claim. Pin the tier so resolving from claims agrees
-        with the value set here."""
+    def test_content_claim_carries_content_tier(self):
+        """The rGFA claim reads segment bytes, so it sits at CONTENT_TIER (#226) —
+        above the tier-1 `pangenome` claim it refines. Pin the tier so resolving
+        from claims agrees with the value set here."""
         record = classify_from_gfa_segment_tags(
             [SegmentTag(sn="chr1", sr="0")], file_name="hprc-v1.0-minigraph-grch38.gfa.gz"
         )
         claims = record["data_type"]["evidence"]
         content = next(c for c in claims if c["rule_id"] == "rgfa_stable_rank_reference")
-        assert content["tier"] == 3
+        assert content["tier"] == CONTENT_TIER
         # Resolving the claim list independently must reach the same value.
         assert evaluate_claims(claims).value == "pangenome.reference"
 

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -11,6 +11,7 @@ from meta_disco.models import (
     FileInfo,
 )
 from meta_disco.rule_engine import (
+    CONTENT_TIER,
     ExtendedClassificationResult,
     ExtendedFileInfo,
     ResolutionReason,
@@ -636,6 +637,58 @@ class TestEvaluateClaims:
         # Should have the rule's ID, not the generic "not_classified" placeholder
         assert "fastq_modality_unknown" in rule_ids
         assert "not_classified" not in rule_ids
+
+
+class TestContentTier:
+    """The definitive-content tier (issue #226).
+
+    ``CONTENT_TIER`` is a unique tier above the rule tiers (1-3), so
+    ``evaluate_claims`` resolves a byte-derived claim over any disagreeing rule
+    without a special case. These pin the resolution semantics the migration
+    (#227) relies on — that content wins its field, and content ``not_applicable``
+    stays terminal — not the rule tiers themselves.
+    """
+
+    def test_content_tier_is_above_the_rule_tiers(self):
+        """The reserved content tier sits strictly above the tier-3 rule ceiling."""
+        assert CONTENT_TIER > 3
+
+    def test_content_claim_overrides_disagreeing_tier3_rule(self):
+        """A tier-4 content claim beats a disagreeing tier-3 rule (override, not conflict)."""
+        result = evaluate_claims(
+            [
+                {"rule_id": "header_ref_grch38", "value": "GRCh38", "tier": 3},
+                {"rule_id": "contig_length_detection", "value": "CHM13", "tier": CONTENT_TIER},
+            ]
+        )
+        assert result.value == "CHM13"
+        assert result.is_conflict is False
+        assert result.reason == ResolutionReason.HIGHER_SPECIFICITY_OVERRIDE
+
+    def test_content_not_applicable_beats_tier3_real_value(self):
+        """A tier-4 content not_applicable wins terminally over a tier-3 real value."""
+        result = evaluate_claims(
+            [
+                {"rule_id": "filename_ref_grch38", "value": "GRCh38", "tier": 3},
+                {"rule_id": "fasta_assembly_no_reference", "status": NOT_APPLICABLE, "tier": CONTENT_TIER},
+            ]
+        )
+        assert result.status == NOT_APPLICABLE
+        assert result.value is None
+        assert result.is_conflict is False
+        assert result.reason == ResolutionReason.NOT_APPLICABLE_TERMINAL
+
+    def test_content_claim_agreeing_with_rule_stays_unanimous(self):
+        """When content agrees with the rule, the field is unanimous, not a conflict."""
+        result = evaluate_claims(
+            [
+                {"rule_id": "header_ref_grch38", "value": "GRCh38", "tier": 3},
+                {"rule_id": "contig_length_detection", "value": "GRCh38", "tier": CONTENT_TIER},
+            ]
+        )
+        assert result.value == "GRCh38"
+        assert result.is_conflict is False
+        assert result.reason == ResolutionReason.UNANIMOUS
 
 
 class TestAssayTypeInference:


### PR DESCRIPTION
Closes #226. Part of epic #203 (parse-don't-validate typed-record sweep); unblocks the migration follow-up #227.

## What changed

Decides the tiering mechanism for migrating the hand-rolled content classifiers onto `add_claim`, and documents it.

- **`src/meta_disco/rule_engine.py`** — adds `CONTENT_TIER = 4`, a reserved tier for claims *derived from reading file bytes* (contig lengths, VCF `##contig` lengths, FASTA content, GFA segment tags). It sits above the tier-1..3 rule tiers declared in `unified_rules.yaml`. Extends `evaluate_claims`' docstring with the tier ladder. **No change to resolution logic** — the existing "highest unique tier wins" rule already resolves a tier-4 content claim over any disagreeing rule.
- **`src/meta_disco/header_classifier.py`** — bumps the one already-migrated content site (gfa `rgfa_stable_rank_reference`, the only `add_claim` caller in the codebase) from `tier=3` to `tier=CONTENT_TIER`, so the convention has zero exceptions from day one.
- **`src/meta_disco/schema/classification.yaml`** — the `tier` slot description drops the word "rule" ("The **rule** tier…" → "The tier…"), because tier is an evidence property, not rules-only; content is synthetic-source evidence, which the adjacent `rule_id` slot description already acknowledges.
- **`CLAUDE.md`** — adds a "Claim tiers" design principle documenting the 1–3-rules / 4-definitive-content ladder and "use `CONTENT_TIER`, never a hard-coded number."
- **Tests** — new `TestContentTier` in `tests/test_rule_engine.py` pins the resolution semantics the migration relies on; `tests/test_evals.py` gfa tier assertion updated to `CONTENT_TIER`; golden regenerated (tier field only).

## Why

The 17 hand-rolled content sites in `header_classifier.py` currently *replace* the engine's claim list and `set_field` the value definitively, so content always wins. Migrating them to `add_claim` (append + re-resolve by tier) means the content signal must **out-tier** whatever the engine already claimed — and `reference_assembly` / `data_type` / `data_modality` each already have tier-3 engine rules, so a content claim at tier 3 would *tie* and resolve to `conflict` → `not_classified` instead of content winning. Giving content its own tier above the rule tiers is what preserves "definitive content wins" (the Accuracy-over-* design principle) once those sites move onto the shared resolution path.

Chosen mechanism is **Option 1 from the issue (a reserved tier 4)** over Option 2 (a terminal-override flag): tier 4 reuses the existing generalized "unique max tier wins" mechanism instead of adding a new special-case branch to `evaluate_claims`, which the altitude principle prefers.

## Assumptions I made

- **This is a decision-only PR.** It delivers the constant + docs + the one aligned site. The actual migration of the 17 replace-and-`set_field` sites is **#227**, and tightening `evaluate_claims` to require `claim["tier"]` (dropping the tier-0 `.get` default) is **#228**. Bumping only the gfa site now is safe because the replace-sites never run `evaluate_claims` incrementally — their tier is inert today — so there is no cross-site inconsistency while they wait for #227.
- **The gfa bump is output-identical**, not a behavior change: at tier 3 the content claim already out-ranked the tier-1 `pangenome_graph` claim via `higher_specificity_override`; at tier 4 it still does. The golden diff is the `tier` field alone (3→4); the resolved `pangenome.reference` value is unchanged.
- **`CONTENT_TIER` needs no `evaluate_claims` code change.** Tier 4 is above the rule ceiling (`max_tier = 3`) but that ceiling only *filters which rules run*; content claims are added after `classify_extended`, so they are never filtered by it. Resolution reads `c.get("tier", 0)` and compares — a unique tier-4 claim wins, and a tier-4 `not_applicable` wins via the existing terminal rule.
- **The schema accepts `tier: 4`** — the slot is `range: integer` with no bound, so the golden's new value validates.

## How to verify

Definition of done for #226:

1. **Mechanism decided and documented in `evaluate_claims`' docstring + CLAUDE.md design principles.**
   - `git show HEAD -- src/meta_disco/rule_engine.py` — `CONTENT_TIER = 4` with the tier-ladder comment, and the "Tier ladder:" paragraph in `evaluate_claims`.
   - `git show HEAD -- CLAUDE.md` — the "Claim tiers" bullet under Design Principles.
2. **It preserves today's resolved values for the sites that will migrate.**
   - Run `uv run pytest tests/test_rule_engine.py::TestContentTier -v`. Expect: a tier-4 content claim beats a disagreeing tier-3 rule (`higher_specificity_override`, not conflict); a tier-4 `not_applicable` beats a tier-3 real value (`not_applicable_terminal`); content agreeing with a rule stays unanimous.
   - Run `uv run pytest tests/test_evals.py tests/test_output_shape.py -q`. Expect all green; the gfa `data_type` still resolves to `pangenome.reference`, and the golden's gfa evidence shows the tier-1 `pangenome_graph` and the tier-4 `rgfa_stable_rank_reference` claims.
3. **Full gate** — `make test-all && make lint-all && make format-check` all pass (708 root + 10 schema tests, ruff clean, pyright 0 errors).
