### PR TITLE
Fix VCF ##contig assembly rules to read the parsed assembly subfield (#221)

### DIFF
--- a/src/meta_disco/rules/unified_rules.yaml
+++ b/src/meta_disco/rules/unified_rules.yaml
@@ -1323,6 +1323,13 @@ rules:
 
   # ---------------------------------------------------------------------------
   # VCF reference detection
+  #
+  # The human primary-assembly GenBank accession GCA_000001405 encodes the
+  # assembly in its version: .1-.14 are GRCh37 (frozen at GRCh37.p13 = .14),
+  # and .15 onward are GRCh38 (.15 base, .16+ are GRCh38 patches). So the
+  # accession sub-patterns below split at that boundary: <=14 -> GRCh37 (a
+  # closed range), >=15 -> GRCh38 (open-ended, to catch future patches). The
+  # durable fix is an accession->assembly deriver (see follow-up issue).
   # ---------------------------------------------------------------------------
   - id: vcf_ref_grch38
     tier: 3
@@ -1330,7 +1337,7 @@ rules:
     when:
       extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
       vcf_header_type: "##reference"
-      vcf_pattern: "(?i)(grch38|hg38|hs38|GCA_000001405\\.15)"
+      vcf_pattern: "(?i)(grch38|hg38|hs38|GCA_000001405\\.(1[5-9]|[2-9]\\d|\\d{3,}))"
     then:
       reference_assembly: GRCh38
     rationale: "##reference line containing GRCh38, hg38, or the GRCh38 GenBank accession indicates variants called against GRCh38"
@@ -1341,7 +1348,7 @@ rules:
     when:
       extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
       vcf_header_type: "##reference"
-      vcf_pattern: "(?i)(grch37|hg19|hs37|GCA_000001405\\.(?!15)\\d+|b37)"
+      vcf_pattern: "(?i)(grch37|hg19|hs37|GCA_000001405\\.(1[0-4]|[1-9])(?!\\d)|b37)"
     then:
       reference_assembly: GRCh37
     rationale: "##reference line containing GRCh37, hg19, b37, or earlier accessions indicates variants called against GRCh37"
@@ -1363,7 +1370,7 @@ rules:
     when:
       extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
       vcf_header_type: "##contig"
-      vcf_pattern: "(?i)(grch38|hg38|hs38|GCA_000001405\\.15)"
+      vcf_pattern: "(?i)(grch38|hg38|hs38|GCA_000001405\\.(1[5-9]|[2-9]\\d|\\d{3,}))"
     then:
       reference_assembly: GRCh38
     rationale: "##contig assembly subfield naming GRCh38, hg38, hs38, or the GRCh38 GenBank accession declares the reference genome"
@@ -1374,7 +1381,7 @@ rules:
     when:
       extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
       vcf_header_type: "##contig"
-      vcf_pattern: "(?i)(grch37|hg19|hs37|GCA_000001405\\.(?!15)\\d+|b37)"
+      vcf_pattern: "(?i)(grch37|hg19|hs37|GCA_000001405\\.(1[0-4]|[1-9])(?!\\d)|b37)"
     then:
       reference_assembly: GRCh37
     rationale: "##contig assembly subfield naming GRCh37, hg19, hs37, b37, or an earlier GenBank accession declares the reference genome"

--- a/src/meta_disco/rules/unified_rules.yaml
+++ b/src/meta_disco/rules/unified_rules.yaml
@@ -1341,7 +1341,7 @@ rules:
     when:
       extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
       vcf_header_type: "##reference"
-      vcf_pattern: "(?i)(grch37|hg19|hs37|GCA_000001405\\.[^5]|b37)"
+      vcf_pattern: "(?i)(grch37|hg19|hs37|GCA_000001405\\.(?!15)\\d+|b37)"
     then:
       reference_assembly: GRCh37
     rationale: "##reference line containing GRCh37, hg19, b37, or earlier accessions indicates variants called against GRCh37"
@@ -1366,7 +1366,7 @@ rules:
       vcf_pattern: "(?i)(grch38|hg38|hs38|GCA_000001405\\.15)"
     then:
       reference_assembly: GRCh38
