### PR TITLE
Lift shared-owned and stale sections out of CLAUDE.md (#235)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,55 +84,6 @@ evidence}` entry — plus the controlled vocabulary:
   Give any content-read claim `tier=CONTENT_TIER`, never a hard-coded number
   (issue #226).
 
-## Team roster
-
-| Name   | GitHub handle |
-|--------|---------------|
-| Dave   | NoopDog       |
-| Fran   | frano-m       |
-| Hunter | hunterckx     |
-| Mim    | MillenniumFalconMechanic |
-
-"Assign to Fran" always means the GitHub handle in this table. Never guess a
-handle. If someone is not in this table, ask.
-
-## Error handling philosophy
-
-Validate at trust boundaries only, and trust everything inside them.
-
-- The trust boundaries are: user input, network responses, file contents,
-  environment variables, CLI arguments, and data crossing a public API.
-  Validate at the boundary, once, and fail with a clear error that names
-  what was wrong.
-- Inside the boundary, where our functions call our functions, do not check
-  for null, missing, or wrong-typed values. A caller passing bad input is a
-  bug in the caller, so let the code throw. A stack trace at the real call
-  site is what enables the fix. A defensive fallback hides the bug.
-- Never silently coerce, default, or catch-and-continue to "handle" bad
-  input, and never rewrite a caller's input for backward compatibility. The
-  removal of the `classification_rules.yaml` legacy redirect (#169, #170)
-  is the model: update callers or fail loudly, do not add a silent shim.
-- When a reviewer suggests defensive handling of internal inputs, decline
-  and cite this section.
-
-## Workflow
-
-1. Create a GitHub issue for every change, with a definition-of-done
-   checklist. The issue is the record that the result is checked against.
-2. Create a feature branch `noopdog/{issue#}-short-description`.
-3. Implement with tests. Run `make test-all` from the repo root before
-   committing. It is the root-level aggregator that runs both the root
-   suite and the schema suite. Plain `make test` runs the root suite only,
-   so it is not sufficient before pushing.
-4. When the code is complete, announce it and run `/cc:auto-review`. That
-   skill runs the local reviews, has you triage the findings, stops at a
-   push gate, opens the PR, and drives the Copilot feedback rounds to
-   merge-ready. It is the canonical definition of the review and PR cycle;
-   do not hand-run those steps here.
-
-A human reads the PR against the issue's definition of done and merges it.
-Claude never merges.
-
 ## Surprises
 
 You may encounter an environment, tool, dependency, or constraint that the
@@ -140,21 +91,6 @@ user never mentioned and that changes your approach. Examples: an unexpected
 conda environment, a missing credential, a second uv project. When that
 happens, STOP and ask before proceeding. Do not work around the surprise
 silently.
-
-## Communication
-
-- Do not use analogies or metaphors.
-- Lead with the outcome in one sentence.
-- Keep status updates to one line.
-- Flag your assumptions explicitly.
-
-## GitHub API discipline
-
-- Never enumerate a full project board, and never paginate more than two
-  pages to find one item.
-- Never fetch issues or pull requests in a loop. Use a single search or
-  list call with filters instead.
-- If you get a rate-limit response, STOP and tell the user. Do not retry.
 
 ## Git Discipline
 


### PR DESCRIPTION
Closes #235

## What changed

Removed 5 sections from `CLAUDE.md` (64-line deletion, no additions):

- **Now owned by `cc/shared/general.md`:** `## Team roster`, `## Error handling philosophy`, `## Communication`, `## GitHub API discipline`.
- **Stale restated process:** `## Workflow`.

No `cc:shared:*` markers were hand-added — fleet apply owns region insertion. Repo-specific sections are untouched: Project Overview, Architecture, Commands, Schema Details, Design Principles, Surprises, Git Discipline, Code Change Discipline, Docstring & Comment Accuracy, Environment.

## Why

`CLAUDE.md` predates the cc-claude-tools fleet sync. The fleet reconcile only manages marked `cc:shared:*` regions and never edits content outside them, so adopting meta-disco as-is would insert the shared regions *alongside* the existing hand-authored copies — two copies of each, with the stale versions still live. The duplicates must be lifted out by hand first; the fleet can't tell an intended repo-specific section from a duplicate-to-delete. The `## Workflow` section additionally named the old `/cc:auto-review` skill and a push gate removed in cc-claude-tools #148/#149, so it had already drifted.

## Assumptions I made

- **`## Git Discipline` is kept.** The issue listed it in neither Remove nor Keep. I checked `general.md`: it owns "Commits and pull request titles" (Conventional Commits / PR-title conventions) — a *different* topic from meta-disco's Git Discipline (amend / force-push / rebase). So it is not shared-owned and stays.
- **The repo-specific error-handling example is dropped with its section.** meta-disco's `## Error handling philosophy` cited the `classification_rules.yaml` #169/#170 redirect removal as "the model"; `general.md`'s version is generic. Per the issue, the section is general.md-owned and removed; the generic principle returns via fleet apply.
- **Interim gap is intended.** This PR only *removes*; the shared regions are not inserted until fleet apply runs, so `CLAUDE.md` temporarily lacks these sections. That is the issue's designed sequence.
- **Workflow is deleted, not replaced.** No shared fragment restates the review/PR cycle — the `/cc:build` and `/cc:self-review` skills own it — so removing the section means the repo relies on the skills and cannot drift again.

## How to verify

Definition of done from #235:

- [x] **The four `general.md`-owned sections are removed.** `grep -nE '^## (Team roster|Error handling philosophy|Communication|GitHub API discipline)$' CLAUDE.md` returns nothing.
- [x] **`## Workflow` is removed.** `grep -n '^## Workflow$' CLAUDE.md` returns nothing.
- [x] **All genuinely repo-specific sections remain, unchanged in meaning.** `grep -nE '^## ' CLAUDE.md` shows: Project Overview, Architecture, Commands, Schema Details, Design Principles, Surprises, Git Discipline, Code Change Discipline, Docstring & Comment Accuracy, Environment.
- [x] **No `cc:shared:*` markers hand-added.** `grep -n 'cc:shared' CLAUDE.md` returns nothing.
- [x] **`CLAUDE.md` reads coherently, no dangling references.** No internal cross-refs to removed sections; repo-wide grep finds no references to the removed section names outside the plugin cache.

Manual check: `git diff main -- CLAUDE.md` shows only deletions; read the Design Principles → Surprises → Git Discipline seams to confirm they flow.