### PR TITLE
Migrate wholesale field_evidence sites to add_claim (#227)

### DIFF
--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -185,7 +185,7 @@ def classify_from_vcf_header(
             - {field}: {value, status, evidence[]} for each of
               data_modality, data_type, assay_type, reference_assembly, platform
     """
-    from .rule_engine import ExtendedFileInfo
+    from .rule_engine import CONTENT_TIER, ExtendedFileInfo
 
     # Determine filename for extension-based rules
     filename = "sample.vcf.gz"
@@ -214,17 +214,18 @@ def classify_from_vcf_header(
     engine = _get_engine()
     result = engine.classify_extended(file_info, include_tier3=True)
 
-    # Apply contig-based reference (overrides everything — definitive signal)
+    # Apply contig-based reference. Read from the ##contig lengths, so it lands at
+    # CONTENT_TIER and out-ranks any disagreeing filename/header rule; add_claim
+    # re-resolves from the full list (#226/#227).
     if contig_ref:
-        result.set_field("reference_assembly", contig_ref)
         reason = f"Reference {contig_ref} detected from {contig_matches} matching contig lengths (definitive)"
-        result.field_evidence["reference_assembly"] = [
-            {
-                "rule_id": "vcf_contig_length",
-                "reason": reason,
-                "value": contig_ref,
-            }
-        ]
+        result.add_claim(
+            "reference_assembly",
+            rule_id="vcf_contig_length",
+            tier=CONTENT_TIER,
+            reason=reason,
+            value=contig_ref,
+        )
 
     return result.to_output_dict()
 

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -639,11 +639,8 @@ def classify_from_fasta_header(
             reason="Transcript sequences in FASTA",
             value="sequence",
         )
-        # No content signal for reference here; assert not_classified only if a
-        # filename rule did not already determine it (asserts no claim, so it stays
-        # a bare set_field rather than an add_claim — issue #227 scope note).
-        if not result.is_declared("reference_assembly"):
-            result.set_field("reference_assembly", status=NOT_CLASSIFIED)
+        # No content signal for reference_assembly; it keeps whatever the filename
+        # rules resolved (a real value, or not_classified when they found none).
         return result.to_output_dict()
 
     # 2. Contigs match a known reference set → reference genome

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -590,7 +590,7 @@ def classify_from_fasta_header(
     Returns:
         Per-field classification dict (same format as classify_from_fastq_header)
     """
-    from .rule_engine import ExtendedFileInfo
+    from .rule_engine import CONTENT_TIER, ExtendedFileInfo
     from .validators.contig_lengths import REFERENCE_CONTIG_LENGTHS
 
     filename = file_name or "sample.fa.gz"
@@ -621,26 +621,29 @@ def classify_from_fasta_header(
 
     # Classification logic
 
-    # 1. Transcript IDs → transcriptomic
+    # 1. Transcript IDs → transcriptomic. Contig names are read from the file, so
+    # these land at CONTENT_TIER; add_claim re-resolves from the full list (the
+    # tier-1 fasta_base data_type=sequence claim agrees and stays in the chain).
     if transcript_contigs and len(transcript_contigs) > len(ref_matches):
-        result.set_field("data_modality", "transcriptomic.bulk")
-        result.set_field("data_type", "sequence")
+        result.add_claim(
+            "data_modality",
+            rule_id="fasta_transcript_contigs",
+            tier=CONTENT_TIER,
+            reason=f"Found {len(transcript_contigs)} transcript IDs (e.g., {transcript_contigs[0]})",
+            value="transcriptomic.bulk",
+        )
+        result.add_claim(
+            "data_type",
+            rule_id="fasta_transcript_contigs",
+            tier=CONTENT_TIER,
+            reason="Transcript sequences in FASTA",
+            value="sequence",
+        )
+        # No content signal for reference here; assert not_classified only if a
+        # filename rule did not already determine it (asserts no claim, so it stays
+        # a bare set_field rather than an add_claim — issue #227 scope note).
         if not result.is_declared("reference_assembly"):
             result.set_field("reference_assembly", status=NOT_CLASSIFIED)
-        result.field_evidence["data_modality"] = [
-            {
-                "rule_id": "fasta_transcript_contigs",
-                "reason": f"Found {len(transcript_contigs)} transcript IDs (e.g., {transcript_contigs[0]})",
-                "value": "transcriptomic.bulk",
-            }
-        ]
-        result.field_evidence["data_type"] = [
-            {
-                "rule_id": "fasta_transcript_contigs",
-                "reason": "Transcript sequences in FASTA",
-                "value": "sequence",
-            }
-        ]
         return result.to_output_dict()
 
     # 2. Contigs match a known reference set → reference genome
@@ -667,113 +670,111 @@ def classify_from_fasta_header(
                 # Can't distinguish — contigs match multiple references equally
                 best_ref = None
 
-            result.set_field("data_modality", "genomic")
-            result.set_field("data_type", "assembly.reference")
-            ref_entry = {
-                "rule_id": "fasta_reference_contigs",
-                "reason": f"Matched {best_count} contigs to reference chromosomes"
-                + (f" ({best_ref})" if best_ref else " (ambiguous — multiple references share these names)"),
-            }
+            ref_reason = f"Matched {best_count} contigs to reference chromosomes" + (
+                f" ({best_ref})" if best_ref else " (ambiguous — multiple references share these names)"
+            )
             if best_ref:
-                result.set_field("reference_assembly", best_ref)
-                ref_entry["value"] = best_ref
+                result.add_claim(
+                    "reference_assembly",
+                    rule_id="fasta_reference_contigs",
+                    tier=CONTENT_TIER,
+                    reason=ref_reason,
+                    value=best_ref,
+                )
             else:
-                result.set_field("reference_assembly", status=NOT_CLASSIFIED)
-                ref_entry["status"] = NOT_CLASSIFIED
-            result.field_evidence["reference_assembly"] = [ref_entry]
-            result.field_evidence["data_modality"] = [
-                {
-                    "rule_id": "fasta_reference_contigs",
-                    "reason": "Contig names match known reference genome",
-                    "value": "genomic",
-                }
-            ]
-            result.field_evidence["data_type"] = [
-                {
-                    "rule_id": "fasta_reference_contigs",
-                    "reason": "FASTA contains reference genome sequences",
-                    "value": "assembly.reference",
-                }
-            ]
+                result.add_claim(
+                    "reference_assembly",
+                    rule_id="fasta_reference_contigs",
+                    tier=CONTENT_TIER,
+                    reason=ref_reason,
+                    status=NOT_CLASSIFIED,
+                )
+            result.add_claim(
+                "data_modality",
+                rule_id="fasta_reference_contigs",
+                tier=CONTENT_TIER,
+                reason="Contig names match known reference genome",
+                value="genomic",
+            )
+            result.add_claim(
+                "data_type",
+                rule_id="fasta_reference_contigs",
+                tier=CONTENT_TIER,
+                reason="FASTA contains reference genome sequences",
+                value="assembly.reference",
+            )
             return result.to_output_dict()
 
     # 3. Assembler output contigs → de novo assembly
     if assembler_contigs:
-        result.set_field("data_modality", "genomic")
-        result.set_field("data_type", "assembly")
-        result.set_field("reference_assembly", status=NOT_APPLICABLE)
         sample = assembler_contigs[0]
-        result.field_evidence["data_modality"] = [
-            {
-                "rule_id": "fasta_assembler_contigs",
-                "reason": f"Found {len(assembler_contigs)} assembler-named contigs (e.g., {sample})",
-                "value": "genomic",
-            }
-        ]
-        result.field_evidence["data_type"] = [
-            {
-                "rule_id": "fasta_assembler_contigs",
-                "reason": "Contig names indicate assembler output",
-                "value": "assembly",
-            }
-        ]
-        result.field_evidence["reference_assembly"] = [
-            {
-                "rule_id": "fasta_assembler_contigs",
-                "reason": "De novo assembly — no reference genome applicable",
-                "status": NOT_APPLICABLE,
-            }
-        ]
+        result.add_claim(
+            "data_modality",
+            rule_id="fasta_assembler_contigs",
+            tier=CONTENT_TIER,
+            reason=f"Found {len(assembler_contigs)} assembler-named contigs (e.g., {sample})",
+            value="genomic",
+        )
+        result.add_claim(
+            "data_type",
+            rule_id="fasta_assembler_contigs",
+            tier=CONTENT_TIER,
+            reason="Contig names indicate assembler output",
+            value="assembly",
+        )
+        result.add_claim(
+            "reference_assembly",
+            rule_id="fasta_assembler_contigs",
+            tier=CONTENT_TIER,
+            reason="De novo assembly — no reference genome applicable",
+            status=NOT_APPLICABLE,
+        )
         return result.to_output_dict()
 
     # 4. Many non-standard contigs → likely de novo assembly
     if num_contigs > 50 and not ref_matches:
-        result.set_field("data_modality", "genomic")
-        result.set_field("data_type", "assembly")
-        result.set_field("reference_assembly", status=NOT_APPLICABLE)
-        result.field_evidence["data_modality"] = [
-            {
-                "rule_id": "fasta_many_contigs",
-                "reason": f"Large number of contigs ({num_contigs}) with non-standard names suggests de novo assembly",
-                "value": "genomic",
-            }
-        ]
-        result.field_evidence["data_type"] = [
-            {
-                "rule_id": "fasta_many_contigs",
-                "reason": "High contig count suggests assembly",
-                "value": "assembly",
-            }
-        ]
-        result.field_evidence["reference_assembly"] = [
-            {
-                "rule_id": "fasta_many_contigs",
-                "reason": "De novo assembly — no reference genome applicable",
-                "status": NOT_APPLICABLE,
-            }
-        ]
+        result.add_claim(
+            "data_modality",
+            rule_id="fasta_many_contigs",
+            tier=CONTENT_TIER,
+            reason=f"Large number of contigs ({num_contigs}) with non-standard names suggests de novo assembly",
+            value="genomic",
+        )
+        result.add_claim(
+            "data_type",
+            rule_id="fasta_many_contigs",
+            tier=CONTENT_TIER,
+            reason="High contig count suggests assembly",
+            value="assembly",
+        )
+        result.add_claim(
+            "reference_assembly",
+            rule_id="fasta_many_contigs",
+            tier=CONTENT_TIER,
+            reason="De novo assembly — no reference genome applicable",
+            status=NOT_APPLICABLE,
+        )
         return result.to_output_dict()
 
     # 5. Default: preserve rule engine results if they set modality/type,
-    #    otherwise fall back to genomic/sequence
+    #    otherwise fall back to genomic/sequence. Guarded so a filename rule that
+    #    already declared the field is not overridden by the content default.
     if not result.is_declared("data_modality"):
-        result.set_field("data_modality", "genomic")
-        result.field_evidence["data_modality"] = [
-            {
-                "rule_id": "fasta_default_genomic",
-                "reason": f"FASTA with {num_contigs} contigs — defaulting to genomic",
-                "value": "genomic",
-            }
-        ]
+        result.add_claim(
+            "data_modality",
+            rule_id="fasta_default_genomic",
+            tier=CONTENT_TIER,
+            reason=f"FASTA with {num_contigs} contigs — defaulting to genomic",
+            value="genomic",
+        )
     if not result.is_declared("data_type"):
-        result.set_field("data_type", "sequence")
-        result.field_evidence["data_type"] = [
-            {
-                "rule_id": "fasta_default_genomic",
-                "reason": "Unable to determine specific FASTA type from headers",
-                "value": "sequence",
-            }
-        ]
+        result.add_claim(
+            "data_type",
+            rule_id="fasta_default_genomic",
+            tier=CONTENT_TIER,
+            reason="Unable to determine specific FASTA type from headers",
+            value="sequence",
+        )
     return result.to_output_dict()
 
 

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -908,7 +908,7 @@ def classify_from_bed_signals(
     Returns:
         Per-field classification dict with evidence
     """
-    from .rule_engine import ExtendedFileInfo
+    from .rule_engine import CONTENT_TIER, ExtendedFileInfo
 
     filename = file_name or "sample.bed"
     max_coordinates = signals.max_coordinates
@@ -927,28 +927,27 @@ def classify_from_bed_signals(
         coord_ref, coord_rationale = _infer_bed_reference(signals)
 
         if coord_ref and result.status_of("reference_assembly") != NOT_APPLICABLE:
-            # Coordinate detection reads the actual file content, so it overrides
-            # a filename-based reference guess (CLAUDE.md design principle: prefer
-            # reading actual file content over guessing from filenames). But it does
-            # not overturn an existing not_applicable — that is a positive
-            # determination ("no reference applies"), not a filename guess.
-            result.set_field("reference_assembly", coord_ref)
-            result.field_evidence["reference_assembly"] = [
-                {
-                    "rule_id": "bed_coordinate_reference",
-                    "reason": coord_rationale,
-                    "value": coord_ref,
-                }
-            ]
+            # Coordinate detection reads the actual file content, so at CONTENT_TIER
+            # it overrides a filename-based reference guess (CLAUDE.md design
+            # principle: prefer reading actual file content over guessing from
+            # filenames). The guard preserves an existing not_applicable — a positive
+            # determination ("no reference applies"), not a filename guess — which a
+            # CONTENT_TIER value claim would otherwise out-rank.
+            result.add_claim(
+                "reference_assembly",
+                rule_id="bed_coordinate_reference",
+                tier=CONTENT_TIER,
+                reason=coord_rationale,
+                value=coord_ref,
+            )
         elif "Non-standard chromosome" in coord_rationale:
-            result.set_field("reference_assembly", status=NOT_APPLICABLE)
-            result.field_evidence["reference_assembly"] = [
-                {
-                    "rule_id": "bed_nonstandard_contigs",
-                    "reason": coord_rationale,
-                    "status": NOT_APPLICABLE,
-                }
-            ]
+            result.add_claim(
+                "reference_assembly",
+                rule_id="bed_nonstandard_contigs",
+                tier=CONTENT_TIER,
+                reason=coord_rationale,
+                status=NOT_APPLICABLE,
+            )
 
     return result.to_output_dict()
 

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -101,7 +101,7 @@ def classify_from_header(
             - {field}: {value, status, evidence[]} for each of
               data_modality, data_type, assay_type, reference_assembly, platform
     """
-    from .rule_engine import ExtendedFileInfo
+    from .rule_engine import CONTENT_TIER, ExtendedFileInfo
 
     # Determine filename for extension-based rules
     filename = "sample.bam"
@@ -131,27 +131,30 @@ def classify_from_header(
     engine = _get_engine()
     result = engine.classify_extended(file_info, include_tier3=True)
 
-    # Apply contig-based reference (overrides everything — definitive signal)
+    # Apply contig-based reference. Read from the @SQ contig lengths, so it lands
+    # at CONTENT_TIER and out-ranks any disagreeing filename/header rule; add_claim
+    # re-resolves from the full list, so a filename_ref rule that agrees stays in
+    # the evidence chain rather than being clobbered (#226/#227).
     if contig_ref:
-        result.set_field("reference_assembly", contig_ref)
         reason = f"Reference {contig_ref} detected from {contig_matches} matching contig lengths (definitive)"
-        result.field_evidence["reference_assembly"] = [
-            {
-                "rule_id": "contig_length_detection",
-                "reason": reason,
-                "value": contig_ref,
-            }
-        ]
-        # Aligned to a known reference genome = genomic data
+        result.add_claim(
+            "reference_assembly",
+            rule_id="contig_length_detection",
+            tier=CONTENT_TIER,
+            reason=reason,
+            value=contig_ref,
+        )
+        # Aligned to a known reference genome = genomic data. Guarded so a header
+        # rule that already declared a modality (e.g. transcriptomic) is not
+        # overridden by this genomic claim.
         if not result.is_declared("data_modality"):
-            result.set_field("data_modality", "genomic")
-            result.field_evidence["data_modality"] = [
-                {
-                    "rule_id": "aligned_to_reference",
-                    "reason": f"Aligned to {contig_ref} — file contains genomic alignments",
-                    "value": "genomic",
-                }
-            ]
+            result.add_claim(
+                "data_modality",
+                rule_id="aligned_to_reference",
+                tier=CONTENT_TIER,
+                reason=f"Aligned to {contig_ref} — file contains genomic alignments",
+                value="genomic",
+            )
 
     # Infer assay type
     engine.infer_assay_type(result, file_info)

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -200,7 +200,7 @@ class ExtendedClassificationResult:
         self.field_evidence[fld].append(claim)
         evaluation = evaluate_claims(self.field_evidence[fld])
         self.set_field(fld, evaluation.value, evaluation.status)
-        # A rule just added a claim, so the synthetic "no rule determined a value"
+        # A claim was just added, so the synthetic "no rule determined a value"
         # placeholder _finalize_result may have appended is now false — drop it so
         # the evidence reads as the derivation.
         self.field_evidence[fld] = [e for e in self.field_evidence[fld] if e.get("rule_id") != "not_classified"]

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -186,10 +186,10 @@ class ExtendedClassificationResult:
         Callers use this *after* ``classify_extended`` has run, so
         ``_finalize_result`` may already have appended a synthetic
         ``not_classified`` / conflict marker to the list. ``evaluate_claims``
-        ignores the ``"not_classified"`` placeholder when resolving. When the new
-        claim resolves the field assertively (a real value or not_applicable),
-        that placeholder is now false, so it is dropped here (#227) — the same
-        strip ``infer_assay_type`` does. Only the synthetic ``"not_classified"``
+        ignores the ``"not_classified"`` placeholder when resolving. Adding any
+        claim makes that "no rule determined a value" placeholder false, so it is
+        dropped here (#227); the field still carries the claim just appended, so
+        its evidence is never emptied. Only the synthetic ``"not_classified"``
         marker is removed; rule-authored not_classified declarations carry real
         rule_ids and stay, and a conflict marker is left in place. Emitting *fresh*
         markers on an incremental add, and requiring ``claim["tier"]`` in
@@ -200,11 +200,10 @@ class ExtendedClassificationResult:
         self.field_evidence[fld].append(claim)
         evaluation = evaluate_claims(self.field_evidence[fld])
         self.set_field(fld, evaluation.value, evaluation.status)
-        if self.is_declared(fld):
-            # The claim just resolved the field to a real value or not_applicable,
-            # so any synthetic "no rule determined a value" placeholder is now
-            # false — drop it so the evidence reads as the derivation.
-            self.field_evidence[fld] = [e for e in self.field_evidence[fld] if e.get("rule_id") != "not_classified"]
+        # A rule just added a claim, so the synthetic "no rule determined a value"
+        # placeholder _finalize_result may have appended is now false — drop it so
+        # the evidence reads as the derivation.
+        self.field_evidence[fld] = [e for e in self.field_evidence[fld] if e.get("rule_id") != "not_classified"]
 
     def _require_field(self, fld: str) -> None:
         """Raise ValueError for an unknown classification field, so every accessor
@@ -795,24 +794,20 @@ class RuleEngine:
             ):
                 continue
 
-            # All conditions passed — apply and record evidence
-            result.set_field("assay_type", assay_rule.assay_type)
-            # Remove stale not_classified placeholder if _finalize_result ran first
-            result.field_evidence["assay_type"] = [
-                e for e in result.field_evidence["assay_type"] if e.get("rule_id") != "not_classified"
-            ]
-            # tier 3: this inference derives from already-resolved signals (the
-            # header-derived platform is typically tier 3), so it carries a tier
-            # rather than the tier-0 default #228 will forbid. It never competes —
-            # the is_declared guard above means it only fires when no other claim
-            # determined assay_type — so the tier is for consistency, not resolution.
-            result.field_evidence["assay_type"].append(
-                {
-                    "rule_id": "infer_assay_type",
-                    "reason": f"Inferred {assay_rule.assay_type} from platform/modality/file size signals",
-                    "value": assay_rule.assay_type,
-                    "tier": 3,
-                }
+            # All conditions passed — record the inference as a claim. add_claim
+            # sets the field, drops the synthetic not_classified placeholder, and
+            # enforces _make_claim's value-xor-status invariant. tier 3: the
+            # inference derives from already-resolved signals (the header-derived
+            # platform is typically tier 3), so it carries a tier rather than the
+            # tier-0 default #228 will forbid; it never competes (the is_declared
+            # guard above means it only fires when no other claim determined
+            # assay_type), so the tier is for consistency, not resolution.
+            result.add_claim(
+                "assay_type",
+                rule_id="infer_assay_type",
+                tier=3,
+                reason=f"Inferred {assay_rule.assay_type} from platform/modality/file size signals",
+                value=assay_rule.assay_type,
             )
             return
 

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -801,11 +801,17 @@ class RuleEngine:
             result.field_evidence["assay_type"] = [
                 e for e in result.field_evidence["assay_type"] if e.get("rule_id") != "not_classified"
             ]
+            # tier 3: this inference derives from already-resolved signals (the
+            # header-derived platform is typically tier 3), so it carries a tier
+            # rather than the tier-0 default #228 will forbid. It never competes —
+            # the is_declared guard above means it only fires when no other claim
+            # determined assay_type — so the tier is for consistency, not resolution.
             result.field_evidence["assay_type"].append(
                 {
                     "rule_id": "infer_assay_type",
                     "reason": f"Inferred {assay_rule.assay_type} from platform/modality/file size signals",
                     "value": assay_rule.assay_type,
+                    "tier": 3,
                 }
             )
             return

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -186,17 +186,25 @@ class ExtendedClassificationResult:
         Callers use this *after* ``classify_extended`` has run, so
         ``_finalize_result`` may already have appended a synthetic
         ``not_classified`` / conflict marker to the list. ``evaluate_claims``
-        ignores the ``"not_classified"`` placeholder when resolving, so the value
-        stays correct, but this method neither removes that stale marker nor
-        appends a fresh one — it only re-sets the field. Cleaning up prior markers
-        and emitting them on incremental adds is a follow-up (the ``rule_engine``
-        placeholder-filter revisit under #228).
+        ignores the ``"not_classified"`` placeholder when resolving. When the new
+        claim resolves the field assertively (a real value or not_applicable),
+        that placeholder is now false, so it is dropped here (#227) — the same
+        strip ``infer_assay_type`` does. Only the synthetic ``"not_classified"``
+        marker is removed; rule-authored not_classified declarations carry real
+        rule_ids and stay, and a conflict marker is left in place. Emitting *fresh*
+        markers on an incremental add, and requiring ``claim["tier"]`` in
+        ``evaluate_claims``, remain follow-ups (#228).
         """
         self._require_field(fld)
         claim = _make_claim(rule_id=rule_id, reason=reason, tier=tier, value=value, status=status)
         self.field_evidence[fld].append(claim)
         evaluation = evaluate_claims(self.field_evidence[fld])
         self.set_field(fld, evaluation.value, evaluation.status)
+        if self.is_declared(fld):
+            # The claim just resolved the field to a real value or not_applicable,
+            # so any synthetic "no rule determined a value" placeholder is now
+            # false — drop it so the evidence reads as the derivation.
+            self.field_evidence[fld] = [e for e in self.field_evidence[fld] if e.get("rule_id") != "not_classified"]
 
     def _require_field(self, fld: str) -> None:
         """Raise ValueError for an unknown classification field, so every accessor

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -285,10 +285,11 @@ class TestAddClaim:
         rule_ids = [e["rule_id"] for e in result.field_evidence["data_modality"]]
         assert rule_ids == ["fastq_modality_unknown", "aligned_to_reference"], rule_ids
 
-    def test_keeps_placeholder_when_resolution_stays_not_classified(self):
-        # A non-assertive add (a not_classified status claim) does not resolve the
-        # field, so the placeholder is left untouched — only assertive resolutions
-        # trigger the drop.
+    def test_drops_synthetic_placeholder_even_on_non_assertive_add(self):
+        # Adding any claim makes the synthetic "no rule determined a value"
+        # placeholder false, so it is dropped even when the field stays
+        # not_classified — the field still carries the newly added claim, which
+        # explains the status better than the generic placeholder.
         result = ExtendedClassificationResult()
         result.field_evidence["reference_assembly"].append(
             {"rule_id": "not_classified", "reason": "No rule determined a value", "status": NOT_CLASSIFIED}
@@ -296,7 +297,7 @@ class TestAddClaim:
         result.add_claim("reference_assembly", rule_id="looked_but_unsure", reason="?", tier=4, status=NOT_CLASSIFIED)
         assert result.status_of("reference_assembly") == NOT_CLASSIFIED
         rule_ids = [e["rule_id"] for e in result.field_evidence["reference_assembly"]]
-        assert "not_classified" in rule_ids
+        assert rule_ids == ["looked_but_unsure"], f"synthetic placeholder not dropped: {rule_ids}"
 
     def test_rejects_unknown_field_before_appending(self):
         # add_claim delegates field validation to _require_field and raises rather

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -254,6 +254,50 @@ class TestAddClaim:
         assert result.reference_assembly is None
         assert result.status_of("reference_assembly") == NOT_CLASSIFIED
 
+    def test_drops_synthetic_not_classified_placeholder_on_assertive_resolution(self):
+        # _finalize_result appends a synthetic {rule_id: "not_classified"} marker
+        # for a field no rule matched. A later content claim that resolves the field
+        # assertively makes that "no rule determined a value" marker false, so
+        # add_claim drops it (#227) — the evidence reads as the derivation, not a
+        # value beside a contradiction.
+        result = ExtendedClassificationResult()
+        result.field_evidence["reference_assembly"].append(
+            {"rule_id": "not_classified", "reason": "No rule determined a value", "status": NOT_CLASSIFIED}
+        )
+        result.add_claim("reference_assembly", rule_id="vcf_contig_length", reason="contigs", tier=4, value="GRCh38")
+        assert result.reference_assembly == "GRCh38"
+        rule_ids = [e["rule_id"] for e in result.field_evidence["reference_assembly"]]
+        assert rule_ids == ["vcf_contig_length"], f"stale placeholder not dropped: {rule_ids}"
+
+    def test_keeps_rule_authored_not_classified_when_dropping_placeholder(self):
+        # Only the *synthetic* placeholder (rule_id "not_classified") is dropped;
+        # a rule that intentionally declares not_classified carries a real rule_id
+        # and stays in the evidence chain even when a higher-tier claim wins.
+        result = ExtendedClassificationResult()
+        result.field_evidence["data_modality"].append(
+            {"rule_id": "fastq_modality_unknown", "reason": "unknown", "status": NOT_CLASSIFIED, "tier": 3}
+        )
+        result.field_evidence["data_modality"].append(
+            {"rule_id": "not_classified", "reason": "No rule determined a value", "status": NOT_CLASSIFIED}
+        )
+        result.add_claim("data_modality", rule_id="aligned_to_reference", reason="aligned", tier=4, value="genomic")
+        assert result.data_modality == "genomic"
+        rule_ids = [e["rule_id"] for e in result.field_evidence["data_modality"]]
+        assert rule_ids == ["fastq_modality_unknown", "aligned_to_reference"], rule_ids
+
+    def test_keeps_placeholder_when_resolution_stays_not_classified(self):
+        # A non-assertive add (a not_classified status claim) does not resolve the
+        # field, so the placeholder is left untouched — only assertive resolutions
+        # trigger the drop.
+        result = ExtendedClassificationResult()
+        result.field_evidence["reference_assembly"].append(
+            {"rule_id": "not_classified", "reason": "No rule determined a value", "status": NOT_CLASSIFIED}
+        )
+        result.add_claim("reference_assembly", rule_id="looked_but_unsure", reason="?", tier=4, status=NOT_CLASSIFIED)
+        assert result.status_of("reference_assembly") == NOT_CLASSIFIED
+        rule_ids = [e["rule_id"] for e in result.field_evidence["reference_assembly"]]
+        assert "not_classified" in rule_ids
+
     def test_rejects_unknown_field_before_appending(self):
         # add_claim delegates field validation to _require_field and raises rather
         # than appending a claim under a typo'd field.


### PR DESCRIPTION
Closes #227.

## What changed

Migrated every "wholesale" `field_evidence[fld] = [entry]` + imperative `set_field` site in the content classifiers to `result.add_claim(fld, ..., tier=CONTENT_TIER, ...)`, so each field's value is *derived* from its claim list instead of being written alongside a clobbered list. One classifier per commit:

- **`add_claim` infra** — appending a claim now drops the synthetic `not_classified` placeholder `_finalize_result` leaves for unmatched fields (the field still carries the new claim, so evidence is never emptied). This is what makes the migration behavior-preserving, since the old wholesale assignment used to clobber that placeholder.
- **BAM** — `contig_length_detection` (reference_assembly) + `aligned_to_reference` (data_modality).
- **VCF** — `vcf_contig_length` (reference_assembly).
- **FASTA** — all five buckets (`fasta_transcript_contigs`, `fasta_reference_contigs`, `fasta_assembler_contigs`, `fasta_many_contigs`, `fasta_default_genomic`).
- **BED** — `bed_coordinate_reference` + `bed_nonstandard_contigs`.
- **`infer_assay_type`** now records its inference through `add_claim` (was a hand-built dict defaulting to tier 0); it carries `tier=3` and gains `_make_claim`'s value-xor-status check.

## Why

Part of epic #203 ("parse, don't validate"). The wholesale assignments were the last places a field's value was set imperatively and then a *separate* evidence list written next to it — two sources of truth that could disagree. Deriving each value from its claims via `evaluate_claims` gives one source of truth and makes conflict detection run for free. #226 reserved `CONTENT_TIER` (4, above the rule tiers) so a byte-derived claim out-ranks a disagreeing filename/header rule; this PR is the migration #226 unblocked. #227 was split from #150.

## Assumptions I made

- **Resolved values are preserved; evidence chains grow.** The review signal for each site is that its evidence goes from one hand-rolled entry to the full derivation — e.g. a GRCh38 reference FASTA's `reference_assembly` now reads `[filename_ref_grch38 (t2), fasta_reference_contigs (t4)]` and `data_type` reads `[fasta_base (t1, sequence), fasta_reference_contigs (t4, assembly.reference)]`. The resolved value is unchanged; the chain now shows how it was reached. Verified against the real cached-header e2e suite plus the golden.
- **Guards are load-bearing and kept.** Because `CONTENT_TIER` is a unique top tier, an unguarded content claim would override a real header modality or a positive `not_applicable`. So the BAM/FASTA-default `is_declared` guards and the BED `!= NOT_APPLICABLE` guard are preserved deliberately.
- **`infer_assay_type` tier = 3 is for consistency, not resolution.** The `is_declared` guard means it only fires when nothing else determined assay_type, so it never competes; tier 3 reflects its typical input (the header-derived platform) and pre-empts the tier-0 default #228 will forbid.
- **Placeholder-drop fires on any add, not just assertive resolutions** (adopted during review). It also fixes `generate_coverage_report.py`, which reads `evidence[0].reason` for its not-classified aggregation: the ambiguous-reference FASTA case now reports "ambiguous — multiple references share these names" instead of a generic placeholder.
- **Deferred to #228** (which owns tightening `evaluate_claims`): requiring `claim["tier"]` and emitting *fresh* markers on incremental adds. A stale conflict marker left by `_finalize_result` is not dropped when a later content claim resolves the conflict — out of scope here.
- **Golden is unchanged** across every commit: the golden's stub payloads don't trigger the BAM/VCF/FASTA content sites, and the fasta fixture's guards skip its default bucket, so no golden fixture exercised the migrated paths.

## How to verify

Definition of done (from #227), mapped to steps:

1. **BAM `classify_from_header`: `contig_length_detection` + `aligned_to_reference` → `add_claim`.**
   `python -m pytest tests/test_evals.py::TestBamE2E -q` (needs the local `data/evidence/anvil/` cache). `test_grch38_aligned_bam` still resolves `reference_assembly=GRCh38` and `data_modality=genomic`; `test_no_stale_evidence` confirms no stale `not_classified`.
2. **VCF `classify_from_vcf_header`: `vcf_contig_length` → `add_claim`.**
   `python -m pytest tests/test_evals.py::TestVcfE2E -q`. `test_vcf_has_contig_evidence` and `test_vcf_no_stale_evidence` pass (the NA21125 fixture has no filename ref token, so this exercises the placeholder-drop).
3. **FASTA `classify_from_fasta_header`: the 5 buckets → `add_claim`.**
   `python -m pytest tests/test_evals.py::TestFastaE2E -q`. Reference/assembly/mito cases keep their values. For the chain-growth signal: run a GRCh38 reference FASTA and confirm `reference_assembly` evidence lists both `filename_ref_grch38` and `fasta_reference_contigs`.
4. **BED `classify_from_bed_signals`: `bed_coordinate_reference` + `bed_nonstandard_contigs` → `add_claim`.**
   `python -m pytest tests/test_bed_classification.py -q`. Coordinate detection still overrides a filename guess but not a positive `not_applicable`.
5. **`tier` added to the `infer_assay_type` entry.**
   `python -m pytest tests/test_rule_engine.py -q`, then confirm an inferred assay carries `tier: 3`, e.g. the WGS BAM above shows `assay_type` evidence `[('infer_assay_type', 3)]`.
6. **Each migrated site preserves its resolved value.** The e2e suites above are the check; the golden deep-equal (`python -m pytest tests/test_output_shape.py -q`) pins the output shape and is unchanged.

Full gate: `make test-all`, `make lint-all`, `make format-check` — all green.