-    rationale: "##contig assembly subfield naming GRCh38, hg38, or the GRCh38 GenBank accession declares the reference genome"
+    rationale: "##contig assembly subfield naming GRCh38, hg38, hs38, or the GRCh38 GenBank accession declares the reference genome"
 
   - id: vcf_contig_grch37
     tier: 3
@@ -1374,10 +1374,10 @@ rules:
     when:
       extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
       vcf_header_type: "##contig"
-      vcf_pattern: "(?i)(grch37|hg19|hs37|GCA_000001405\\.[^5]|b37)"
+      vcf_pattern: "(?i)(grch37|hg19|hs37|GCA_000001405\\.(?!15)\\d+|b37)"
     then:
       reference_assembly: GRCh37
-    rationale: "##contig assembly subfield naming GRCh37, hg19, b37, or an earlier GenBank accession declares the reference genome"
+    rationale: "##contig assembly subfield naming GRCh37, hg19, hs37, b37, or an earlier GenBank accession declares the reference genome"
 
   - id: vcf_contig_chm13
     tier: 3
@@ -1388,7 +1388,7 @@ rules:
       vcf_pattern: "(?i)(chm13|t2t|hs1)"
     then:
       reference_assembly: CHM13
-    rationale: "##contig assembly subfield naming CHM13 explicitly declares the reference genome"
+    rationale: "##contig assembly subfield naming CHM13, T2T, or hs1 declares the reference genome"
 
   # ---------------------------------------------------------------------------
   # VCF germline variant callers

--- a/src/meta_disco/rules/unified_rules.yaml
+++ b/src/meta_disco/rules/unified_rules.yaml
@@ -1363,10 +1363,10 @@ rules:
     when:
       extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
       vcf_header_type: "##contig"
-      vcf_pattern: "(?i)assembly=(grch38|hg38|GCA_000001405\\.15)"
+      vcf_pattern: "(?i)(grch38|hg38|hs38|GCA_000001405\\.15)"
     then:
       reference_assembly: GRCh38
-    rationale: "##contig lines with assembly=GRCh38 explicitly declare the reference genome"
+    rationale: "##contig assembly subfield naming GRCh38, hg38, or the GRCh38 GenBank accession declares the reference genome"
 
   - id: vcf_contig_grch37
     tier: 3
@@ -1374,10 +1374,10 @@ rules:
     when:
       extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
       vcf_header_type: "##contig"
-      vcf_pattern: "(?i)assembly=(grch37|hg19|b37)"
+      vcf_pattern: "(?i)(grch37|hg19|hs37|GCA_000001405\\.[^5]|b37)"
     then:
       reference_assembly: GRCh37
-    rationale: "##contig lines with assembly=GRCh37 explicitly declare the reference genome"
+    rationale: "##contig assembly subfield naming GRCh37, hg19, b37, or an earlier GenBank accession declares the reference genome"
 
   - id: vcf_contig_chm13
     tier: 3
@@ -1385,10 +1385,10 @@ rules:
     when:
       extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
       vcf_header_type: "##contig"
-      vcf_pattern: "(?i)assembly=(chm13|t2t|hs1)"
+      vcf_pattern: "(?i)(chm13|t2t|hs1)"
     then:
       reference_assembly: CHM13
-    rationale: "##contig lines with assembly=CHM13 explicitly declare the reference genome"
+    rationale: "##contig assembly subfield naming CHM13 explicitly declares the reference genome"
 
   # ---------------------------------------------------------------------------
   # VCF germline variant callers

--- a/src/meta_disco/validators/header_extractors.py
+++ b/src/meta_disco/validators/header_extractors.py
@@ -321,7 +321,10 @@ def match_vcf_header_pattern(header: VCFHeader, header_type: str, pattern: str) 
         pattern: Regex pattern to match
 
     Returns:
