### PR TITLE
Tighten evaluate_claims to claim[tier] + de-overload marker rule_id (#228)

### DIFF
--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -123,20 +123,16 @@ def _make_claim(
 # Kinds of synthetic resolution marker ``_sync_markers`` appends to explain an
 # absent or ambiguous answer. These are NOT rules: a marker carries a ``marker``
 # kind and no ``rule_id`` (issue #228 — stop overloading ``rule_id`` to hold a
-# sentinel). ``marker`` is a string so more kinds can be added without a schema
-# migration.
+# sentinel). These must stay in lockstep with the schema's ``evidence_marker_enum``
+# (pinned by tests/test_rule_vocabulary.py); adding a kind means editing both.
 NOT_CLASSIFIED_MARKER = "not_classified"
 CONFLICT_MARKER = "conflict"
 
 
 def _is_synthetic_marker(entry: dict) -> bool:
-    """True if this evidence entry is a synthetic resolution marker rather than a
-    claim from a rule or content classifier.
-
-    A marker is identified by its ``marker`` kind, not by a magic ``rule_id``: a
-    rule-authored ``not_classified`` declaration carries a real ``rule_id`` and no
-    ``marker`` key, so it is a real claim and is not matched here.
-    """
+    """True if this evidence entry is a synthetic resolution marker (carries a
+    ``marker`` kind), not a claim. A rule-authored ``not_classified`` declaration
+    has a real ``rule_id`` and no ``marker``, so it is a claim, not a marker."""
     return "marker" in entry
 
 
@@ -445,8 +441,11 @@ def evaluate_claims(claims: list[dict]) -> ClaimResolution:
     the terminal rule — no special case needed here (issue #226).
 
     Args:
-        claims: List of evidence dicts, each with a ``value`` or a ``status`` and
-                optionally ``tier`` / ``rule_id`` / ``reason``.
+        claims: List of evidence dicts, each declaring a ``value`` or a ``status``.
+                An assertive claim that reaches the disagreement path must carry a
+                ``tier`` (raises ``KeyError`` otherwise — #228); ``rule_id`` /
+                ``reason`` are optional here. Synthetic markers (which carry a
+                ``marker`` kind, no tier) are dropped before the tier math.
 
     Returns:
         ClaimResolution with: value (real or None), status, reason, is_conflict,

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -120,6 +120,45 @@ def _make_claim(
     return claim
 
 
+# Reserved ``rule_id`` for the synthetic "no rule determined a value" placeholder
+# ``_sync_markers`` appends. It is not a real rule id (issue #228 moves this
+# sentinel out of ``rule_id`` in a follow-up commit); the constant keeps the one
+# magic string in one place until then.
+NOT_CLASSIFIED_MARKER = "not_classified"
+
+
+def _is_synthetic_marker(entry: dict) -> bool:
+    """True if this evidence entry is a synthetic resolution marker.
+
+    Two kinds exist, both appended by ``_sync_markers`` to explain an absent or
+    ambiguous answer rather than to assert one: the ``not_classified`` placeholder
+    (no claim was made) and a conflict marker (claims disagreed at the top tier).
+    A rule-authored ``not_classified`` declaration is a real claim, not a marker —
+    it carries a real ``rule_id`` and no ``is_conflict``, so it is not matched here.
+    """
+    return entry.get("rule_id") == NOT_CLASSIFIED_MARKER or bool(entry.get("is_conflict"))
+
+
+def _not_classified_marker(fld: str) -> dict:
+    """The synthetic placeholder that keeps a claimless field's evidence non-empty."""
+    return {
+        "rule_id": NOT_CLASSIFIED_MARKER,
+        "reason": f"No rule determined a value for {fld}",
+        "status": NOT_CLASSIFIED,
+    }
+
+
+def _conflict_marker(fld: str, competing: list[str]) -> dict:
+    """The synthetic marker recording that top-tier claims disagreed."""
+    return {
+        "rule_id": f"conflicting_{fld}_rules",
+        "reason": f"Conflicting {fld}: {competing} — ambiguous",
+        "status": NOT_CLASSIFIED,
+        "competing_values": competing,
+        "is_conflict": True,
+    }
+
+
 @dataclass
 class ExtendedClassificationResult:
     """Extended classification result with additional fields.
@@ -186,24 +225,38 @@ class ExtendedClassificationResult:
         Callers use this *after* ``classify_extended`` has run, so
         ``_finalize_result`` may already have appended a synthetic
         ``not_classified`` / conflict marker to the list. ``evaluate_claims``
-        ignores the ``"not_classified"`` placeholder when resolving. Adding any
-        claim makes that "no rule determined a value" placeholder false, so it is
-        dropped here (#227); the field still carries the claim just appended, so
-        its evidence is never emptied. Only the synthetic ``"not_classified"``
-        marker is removed; rule-authored not_classified declarations carry real
-        rule_ids and stay, and a conflict marker is left in place. Emitting *fresh*
-        markers on an incremental add, and requiring ``claim["tier"]`` in
-        ``evaluate_claims``, remain follow-ups (#228).
+        ignores those markers when resolving, and ``_sync_markers`` then rewrites
+        them to match the new resolution — so a stale placeholder or conflict
+        marker is dropped when this claim resolves the field, and a fresh conflict
+        marker is emitted if this claim creates one. The field always keeps the
+        claim just appended, so its evidence is never emptied.
         """
         self._require_field(fld)
         claim = _make_claim(rule_id=rule_id, reason=reason, tier=tier, value=value, status=status)
         self.field_evidence[fld].append(claim)
         evaluation = evaluate_claims(self.field_evidence[fld])
         self.set_field(fld, evaluation.value, evaluation.status)
-        # A claim was just added, so the synthetic "no rule determined a value"
-        # placeholder _finalize_result may have appended is now false — drop it so
-        # the evidence reads as the derivation.
-        self.field_evidence[fld] = [e for e in self.field_evidence[fld] if e.get("rule_id") != "not_classified"]
+        self._sync_markers(fld, evaluation)
+
+    def _sync_markers(self, fld: str, evaluation: "ClaimResolution") -> None:
+        """Rewrite a field's synthetic markers to match its current resolution.
+
+        Strips any existing synthetic markers (a placeholder or conflict marker
+        left by a prior resolution) and appends the one that describes the current
+        outcome: a conflict marker when top-tier claims disagree, the
+        ``not_classified`` placeholder when no claim was made at all, or nothing
+        when the field resolved to a real value or ``not_applicable``. Real claims
+        (including rule-authored ``not_classified`` declarations) are untouched.
+        Shared by ``_finalize_result`` (fresh classify — nothing to strip) and
+        ``add_claim`` (incremental re-resolve), so both keep the evidence honest.
+        """
+        self.field_evidence[fld] = [e for e in self.field_evidence[fld] if not _is_synthetic_marker(e)]
+        # competing_values is non-None iff the resolution is a conflict (ClaimResolution
+        # invariant); testing it directly narrows the type without a separate assert.
+        if evaluation.competing_values is not None:
+            self.field_evidence[fld].append(_conflict_marker(fld, evaluation.competing_values))
+        elif evaluation.reason == ResolutionReason.NO_CLAIMS:
+            self.field_evidence[fld].append(_not_classified_marker(fld))
 
     def _require_field(self, fld: str) -> None:
         """Raise ValueError for an unknown classification field, so every accessor
@@ -396,7 +449,7 @@ def evaluate_claims(claims: list[dict]) -> ClaimResolution:
     """
     # Drop the synthetic not_classified placeholder and empty claims, but keep
     # rule-authored not_classified declarations (e.g., fastq_modality_unknown).
-    real_claims = [c for c in claims if _claim_declaration(c) is not None and c.get("rule_id") != "not_classified"]
+    real_claims = [c for c in claims if _claim_declaration(c) is not None and c.get("rule_id") != NOT_CLASSIFIED_MARKER]
 
     # Assertive = real-value declarations; a not_classified status means
     # "I looked but can't determine" and doesn't assert a value.
@@ -423,9 +476,11 @@ def evaluate_claims(claims: list[dict]) -> ClaimResolution:
             ResolutionReason.UNANIMOUS if len(assertive_claims) > 1 else ResolutionReason.SINGLE_CLAIM,
         )
 
-    # Assertive declarations disagree — check tiers
-    max_tier = max(c.get("tier", 0) for c in assertive_claims)
-    top_tier_claims = [c for c in assertive_claims if c.get("tier", 0) == max_tier]
+    # Assertive declarations disagree — check tiers. Every assertive claim is built
+    # through _make_claim, which requires a tier, so read it directly: a missing tier
+    # is a bug that should raise here, not silently resolve at a phantom tier 0 (#228).
+    max_tier = max(c["tier"] for c in assertive_claims)
+    top_tier_claims = [c for c in assertive_claims if c["tier"] == max_tier]
     # Declarations are non-None here (real_claims already dropped None ones); the
     # explicit filter restates that so the set is set[str] and sorted() type-checks.
     top_tier_decls = {d for c in top_tier_claims if (d := _claim_declaration(c)) is not None}
@@ -525,33 +580,16 @@ class RuleEngine:
     def _finalize_result(self, result: ExtendedClassificationResult) -> None:
         """Evaluate collected claims for each field and set final values.
 
-        Calls evaluate_claims() per field to resolve competing claims
-        into a single value. Appends conflict or not_classified markers
-        to evidence as appropriate.
+        Calls evaluate_claims() per field to resolve competing claims into a single
+        value, then ``_sync_markers`` records the conflict / not_classified marker
+        when the resolution warrants one. On this fresh pass no prior markers exist,
+        so ``_sync_markers`` only appends.
         """
         for fld in result._CLASSIFICATION_FIELDS:
             claims = result.field_evidence.get(fld, [])
             evaluation = evaluate_claims(claims)
             result.set_field(fld, evaluation.value, evaluation.status)
-
-            if evaluation.is_conflict:
-                result.field_evidence[fld].append(
-                    {
-                        "rule_id": f"conflicting_{fld}_rules",
-                        "reason": (f"Conflicting {fld}: {evaluation.competing_values} — ambiguous"),
-                        "status": NOT_CLASSIFIED,
-                        "competing_values": evaluation.competing_values,
-                        "is_conflict": True,
-                    }
-                )
-            elif evaluation.reason == ResolutionReason.NO_CLAIMS:
-                result.field_evidence[fld].append(
-                    {
-                        "rule_id": "not_classified",
-                        "reason": f"No rule determined a value for {fld}",
-                        "status": NOT_CLASSIFIED,
-                    }
-                )
+            result._sync_markers(fld, evaluation)
 
     def _rule_matches(
         self, rule: UnifiedRule, file_info: ExtendedFileInfo, current: ExtendedClassificationResult

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -120,29 +120,30 @@ def _make_claim(
     return claim
 
 
-# Reserved ``rule_id`` for the synthetic "no rule determined a value" placeholder
-# ``_sync_markers`` appends. It is not a real rule id (issue #228 moves this
-# sentinel out of ``rule_id`` in a follow-up commit); the constant keeps the one
-# magic string in one place until then.
+# Kinds of synthetic resolution marker ``_sync_markers`` appends to explain an
+# absent or ambiguous answer. These are NOT rules: a marker carries a ``marker``
+# kind and no ``rule_id`` (issue #228 — stop overloading ``rule_id`` to hold a
+# sentinel). ``marker`` is a string so more kinds can be added without a schema
+# migration.
 NOT_CLASSIFIED_MARKER = "not_classified"
+CONFLICT_MARKER = "conflict"
 
 
 def _is_synthetic_marker(entry: dict) -> bool:
-    """True if this evidence entry is a synthetic resolution marker.
+    """True if this evidence entry is a synthetic resolution marker rather than a
+    claim from a rule or content classifier.
 
-    Two kinds exist, both appended by ``_sync_markers`` to explain an absent or
-    ambiguous answer rather than to assert one: the ``not_classified`` placeholder
-    (no claim was made) and a conflict marker (claims disagreed at the top tier).
-    A rule-authored ``not_classified`` declaration is a real claim, not a marker —
-    it carries a real ``rule_id`` and no ``is_conflict``, so it is not matched here.
+    A marker is identified by its ``marker`` kind, not by a magic ``rule_id``: a
+    rule-authored ``not_classified`` declaration carries a real ``rule_id`` and no
+    ``marker`` key, so it is a real claim and is not matched here.
     """
-    return entry.get("rule_id") == NOT_CLASSIFIED_MARKER or bool(entry.get("is_conflict"))
+    return "marker" in entry
 
 
 def _not_classified_marker(fld: str) -> dict:
     """The synthetic placeholder that keeps a claimless field's evidence non-empty."""
     return {
-        "rule_id": NOT_CLASSIFIED_MARKER,
+        "marker": NOT_CLASSIFIED_MARKER,
         "reason": f"No rule determined a value for {fld}",
         "status": NOT_CLASSIFIED,
     }
@@ -151,11 +152,10 @@ def _not_classified_marker(fld: str) -> dict:
 def _conflict_marker(fld: str, competing: list[str]) -> dict:
     """The synthetic marker recording that top-tier claims disagreed."""
     return {
-        "rule_id": f"conflicting_{fld}_rules",
+        "marker": CONFLICT_MARKER,
         "reason": f"Conflicting {fld}: {competing} — ambiguous",
         "status": NOT_CLASSIFIED,
         "competing_values": competing,
-        "is_conflict": True,
     }
 
 
@@ -287,14 +287,14 @@ class ExtendedClassificationResult:
     def rules_matched(self) -> list[str]:
         """Deduplicated list of all rule identifiers from field evidence.
 
-        Not limited to YAML-defined rule IDs. Two other sources contribute:
-
-        * The engine itself adds ``not_classified``, ``infer_assay_type`` and
-          ``conflicting_{field}_rules``.
-        * The content classifiers in ``header_classifier`` add their own IDs for
-          signals no YAML rule expresses — ``contig_length_detection``,
-          ``vcf_contig_length``, ``aligned_to_reference``, the ``fasta_*`` and
-          ``bed_*`` IDs, ``rgfa_stable_rank_reference``, and ``fetch_failed``.
+        Not limited to YAML-defined rule IDs, and not exhaustive of evidence:
+        synthetic resolution markers (the ``not_classified`` placeholder and
+        conflict markers) carry no ``rule_id`` and are skipped — they are not
+        rules. The content classifiers in ``header_classifier`` do contribute
+        their own IDs for signals no YAML rule expresses — ``contig_length_detection``,
+        ``vcf_contig_length``, ``aligned_to_reference``, the ``fasta_*`` and
+        ``bed_*`` IDs, ``rgfa_stable_rank_reference``, ``fetch_failed``, and the
+        engine's ``infer_assay_type``.
 
         So a caller must not assume an ID here names a rule in unified_rules.yaml.
         """
@@ -302,6 +302,8 @@ class ExtendedClassificationResult:
         result = []
         for entries in self.field_evidence.values():
             for e in entries:
+                if _is_synthetic_marker(e):
+                    continue
                 rid = e["rule_id"]
                 if rid not in seen:
                     seen.add(rid)
@@ -314,12 +316,15 @@ class ExtendedClassificationResult:
 
         Deduplication is by ``rule_id``, not by reason text, so two rules that
         happen to share a reason both appear — and one rule contributing to
-        several fields appears once.
+        several fields appears once. Synthetic markers carry no ``rule_id`` and
+        are skipped (they are not rules).
         """
         seen = set()
         result = []
         for entries in self.field_evidence.values():
             for e in entries:
+                if _is_synthetic_marker(e):
+                    continue
                 rid = e["rule_id"]
                 if rid not in seen:
                     seen.add(rid)
@@ -447,9 +452,10 @@ def evaluate_claims(claims: list[dict]) -> ClaimResolution:
         ClaimResolution with: value (real or None), status, reason, is_conflict,
         competing_values (non-None iff conflict).
     """
-    # Drop the synthetic not_classified placeholder and empty claims, but keep
-    # rule-authored not_classified declarations (e.g., fastq_modality_unknown).
-    real_claims = [c for c in claims if _claim_declaration(c) is not None and c.get("rule_id") != NOT_CLASSIFIED_MARKER]
+    # Drop synthetic markers (placeholder / conflict) and empty claims, but keep
+    # rule-authored not_classified declarations (e.g., fastq_modality_unknown) —
+    # those are real claims, not markers.
+    real_claims = [c for c in claims if _claim_declaration(c) is not None and not _is_synthetic_marker(c)]
 
     # Assertive = real-value declarations; a not_classified status means
     # "I looked but can't determine" and doesn't assert a value.
@@ -781,7 +787,7 @@ class RuleEngine:
             return
         # Don't infer over conflicts
         assay_evidence = result.field_evidence.get("assay_type", [])
-        if any(e.get("is_conflict") for e in assay_evidence):
+        if any(e.get("marker") == CONFLICT_MARKER for e in assay_evidence):
             return
 
         for assay_rule in self.rules.assay_type_rules:

--- a/src/meta_disco/schema/classification.yaml
+++ b/src/meta_disco/schema/classification.yaml
@@ -133,6 +133,7 @@ classes:
       - value
       - status
       - tier
+      - competing_values
       - source_type
       - authority
       - reference
@@ -224,6 +225,12 @@ slots:
   tier:
     description: The tier at which this evidence fired.
     range: integer
+  competing_values:
+    description: >-
+      On a `conflict` marker, the disagreeing top-tier values that made the field
+      ambiguous. Absent on claims and on the `not_classified` marker.
+    multivalued: true
+    range: string
   source_type:
     description: "Kind of source that produced this evidence (provenance, #90)."
     range: source_type_enum

--- a/src/meta_disco/schema/classification.yaml
+++ b/src/meta_disco/schema/classification.yaml
@@ -121,9 +121,14 @@ classes:
         range: platform_enum
 
   Evidence:
-    description: One piece of supporting evidence for a classification value.
+    description: >-
+      One piece of supporting evidence. Either a claim from a rule or content
+      classifier (carries rule_id + tier), or a synthetic resolution marker
+      (carries marker, no rule_id) recording that no claim was made or that
+      claims conflicted.
     slots:
       - rule_id
+      - marker
       - reason
       - value
       - status
@@ -205,7 +210,15 @@ slots:
 
   # --- Evidence sub-fields ---
   rule_id:
-    description: Identifier of the rule (or synthetic source) that produced this evidence.
+    description: >-
+      Identifier of the rule or content classifier that produced this evidence.
+      Absent on synthetic resolution markers, which carry `marker` instead.
+  marker:
+    description: >-
+      Kind of synthetic resolution marker, when this entry is not a claim but a
+      note about the outcome: `not_classified` (no rule determined a value) or
+      `conflict` (claims disagreed at the top tier). Absent on real claims.
+    range: evidence_marker_enum
   reason:
     description: Human-readable rationale.
   tier:
@@ -359,3 +372,13 @@ enums:
       repository_metadata:
       derivation_inheritance:
       wrangler_annotation:
+
+  evidence_marker_enum:
+    description: >-
+      Kind of synthetic resolution marker on an evidence entry (issue #228): a
+      note that no claim was made or that claims conflicted, rather than a claim.
+    permissible_values:
+      not_classified:
+        description: No rule or content classifier determined a value.
+      conflict:
+        description: Claims disagreed at the top tier, so the field is ambiguous.

--- a/src/meta_disco/schema_vocab.py
+++ b/src/meta_disco/schema_vocab.py
@@ -25,6 +25,10 @@ DIMENSION_ENUMS = {field: f"{field}_enum" for field in CLASSIFICATION_FIELDS}
 # sentinel→status split): classified / not_applicable / not_classified / conflict.
 STATUS_ENUM = "classification_status_enum"
 
+# The enum defining the permissible synthetic-marker kinds on an evidence entry
+# (issue #228): not_classified / conflict.
+MARKER_ENUM = "evidence_marker_enum"
+
 # ``when`` condition keys whose value must be a member of a dimension enum,
 # mapped to that dimension. The rule engine compares these against enum values at
 # match time, so a typo'd value silently never matches rather than erroring — the
@@ -122,6 +126,20 @@ def status_values() -> frozenset[str]:
     if STATUS_ENUM not in enums:
         raise KeyError(f"Schema at {default_schema_path()} is missing enum {STATUS_ENUM!r}")
     return enums[STATUS_ENUM]
+
+
+def marker_values() -> frozenset[str]:
+    """Return the permissible synthetic-marker kinds from the schema.
+
+    The single source of truth for the evidence ``marker`` vocabulary
+    (not_classified / conflict, issue #228), so ``rule_engine``'s marker constants
+    stay pinned to the schema. Raises KeyError (with the schema path) if the schema
+    is missing the marker enum.
+    """
+    enums = _load_enums()
+    if MARKER_ENUM not in enums:
+        raise KeyError(f"Schema at {default_schema_path()} is missing enum {MARKER_ENUM!r}")
+    return enums[MARKER_ENUM]
 
 
 def value_in_vocabulary(field: str, value: object) -> bool:

--- a/tests/fixtures/golden/expected_output.json
+++ b/tests/fixtures/golden/expected_output.json
@@ -6,8 +6,8 @@
           "assay_type": {
             "evidence": [
               {
+                "marker": "not_classified",
                 "reason": "No rule determined a value for assay_type",
-                "rule_id": "not_classified",
                 "status": "not_classified"
               }
             ],
@@ -17,8 +17,8 @@
           "data_modality": {
             "evidence": [
               {
+                "marker": "not_classified",
                 "reason": "No rule determined a value for data_modality",
-                "rule_id": "not_classified",
                 "status": "not_classified"
               }
             ],
@@ -28,8 +28,8 @@
           "data_type": {
             "evidence": [
               {
+                "marker": "not_classified",
                 "reason": "No rule determined a value for data_type",
-                "rule_id": "not_classified",
                 "status": "not_classified"
               }
             ],
@@ -39,8 +39,8 @@
           "platform": {
             "evidence": [
               {
+                "marker": "not_classified",
                 "reason": "No rule determined a value for platform",
-                "rule_id": "not_classified",
                 "status": "not_classified"
               }
             ],
@@ -200,8 +200,8 @@
           "assay_type": {
             "evidence": [
               {
+                "marker": "not_classified",
                 "reason": "No rule determined a value for assay_type",
-                "rule_id": "not_classified",
                 "status": "not_classified"
               }
             ],
@@ -238,8 +238,8 @@
           "platform": {
             "evidence": [
               {
+                "marker": "not_classified",
                 "reason": "No rule determined a value for platform",
-                "rule_id": "not_classified",
                 "status": "not_classified"
               }
             ],
@@ -379,8 +379,8 @@
           "assay_type": {
             "evidence": [
               {
+                "marker": "not_classified",
                 "reason": "No rule determined a value for assay_type",
-                "rule_id": "not_classified",
                 "status": "not_classified"
               }
             ],
@@ -414,8 +414,8 @@
           "platform": {
             "evidence": [
               {
+                "marker": "not_classified",
                 "reason": "No rule determined a value for platform",
-                "rule_id": "not_classified",
                 "status": "not_classified"
               }
             ],
@@ -425,8 +425,8 @@
           "reference_assembly": {
             "evidence": [
               {
+                "marker": "not_classified",
                 "reason": "No rule determined a value for reference_assembly",
-                "rule_id": "not_classified",
                 "status": "not_classified"
               }
             ],

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -116,8 +116,8 @@ class TestBamE2E:
         assert result is not None
         cls = result["classifications"]
         ref_evidence = cls["reference_assembly"]["evidence"]
-        stale = [e for e in ref_evidence if e["rule_id"] == "not_classified"]
-        assert len(stale) == 0, f"Stale not_classified evidence: {stale}"
+        stale = [e for e in ref_evidence if e.get("marker") == "not_classified"]
+        assert len(stale) == 0, f"Stale not_classified marker: {stale}"
 
     def test_star_rnaseq_bam(self):
         """GM20525-10-2.bam — 6.7 GB STAR-aligned RNA-seq."""
@@ -214,8 +214,8 @@ class TestVcfE2E:
         cls = result["classifications"]
         ref = cls["reference_assembly"]
         if field_status(result, "reference_assembly") != NOT_CLASSIFIED:
-            stale = [e for e in ref["evidence"] if e["rule_id"] == "not_classified"]
-            assert len(stale) == 0, f"Stale evidence: {stale}"
+            stale = [e for e in ref["evidence"] if e.get("marker") == "not_classified"]
+            assert len(stale) == 0, f"Stale marker: {stale}"
 
 
 # =============================================================================

--- a/tests/test_header_classifier.py
+++ b/tests/test_header_classifier.py
@@ -17,8 +17,10 @@ def val(result: dict, field: str):
         for fld_val in result.values():
             if isinstance(fld_val, dict) and "evidence" in fld_val:
                 for e in fld_val["evidence"]:
-                    if e.get("rule_id") not in rules:
-                        rules.append(e["rule_id"])
+                    # Synthetic markers carry no rule_id (issue #228); skip them.
+                    rid = e.get("rule_id")
+                    if rid is not None and rid not in rules:
+                        rules.append(rid)
         return rules
     return field_value(result, field)
 

--- a/tests/test_output_shape.py
+++ b/tests/test_output_shape.py
@@ -125,7 +125,10 @@ STUB_PAYLOADS = {
     "fasta": [STUB_HEADER],
     "gfa": [SegmentTag(sn="chr1", sr="0")],
 }
-EVIDENCE_KEYS = {"rule_id", "reason"}
+# Every evidence entry has a reason and is either a claim (rule_id) or a synthetic
+# resolution marker (marker); the two are mutually exclusive (issue #228).
+CLAIM_EVIDENCE_KEYS = {"rule_id", "reason"}
+MARKER_EVIDENCE_KEYS = {"marker", "reason"}
 FIELD_KEYS = {"value", "status", "evidence"}
 RECORD_KEYS = {
     "file_name",
@@ -263,7 +266,11 @@ def test_output_structural_contract(output):
             )
             assert isinstance(entry["evidence"], list)
             for ev in entry["evidence"]:
-                assert set(ev) >= EVIDENCE_KEYS, f"{ftype}.{field} evidence: {set(ev)}"
+                expected = MARKER_EVIDENCE_KEYS if "marker" in ev else CLAIM_EVIDENCE_KEYS
+                assert set(ev) >= expected, f"{ftype}.{field} evidence: {set(ev)}"
+                assert not ("rule_id" in ev and "marker" in ev), (
+                    f"{ftype}.{field} evidence is both claim and marker: {ev}"
+                )
 
 
 def test_output_values_in_vocabulary(output):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -587,14 +587,14 @@ class TestFileTypeConfigs:
 
         # The note lands on the dimension GFA *content* determines (data_type,
         # which the unread rGFA tags might have refined to pangenome.reference).
-        failed = [e for e in cls["data_type"]["evidence"] if e["rule_id"] == "fetch_failed"]
+        failed = [e for e in cls["data_type"]["evidence"] if e.get("rule_id") == "fetch_failed"]
         assert [e["reason"] for e in failed] == ["HTTPError: 404 Not Found"]
 
         # NOT on reference_assembly: GFA content never determines it (no lengths
         # are parsed), so a note there would say a re-fetch could resolve an
         # assembly only the filename can supply.
         assert cls["reference_assembly"]["status"] == NOT_CLASSIFIED
-        assert not [e for e in cls["reference_assembly"]["evidence"] if e["rule_id"] == "fetch_failed"]
+        assert not [e for e in cls["reference_assembly"]["evidence"] if e.get("rule_id") == "fetch_failed"]
 
     def test_fetch_error_on_mc_graph_keeps_the_filename_refinement(self, tmp_path):
         """The `-mc-` token still refines data_type even though content is unreadable."""

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -245,14 +245,18 @@ class TestAddClaim:
     def test_second_claim_accumulates_and_re_resolves(self):
         # Two calls accumulate (append, not replace) and the field re-derives from
         # the full list — here a same-tier disagreement resolves to not_classified,
-        # the semantics the wholesale-site migrations will later adopt (not
-        # last-writer-wins). The resolution rule itself is TestEvaluateClaims' job.
+        # and _sync_markers records a conflict marker explaining why, so add_claim
+        # stays consistent with _finalize_result. The resolution rule itself is
+        # TestEvaluateClaims' job.
         result = ExtendedClassificationResult()
         result.add_claim("reference_assembly", rule_id="a", reason="x", tier=2, value="GRCh38")
         result.add_claim("reference_assembly", rule_id="b", reason="y", tier=2, value="GRCh37")
-        assert len(result.field_evidence["reference_assembly"]) == 2
         assert result.reference_assembly is None
         assert result.status_of("reference_assembly") == NOT_CLASSIFIED
+        evidence = result.field_evidence["reference_assembly"]
+        assert [e["rule_id"] for e in evidence] == ["a", "b", "conflicting_reference_assembly_rules"]
+        assert evidence[-1]["is_conflict"] is True
+        assert set(evidence[-1]["competing_values"]) == {"GRCh38", "GRCh37"}
 
     def test_drops_synthetic_not_classified_placeholder_on_assertive_resolution(self):
         # _finalize_result appends a synthetic {rule_id: "not_classified"} marker
@@ -298,6 +302,31 @@ class TestAddClaim:
         assert result.status_of("reference_assembly") == NOT_CLASSIFIED
         rule_ids = [e["rule_id"] for e in result.field_evidence["reference_assembly"]]
         assert rule_ids == ["looked_but_unsure"], f"synthetic placeholder not dropped: {rule_ids}"
+
+    def test_drops_stale_conflict_marker_on_assertive_resolution(self):
+        # A field left in conflict by _finalize_result carries a conflict marker; a
+        # later higher-tier claim that resolves it must drop the now-stale marker so
+        # the evidence stops asserting ambiguity.
+        result = ExtendedClassificationResult()
+        result.field_evidence["reference_assembly"].extend(
+            [
+                {"rule_id": "r1", "value": "GRCh38", "tier": 3},
+                {"rule_id": "r2", "value": "GRCh37", "tier": 3},
+                {
+                    "rule_id": "conflicting_reference_assembly_rules",
+                    "reason": "Conflicting reference_assembly: ['GRCh37', 'GRCh38'] — ambiguous",
+                    "status": NOT_CLASSIFIED,
+                    "competing_values": ["GRCh37", "GRCh38"],
+                    "is_conflict": True,
+                },
+            ]
+        )
+        result.add_claim(
+            "reference_assembly", rule_id="contig_length_detection", reason="contigs", tier=4, value="CHM13"
+        )
+        assert result.reference_assembly == "CHM13"
+        rule_ids = [e["rule_id"] for e in result.field_evidence["reference_assembly"]]
+        assert rule_ids == ["r1", "r2", "contig_length_detection"], f"stale conflict marker not dropped: {rule_ids}"
 
     def test_rejects_unknown_field_before_appending(self):
         # add_claim delegates field validation to _require_field and raises rather
@@ -604,6 +633,17 @@ class TestEvaluateClaims:
         assert result.status == NOT_CLASSIFIED
         assert result.value is None
         assert result.is_conflict is True
+
+    def test_disagreeing_assertive_claim_without_tier_raises(self):
+        """A tier is required to resolve disagreeing assertive claims; a missing one
+        must raise loudly, not silently resolve at a phantom tier 0 (#228)."""
+        with pytest.raises(KeyError):
+            evaluate_claims(
+                [
+                    {"rule_id": "a", "value": "GRCh38"},  # no tier
+                    {"rule_id": "b", "value": "CHM13", "tier": 2},
+                ]
+            )
 
     def test_not_classified_claims_ignored(self):
         """Claims declaring not_classified (status) don't assert a value."""

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -254,19 +254,20 @@ class TestAddClaim:
         assert result.reference_assembly is None
         assert result.status_of("reference_assembly") == NOT_CLASSIFIED
         evidence = result.field_evidence["reference_assembly"]
-        assert [e["rule_id"] for e in evidence] == ["a", "b", "conflicting_reference_assembly_rules"]
-        assert evidence[-1]["is_conflict"] is True
+        assert [e.get("rule_id") for e in evidence[:2]] == ["a", "b"]
+        assert evidence[-1]["marker"] == "conflict"
+        assert "rule_id" not in evidence[-1]
         assert set(evidence[-1]["competing_values"]) == {"GRCh38", "GRCh37"}
 
     def test_drops_synthetic_not_classified_placeholder_on_assertive_resolution(self):
-        # _finalize_result appends a synthetic {rule_id: "not_classified"} marker
-        # for a field no rule matched. A later content claim that resolves the field
+        # _finalize_result appends a synthetic {marker: "not_classified"} entry for a
+        # field no rule matched. A later content claim that resolves the field
         # assertively makes that "no rule determined a value" marker false, so
         # add_claim drops it (#227) — the evidence reads as the derivation, not a
         # value beside a contradiction.
         result = ExtendedClassificationResult()
         result.field_evidence["reference_assembly"].append(
-            {"rule_id": "not_classified", "reason": "No rule determined a value", "status": NOT_CLASSIFIED}
+            {"marker": "not_classified", "reason": "No rule determined a value", "status": NOT_CLASSIFIED}
         )
         result.add_claim("reference_assembly", rule_id="vcf_contig_length", reason="contigs", tier=4, value="GRCh38")
         assert result.reference_assembly == "GRCh38"
@@ -274,15 +275,15 @@ class TestAddClaim:
         assert rule_ids == ["vcf_contig_length"], f"stale placeholder not dropped: {rule_ids}"
 
     def test_keeps_rule_authored_not_classified_when_dropping_placeholder(self):
-        # Only the *synthetic* placeholder (rule_id "not_classified") is dropped;
-        # a rule that intentionally declares not_classified carries a real rule_id
-        # and stays in the evidence chain even when a higher-tier claim wins.
+        # Only the *synthetic* placeholder (a marker entry) is dropped; a rule that
+        # intentionally declares not_classified carries a real rule_id and no marker,
+        # so it stays in the evidence chain even when a higher-tier claim wins.
         result = ExtendedClassificationResult()
         result.field_evidence["data_modality"].append(
             {"rule_id": "fastq_modality_unknown", "reason": "unknown", "status": NOT_CLASSIFIED, "tier": 3}
         )
         result.field_evidence["data_modality"].append(
-            {"rule_id": "not_classified", "reason": "No rule determined a value", "status": NOT_CLASSIFIED}
+            {"marker": "not_classified", "reason": "No rule determined a value", "status": NOT_CLASSIFIED}
         )
         result.add_claim("data_modality", rule_id="aligned_to_reference", reason="aligned", tier=4, value="genomic")
         assert result.data_modality == "genomic"
@@ -296,7 +297,7 @@ class TestAddClaim:
         # explains the status better than the generic placeholder.
         result = ExtendedClassificationResult()
         result.field_evidence["reference_assembly"].append(
-            {"rule_id": "not_classified", "reason": "No rule determined a value", "status": NOT_CLASSIFIED}
+            {"marker": "not_classified", "reason": "No rule determined a value", "status": NOT_CLASSIFIED}
         )
         result.add_claim("reference_assembly", rule_id="looked_but_unsure", reason="?", tier=4, status=NOT_CLASSIFIED)
         assert result.status_of("reference_assembly") == NOT_CLASSIFIED
@@ -313,11 +314,10 @@ class TestAddClaim:
                 {"rule_id": "r1", "value": "GRCh38", "tier": 3},
                 {"rule_id": "r2", "value": "GRCh37", "tier": 3},
                 {
-                    "rule_id": "conflicting_reference_assembly_rules",
+                    "marker": "conflict",
                     "reason": "Conflicting reference_assembly: ['GRCh37', 'GRCh38'] — ambiguous",
                     "status": NOT_CLASSIFIED,
                     "competing_values": ["GRCh37", "GRCh38"],
-                    "is_conflict": True,
                 },
             ]
         )
@@ -514,11 +514,10 @@ class TestConflictingReferenceRules:
         assert result.reference_assembly == "GRCh38"
 
     def test_conflict_evidence_recorded(self, engine):
-        """Conflict should produce evidence with conflicting_reference_assembly_rules."""
+        """Conflict should produce a conflict marker in reference_assembly evidence."""
         result = engine.classify_extended(FileInfo(filename="CHM13.hg38.gff3.gz"))
         ref_evidence = result.field_evidence.get("reference_assembly", [])
-        rule_ids = [e["rule_id"] for e in ref_evidence]
-        assert "conflicting_reference_assembly_rules" in rule_ids
+        assert any(e.get("marker") == "conflict" for e in ref_evidence)
         # Prior evidence should also be preserved
         assert len(ref_evidence) >= 2
 
@@ -531,24 +530,23 @@ class TestConflictingClassificationFields:
         result = engine.classify_extended(FileInfo(filename="sample_rnaseq_wgs_aligned.bam"))
         assert result.status_of("data_modality") == NOT_CLASSIFIED
         evidence = result.field_evidence.get("data_modality", [])
-        rule_ids = [e["rule_id"] for e in evidence]
-        assert "conflicting_data_modality_rules" in rule_ids
+        assert any(e.get("marker") == "conflict" for e in evidence)
 
     def test_conflict_preserves_prior_evidence(self, engine):
         """Conflict marker is appended to existing evidence, not replaced."""
         result = engine.classify_extended(FileInfo(filename="CHM13.hg38.gff3.gz"))
         evidence = result.field_evidence.get("reference_assembly", [])
-        rule_ids = [e["rule_id"] for e in evidence]
+        rule_ids = [e.get("rule_id") for e in evidence]
         # Both the original rule and the conflict marker should be present
         assert "filename_ref_grch38" in rule_ids or "filename_ref_chm13" in rule_ids
-        assert "conflicting_reference_assembly_rules" in rule_ids
+        assert any(e.get("marker") == "conflict" for e in evidence)
 
     def test_conflict_evidence_has_status_and_competing_values(self, engine):
         """Conflict evidence carries a not_classified status (in the status field,
         not the value slot) and the structured competing_values field."""
         result = engine.classify_extended(FileInfo(filename="CHM13.hg38.gff3.gz"))
         evidence = result.field_evidence.get("reference_assembly", [])
-        conflict = next(e for e in evidence if "conflicting_" in e["rule_id"])
+        conflict = next(e for e in evidence if e.get("marker") == "conflict")
         assert conflict["status"] == NOT_CLASSIFIED
         assert "value" not in conflict
         assert set(conflict["competing_values"]) == {"GRCh38", "CHM13"}
@@ -813,15 +811,16 @@ class TestAssayTypeInference:
         result.set_field("assay_type", status=NOT_CLASSIFIED)
         result.field_evidence["assay_type"] = [
             {
-                "rule_id": "not_classified",
+                "marker": "not_classified",
                 "reason": "No rule determined a value for assay_type",
                 "status": NOT_CLASSIFIED,
             }
         ]
         engine.infer_assay_type(result, file_info)
         assert result.assay_type == "WGS"
-        rule_ids = [e["rule_id"] for e in result.field_evidence["assay_type"]]
-        assert "not_classified" not in rule_ids
+        markers = [e.get("marker") for e in result.field_evidence["assay_type"]]
+        assert "not_classified" not in markers
+        rule_ids = [e.get("rule_id") for e in result.field_evidence["assay_type"]]
         assert "infer_assay_type" in rule_ids
 
 
@@ -864,8 +863,8 @@ class TestSentinelValues:
         checked = 0
         for fld in ["data_modality", "data_type", "platform", "reference_assembly", "assay_type"]:
             evidence = result.field_evidence[fld]
-            nc_evidence = [e for e in evidence if e["rule_id"] == "not_classified"]
-            assert nc_evidence, f"Expected not_classified evidence for {fld}"
+            nc_evidence = [e for e in evidence if e.get("marker") == "not_classified"]
+            assert nc_evidence, f"Expected not_classified marker for {fld}"
             assert fld in nc_evidence[0]["reason"], f"Expected '{fld}' in reason, got: {nc_evidence[0]['reason']}"
             checked += 1
         assert checked == 5

--- a/tests/test_rule_vocabulary.py
+++ b/tests/test_rule_vocabulary.py
@@ -275,6 +275,15 @@ def test_status_values_from_schema():
     assert schema_vocab.status_values() == frozenset({"classified", "not_applicable", "not_classified", "conflict"})
 
 
+def test_marker_constants_match_schema_enum():
+    # rule_engine emits synthetic markers whose `marker` kind must be a member of
+    # the schema's evidence_marker_enum (else LinkML output validation rejects
+    # them). Pin the Python constants to the schema so the two cannot drift (#228).
+    from meta_disco.rule_engine import CONFLICT_MARKER, NOT_CLASSIFIED_MARKER
+
+    assert {NOT_CLASSIFIED_MARKER, CONFLICT_MARKER} == schema_vocab.marker_values()
+
+
 def test_value_in_vocabulary_is_strict_dimension_only():
     # Antecedent/output check: a real dimension value passes; a status does NOT —
     # a status in a when/condition (or an output value) is a bug (#115, Stage 3).


### PR DESCRIPTION
Closes #228.

## What changed

Tightened `evaluate_claims` and revisited the synthetic resolution markers now that the `add_claim` migrations (#227) are complete.

- **Require `claim["tier"]`.** The two `c.get("tier", 0)` reads in `evaluate_claims`' disagree/max-tier block become `c["tier"]`, so a forgotten tier raises a loud `KeyError` at the real call site instead of silently resolving at a phantom tier 0. Safe because every assertive claim is built through `_make_claim` (tier required); the tier-less synthetic markers are non-assertive and filtered out before that block.
- **De-overload `rule_id`.** Synthetic markers no longer smuggle a sentinel into `rule_id`. They now carry a dedicated `marker` kind (`"not_classified"` / `"conflict"`) and **no `rule_id`**, so an evidence entry is unambiguously a claim (`rule_id` + `tier`) or a marker (`marker`).
- **Unify + honest markers.** A shared `_sync_markers`, used by both `_finalize_result` and `add_claim`, strips existing synthetic markers and emits the one matching the current resolution. So `add_claim` now drops a stale conflict marker when a higher-tier claim resolves a prior conflict, and emits a fresh conflict marker if an incremental add creates one — consistent with `_finalize_result`.
- **Schema + drift guard.** `classification.yaml` gains an optional `marker` slot + `evidence_marker_enum`, plus a `competing_values` slot the conflict marker was already emitting. `schema_vocab.marker_values()` + a `test_rule_vocabulary` test pin the Python marker constants to the schema enum, following the repo's established enum-drift pattern.

## Why

Split from #150; the last of epic #203's Lane 4. The `rule_id="not_classified"` sentinel was an illegal state the data model allowed — a fake rule name doing control-flow duty, filtered by magic string in two places, and a footgun (a caller passing that `rule_id` for a real claim would have it silently dropped). #203's north star is making illegal states unrepresentable, so markers get a real identity. And with all `add_claim` sites migrated, no caller omits a tier anymore, so the tier-0 default is no longer load-bearing and becomes a silent-wrong-answer hazard worth removing.

## Assumptions I made

- **Resolution is computed from claims only; markers are pure explanation.** Markers never feed the tier math (they're non-assertive and filtered first), so changing their representation cannot change any field's resolved value or status. This is the safety property the whole change rests on.
- **The work is staged so that property is provable.** Commit 1 (unify `_sync_markers` + tier-tighten) is **byte-identical** on the golden — it proves the refactor changed no output. Commit 2 (flip to a `marker` field) produces a golden diff that is **exclusively** `rule_id: not_classified` → `marker: not_classified` on the 9 placeholders, with **zero `value`/`status` changes** — that diff is the proof the answer held.
- **`rules_matched` / `reasons` skip markers** (they are not rules). Consequence: the legacy batch CSV's `rules_matched`/`reasons` columns (`run_batch_classification.py`) no longer list `not_classified` / `conflicting_*`. This is an improvement and does not affect the canonical per-field JSON output. `infer_assay_type`'s `matched_rules_any` never referenced those ids, so it is unaffected.
- **The conflict marker keeps `competing_values`** (now a modeled schema slot). The only behavior change to `add_claim` is the now-honest conflict-marker handling; in practice a content classifier adds at most one CONTENT_TIER claim per field per call, so `add_claim` creating a *new* conflict is unreachable in production — but it is handled correctly and tested.
- **Schema validation reads `classification.yaml` directly** (via `linkml.validator`), so the `marker`/`competing_values`/enum additions are picked up automatically; the gitignored `schema/generated/` artifacts were regenerated with `make gen`.

## How to verify

Definition of done (from #228), mapped to steps:

1. **Replace the two `c.get("tier", 0)` defaults with `c["tier"]` (loud on a missing tier).**
   `python -m pytest tests/test_rule_engine.py::TestEvaluateClaims -q`. See `test_disagreeing_assertive_claim_without_tier_raises` — a disagreeing assertive claim with no `tier` now raises `KeyError`. Grep confirms no `\.get\("tier"` remains in `evaluate_claims`.
2. **Revisit placeholder handling so the derivation chain stays honest.**
   - `python -m pytest tests/test_rule_engine.py::TestAddClaim -q` — `test_drops_stale_conflict_marker_on_assertive_resolution` (a higher-tier claim resolving a conflict drops the stale marker) and `test_second_claim_accumulates_and_re_resolves` (an incremental add that creates a conflict emits a fresh marker).
   - `test_drops_synthetic_placeholder_even_on_non_assertive_add` and the two `*_no_stale_evidence` tests in `tests/test_evals.py` confirm the `not_classified` placeholder is handled.
   - Marker shape: an evidence entry is a claim (`rule_id`) or a marker (`marker`), never both — `tests/test_output_shape.py` asserts this per entry.
3. **`rule_id` de-overloaded (my #228 note).** The golden diff on this branch shows the 9 placeholders as `{"marker": "not_classified", ...}` with no `rule_id`; grep for `"rule_id": "not_classified"` returns nothing.
4. **No drift between the Python marker constants and the schema enum.**
   `python -m pytest tests/test_rule_vocabulary.py::test_marker_constants_match_schema_enum -q` — asserts `{NOT_CLASSIFIED_MARKER, CONFLICT_MARKER} == schema_vocab.marker_values()`.
5. **Answer unchanged.** `python -m pytest tests/test_output_shape.py tests/test_evals.py -q` (the latter needs the local `data/evidence/anvil/` cache) — resolved values/statuses are pinned by the golden deep-equal and the e2e suite.

Full gate: `make test-all`, `make lint-all`, `make format-check` — all green.