-        True if any matching header line contains the pattern
+        True if a matching header line satisfies the pattern. What the pattern is
+        tested against depends on the type: the value for ##reference/##source,
+        the ID for ##INFO/##FORMAT/##FILTER, the ``assembly`` subfield for
+        ##contig, and the raw line for any other (##-prefixed) type.
     """
     compiled = re.compile(pattern, re.IGNORECASE)
 
@@ -330,11 +333,12 @@ def match_vcf_header_pattern(header: VCFHeader, header_type: str, pattern: str) 
     if header_type == "##source" and header.source:
         return bool(compiled.search(header.source))
     if header_type == "##contig" and header.contigs:
+        # Match the parsed ``assembly`` subfield directly — the value is already
+        # isolated in ``fields``, so the rule pattern is a bare name, not ``assembly=``.
         for contig in header.contigs:
-            # Check all fields in the contig line
-            for value in contig.fields.values():
-                if compiled.search(value):
-                    return True
+            assembly = contig.fields.get("assembly")
+            if assembly and compiled.search(assembly):
+                return True
     elif header_type == "##INFO" and header.info_fields:
         for info in header.info_fields:
             info_id = info.fields.get("ID")

--- a/tests/test_header_extractors.py
+++ b/tests/test_header_extractors.py
@@ -75,7 +75,7 @@ class TestMatchVcfHeaderPattern:
         [
             "##reference=file:///GRCh38.fa",
             "##source=MyCaller_v2",
-            "##contig=<ID=chr1,length=248956422>",
+            "##contig=<ID=chr1,length=248956422,assembly=GRCh38>",
             "##INFO=<ID=DP,Number=1,Type=Integer>",
             "##FORMAT=<ID=GT,Number=1,Type=String>",
             '##FILTER=<ID=LowQual,Description="Low quality">',
@@ -91,12 +91,22 @@ class TestMatchVcfHeaderPattern:
         header = parse_vcf_header(self.HEADER)
         assert match_vcf_header_pattern(header, "##source", "MyCaller")
 
-    def test_contig_value_pattern_matches(self):
-        # Scans each contig field value individually, so this matches a bare
-        # value. It does NOT exercise the shipped ``assembly=<name>`` contig
-        # rules, which can't match this scanner (see #221).
+    def test_contig_assembly_pattern_matches(self):
+        # ##contig matches against the parsed ``assembly`` subfield, so the
+        # shipped bare-name rule pattern (no ``assembly=`` prefix) fires (#221).
         header = parse_vcf_header(self.HEADER)
-        assert match_vcf_header_pattern(header, "##contig", "248956422")
+        assert match_vcf_header_pattern(header, "##contig", r"(?i)(grch38|hg38|hs38|GCA_000001405\.15)")
+
+    def test_contig_non_assembly_subfield_does_not_match(self):
+        # Only the assembly subfield is scanned: a bare contig length value is
+        # not matchable, which is what made the pre-#221 scanner unable to see
+        # the ``assembly=`` rules.
+        header = parse_vcf_header(self.HEADER)
+        assert not match_vcf_header_pattern(header, "##contig", "248956422")
+
+    def test_contig_wrong_assembly_does_not_match(self):
+        header = parse_vcf_header(self.HEADER)
+        assert not match_vcf_header_pattern(header, "##contig", r"(?i)(grch37|hg19|hs37|GCA_000001405\.[^5]|b37)")
 
     def test_info_id_pattern_matches(self):
         header = parse_vcf_header(self.HEADER)

--- a/tests/test_header_extractors.py
+++ b/tests/test_header_extractors.py
@@ -91,22 +91,25 @@ class TestMatchVcfHeaderPattern:
         header = parse_vcf_header(self.HEADER)
         assert match_vcf_header_pattern(header, "##source", "MyCaller")
 
-    def test_contig_assembly_pattern_matches(self):
-        # ##contig matches against the parsed ``assembly`` subfield, so the
-        # shipped bare-name rule pattern (no ``assembly=`` prefix) fires (#221).
-        header = parse_vcf_header(self.HEADER)
-        assert match_vcf_header_pattern(header, "##contig", r"(?i)(grch38|hg38|hs38|GCA_000001405\.15)")
+    def test_contig_matches_against_assembly_subfield(self):
+        # Processor test: ##contig dispatch reads the ``assembly`` subfield
+        # (#221), checked with a representative value. The real rule regexes
+        # (accession ranges, aliases) are exercised against the loaded rules
+        # end-to-end in test_rule_engine.py, not duplicated here.
+        header = parse_vcf_header(self.HEADER)  # contig carries assembly=GRCh38
+        assert match_vcf_header_pattern(header, "##contig", "GRCh38")
 
-    def test_contig_non_assembly_subfield_does_not_match(self):
-        # Only the assembly subfield is scanned: a bare contig length value is
-        # not matchable, which is what made the pre-#221 scanner unable to see
-        # the ``assembly=`` rules.
+    def test_contig_ignores_non_assembly_subfields(self):
+        # Only the ``assembly`` subfield is read: the contig ``length`` value is
+        # not matchable. The pre-#221 code searched every subfield, which is why
+        # the assembly rules could never fire.
         header = parse_vcf_header(self.HEADER)
         assert not match_vcf_header_pattern(header, "##contig", "248956422")
 
-    def test_contig_wrong_assembly_does_not_match(self):
+    def test_contig_no_match_when_assembly_value_differs(self):
+        # assembly is GRCh38, so a value that isn't present returns False.
         header = parse_vcf_header(self.HEADER)
-        assert not match_vcf_header_pattern(header, "##contig", r"(?i)(grch37|hg19|hs37|GCA_000001405\.[^5]|b37)")
+        assert not match_vcf_header_pattern(header, "##contig", "GRCh37")
 
     def test_info_id_pattern_matches(self):
         header = parse_vcf_header(self.HEADER)

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -151,17 +151,22 @@ class TestVariantFiles:
     @pytest.mark.parametrize(
         ("header_line", "expected"),
         [
-            # The GRCh38 accession .15 must NOT also match the GRCh37 rule (whose
-            # old GCA_000001405\.[^5] matched the leading .1), which would resolve
-            # to a GRCh37/GRCh38 conflict. Covers both the ##contig and
-            # ##reference rule families (#221 review).
-            ("##contig=<ID=chr1,length=248956422,assembly=GCA_000001405.15>", "GRCh38"),
+            # GCA_000001405 encodes the assembly in its version: .1-.14 are GRCh37
+            # (frozen at .14), .15+ are GRCh38 (.15 base, .16+ patches). The rules
+            # must split at that boundary, in both the ##contig and ##reference
+            # families (#221 review). In particular .16+ are real GRCh38 patch
+            # accessions and must NOT fall through to GRCh37.
             ("##contig=<ID=chr1,length=248956422,assembly=GCA_000001405.14>", "GRCh37"),
-            ("##reference=file:///ref/GCA_000001405.15.fa", "GRCh38"),
+            ("##contig=<ID=chr1,length=248956422,assembly=GCA_000001405.15>", "GRCh38"),
+            ("##contig=<ID=chr1,length=248956422,assembly=GCA_000001405.16>", "GRCh38"),
+            ("##contig=<ID=chr1,length=248956422,assembly=GCA_000001405.26>", "GRCh38"),
             ("##reference=file:///ref/GCA_000001405.14.fa", "GRCh37"),
+            ("##reference=file:///ref/GCA_000001405.15.fa", "GRCh38"),
+            ("##reference=file:///ref/GCA_000001405.16.fa", "GRCh38"),
+            ("##reference=file:///ref/GCA_000001405.26.fa", "GRCh38"),
         ],
     )
-    def test_vcf_grch38_accession_not_confused_with_grch37(self, engine, header_line, expected):
+    def test_vcf_gca_accession_version_maps_to_correct_assembly(self, engine, header_line, expected):
         ext_info = ExtendedFileInfo(filename="sample.vcf.gz", vcf_header=header_line)
         result = engine.classify_extended(ext_info, include_tier3=True)
         assert result.reference_assembly == expected

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -7,7 +7,6 @@ from meta_disco.models import (
     CLASSIFIED,
     NOT_APPLICABLE,
     NOT_CLASSIFIED,
-    ClassificationResult,
     FileInfo,
 )
 from meta_disco.rule_engine import (
@@ -111,6 +110,43 @@ class TestVariantFiles:
         result = engine.classify(FileInfo(filename="NA19189.chr2.hg38.vcf.gz"))
         assert result.data_modality == "genomic"
         assert result.reference_assembly == "GRCh38"
+
+    def test_vcf_contig_assembly_subfield_sets_reference(self, engine):
+        """A ##contig assembly= subfield sets reference_assembly end-to-end (#221).
+
+        Filename carries no reference token, so GRCh38 can only come from the
+        tier-3 ``vcf_contig_grch38`` rule reading the parsed assembly subfield.
+        """
+        ext_info = ExtendedFileInfo(
+            filename="sample.vcf.gz",
+            vcf_header="##contig=<ID=chr1,length=248956422,assembly=GRCh38>",
+        )
+        result = engine.classify_extended(ext_info, include_tier3=True)
+        assert result.reference_assembly == "GRCh38"
+        rule_ids = [e["rule_id"] for e in result.field_evidence["reference_assembly"] if "rule_id" in e]
+        assert "vcf_contig_grch38" in rule_ids, f"Expected vcf_contig_grch38, got {rule_ids}"
+
+    @pytest.mark.parametrize(
+        ("assembly", "expected"),
+        [
+            ("GRCh38", "GRCh38"),
+            ("hg38", "GRCh38"),
+            ("hs38", "GRCh38"),  # alias aligned with ##reference (#221 follow-up)
+            ("GRCh37", "GRCh37"),
+            ("hs37", "GRCh37"),  # alias aligned with ##reference (#221 follow-up)
+            ("hg19", "GRCh37"),
+            ("CHM13", "CHM13"),
+            ("T2T-CHM13v2.0", "CHM13"),
+        ],
+    )
+    def test_vcf_contig_assembly_aliases_classify(self, engine, assembly, expected):
+        """##contig assembly aliases classify to the same set as ##reference (#221)."""
+        ext_info = ExtendedFileInfo(
+            filename="sample.vcf.gz",
+            vcf_header=f"##contig=<ID=chr1,length=248956422,assembly={assembly}>",
+        )
+        result = engine.classify_extended(ext_info, include_tier3=True)
+        assert result.reference_assembly == expected
 
 
 class TestThenStatus:

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -148,6 +148,24 @@ class TestVariantFiles:
         result = engine.classify_extended(ext_info, include_tier3=True)
         assert result.reference_assembly == expected
 
+    @pytest.mark.parametrize(
+        ("header_line", "expected"),
+        [
+            # The GRCh38 accession .15 must NOT also match the GRCh37 rule (whose
+            # old GCA_000001405\.[^5] matched the leading .1), which would resolve
+            # to a GRCh37/GRCh38 conflict. Covers both the ##contig and
+            # ##reference rule families (#221 review).
+            ("##contig=<ID=chr1,length=248956422,assembly=GCA_000001405.15>", "GRCh38"),
+            ("##contig=<ID=chr1,length=248956422,assembly=GCA_000001405.14>", "GRCh37"),
+            ("##reference=file:///ref/GCA_000001405.15.fa", "GRCh38"),
+            ("##reference=file:///ref/GCA_000001405.14.fa", "GRCh37"),
+        ],
+    )
+    def test_vcf_grch38_accession_not_confused_with_grch37(self, engine, header_line, expected):
+        ext_info = ExtendedFileInfo(filename="sample.vcf.gz", vcf_header=header_line)
+        result = engine.classify_extended(ext_info, include_tier3=True)
+        assert result.reference_assembly == expected
+
 
 class TestThenStatus:
     """A rule authoring a non-classified status via `then.status` (#133)."""


### PR DESCRIPTION
Closes #221

## What changed

- **`header_extractors.py`** — `match_vcf_header_pattern`'s `##contig` branch now reads the parsed `assembly` subfield directly (`contig.fields.get("assembly")`) and matches the rule pattern against that value, instead of scanning every contig field value in isolation. Docstring updated to state, per header type, what the pattern is tested against.
- **`unified_rules.yaml`** — the three `vcf_contig_*` patterns drop the now-redundant `assembly=` prefix (`(?i)(grch38|...)`), and their alias sets are aligned with the richer `##reference` patterns (added `hs38`, `hs37`, and the GRCh37 GenBank accession). Rationale strings updated to match.
- **Tests** — unit tests over the shipped patterns (positive assembly match; bare non-assembly subfield does not match; wrong-assembly does not match); an end-to-end `classify_extended` test that a real `##contig=<...,assembly=GRCh38>` classifies as GRCh38 via `vcf_contig_grch38`; and a parametrized end-to-end test over all aligned aliases. Removed a pre-existing unused import flagged by Pyright.

## Why

The three `##contig` reference-assembly rules never matched. The matcher split each contig line into `key=value` pairs and then scanned each **value** (`chr1`, `248956422`, `GRCh38`) against a pattern requiring the literal `assembly=` substring — which had already been split off into the key. So contig-based assembly detection had effectively never fired (masked in practice by `##reference` rules, filename tokens, and the content-tier `vcf_contig_length` rule). This predates #210, which only surfaced it.

Reading the already-parsed `assembly` value is the direct fix: no lossy text reconstruction, and it mirrors the per-type field dispatch the matcher already uses (`ID` for `##INFO`/`##FORMAT`/`##FILTER`).

## Assumptions I made

- **`assembly` key is lowercase.** `contig.fields.get("assembly")` is an exact-case lookup. The VCF spec reserves the lowercase `assembly` contig key (as with `ID`, `length`, `md5`), and GATK/bcftools emit it lowercase, so this is spec-correct. A nonstandard-case key would silently miss — consistent with the repo's accuracy-over-coverage principle (no wrong answer, just no claim).
- **Narrowing to the `assembly` subfield is safe.** Only the three assembly rules use `vcf_header_type: ##contig`; no rule matches other contig subfields. Any prior match on a non-assembly value would have been an accidental false positive.
- **Golden fixture intentionally unchanged.** The issue mentioned regenerating it, but the golden VCF input (`test_output_shape.py`) uses a stub header with no `##contig` lines, so this change produces no golden diff. `test_output_shape` passes unchanged, confirming no output drift — no regeneration was needed.
- **Known pre-existing quirk, now shared by both families:** the GRCh37 pattern's `GCA_000001405\.[^5]` also matches the GRCh38 accession `GCA_000001405.15` (the `[^5]` matches the `1`), so a bare-accession assembly value would fire both rules → conflict. This already exists in the `##reference` rules; aligning the contig patterns keeps the two families consistent rather than introducing a new divergence. Candidate for a follow-up to fix across both.
- Filed #233 for the pre-existing, now test-only `get_contig_lines` helper (this PR did not cause it; overlaps with #188).

## How to verify

Definition of done from #221:

- [x] **Scanner/pattern mismatch fixed so contig assembly detection fires.** `match_vcf_header_pattern` reads the `assembly` subfield.
- [x] **A test proves a real `##contig=<...,assembly=GRCh38>` classifies as GRCh38.** `tests/test_rule_engine.py::TestVariantFiles::test_vcf_contig_assembly_subfield_sets_reference` (end-to-end) and the parametrized `test_vcf_contig_assembly_aliases_classify`.
- [x] **Golden fixture handled.** No diff needed (stub header has no contigs); `test_output_shape` passes unchanged.
- [x] **The misleading `test_contig_value_pattern_matches` is replaced.** Now `test_contig_assembly_pattern_matches` + `test_contig_non_assembly_subfield_does_not_match` + `test_contig_wrong_assembly_does_not_match`.

Manual steps:

1. `make test-all` — root + schema suites pass (includes the new contig/alias tests).
2. `make lint && make format-check && make type` — all clean.
3. Targeted check: `python -m pytest tests/test_header_extractors.py tests/test_rule_engine.py -q -k contig` — the contig assembly and alias cases pass.
4. Confirm no output drift: `python -m pytest tests/test_output_shape.py -q` passes without regenerating the golden.