### PR TITLE
FileName value object + engine routes through it; bytes-only size (#241)

### DIFF
--- a/src/meta_disco/file_name.py
+++ b/src/meta_disco/file_name.py
@@ -1,0 +1,81 @@
+"""The parsed filename fact.
+
+A file's name answers several unrelated questions at once — what tokens it
+carries (`rnaseq`, `chm13`), what its extension is, whether it is compressed or
+archived. `FileName` parses those apart once so the rest of the system reads a
+structured fact instead of re-deriving from a raw string (epic #242).
+
+This is the foundation increment (#241): the engine consumes ``extension``; the
+follow-ups separate a derived ``format`` from the extension (#243), split the
+compression/archive wrappers out of the extension vocabulary (#244), and thread
+the parsed ``FileName`` from the load boundary (#246).
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .rule_loader import UnifiedRules
+
+# Compression and archive suffixes — "wrappers" around the format, not the
+# format itself. Kept as advice; in this foundation they are informational and
+# may overlap the (still-compound) ``extension`` — the clean split is #244.
+WRAPPER_SUFFIXES = (".gz", ".bgz", ".bz2", ".xz", ".zip", ".tar")
+
+
+@dataclass(frozen=True)
+class FileName:
+    """A filename parsed into its parts.
+
+    ``raw`` is the name as given (never empty — the input contract guarantees
+    ``^.+$``, so a nameless record is diverted to ``validation_failed`` and
+    never reaches a parser). ``extension`` is the known extension the rules key
+    on, or ``None`` when the name carries no known extension — never the junk
+    last-dot suffix ``UnifiedRules.extract_extension`` returns
+    (``"hprc-v1.0-mc-grch38"`` → ``".0-mc-grch38"``). ``wrappers`` are the
+    trailing compression/archive suffixes, in name order. ``stem`` is the name
+    with the extension removed.
+    """
+
+    raw: str
+    stem: str
+    extension: str | None
+    wrappers: tuple[str, ...]
+
+    @classmethod
+    def parse(cls, raw: str, rules: "UnifiedRules") -> "FileName":
+        """Parse ``raw`` against the rule vocabulary.
+
+        ``extension`` matches ``UnifiedRules.extract_extension`` for every name
+        that has a known extension (a compound like ``.vcf.gz``, else a simple
+        suffix the ``extension_map`` knows), and is ``None`` otherwise — where
+        ``extract_extension`` would have returned a junk last-dot suffix that
+        matched no rules anyway. So routing is unchanged; the value is that the
+        absence of an extension is now stated honestly.
+        """
+        lower = raw.lower()
+
+        extension = None
+        for ext in rules.COMPOUND_EXTENSIONS:
+            if lower.endswith(ext):
+                extension = ext
+                break
+        if extension is None and "." in raw:
+            simple = "." + raw.rsplit(".", 1)[1].lower()
+            if simple in rules.extension_map:
+                extension = simple
+
+        wrappers: list[str] = []
+        rest = lower
+        while True:
+            for suffix in WRAPPER_SUFFIXES:
+                if rest.endswith(suffix):
+                    wrappers.append(suffix)
+                    rest = rest[: -len(suffix)]
+                    break
+            else:
+                break
+        wrappers.reverse()  # name order: "x.tar.gz" -> (".tar", ".gz")
+
+        stem = raw[: -len(extension)] if extension else raw
+        return cls(raw=raw, stem=stem, extension=extension, wrappers=tuple(wrappers))

--- a/src/meta_disco/file_name.py
+++ b/src/meta_disco/file_name.py
@@ -2,25 +2,18 @@
 
 A file's name answers several unrelated questions at once — what tokens it
 carries (`rnaseq`, `chm13`), what its extension is, whether it is compressed or
-archived. `FileName` parses those apart once so the rest of the system reads a
+archived. ``FileName`` parses those apart once so the rest of the system reads a
 structured fact instead of re-deriving from a raw string (epic #242).
 
-This is the foundation increment (#241): the engine consumes ``extension``; the
-follow-ups separate a derived ``format`` from the extension (#243), split the
+``FileName`` is a pure data type; it is built by ``UnifiedRules.parse_file_name``
+(the parse is vocabulary-gated, so it lives with the rules). This is the
+foundation increment (#241): the engine consumes ``extension``; the follow-ups
+separate a derived ``format`` from the extension (#243), split the
 compression/archive wrappers out of the extension vocabulary (#244), and thread
 the parsed ``FileName`` from the load boundary (#246).
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .rule_loader import UnifiedRules
-
-# Compression and archive suffixes — "wrappers" around the format, not the
-# format itself. Kept as advice; in this foundation they are informational and
-# may overlap the (still-compound) ``extension`` — the clean split is #244.
-WRAPPER_SUFFIXES = (".gz", ".bgz", ".bz2", ".xz", ".zip", ".tar")
 
 
 @dataclass(frozen=True)
@@ -41,41 +34,3 @@ class FileName:
     stem: str
     extension: str | None
     wrappers: tuple[str, ...]
-
-    @classmethod
-    def parse(cls, raw: str, rules: "UnifiedRules") -> "FileName":
-        """Parse ``raw`` against the rule vocabulary.
-
-        ``extension`` matches ``UnifiedRules.extract_extension`` for every name
-        that has a known extension (a compound like ``.vcf.gz``, else a simple
-        suffix the ``extension_map`` knows), and is ``None`` otherwise — where
-        ``extract_extension`` would have returned a junk last-dot suffix that
-        matched no rules anyway. So routing is unchanged; the value is that the
-        absence of an extension is now stated honestly.
-        """
-        lower = raw.lower()
-
-        extension = None
-        for ext in rules.COMPOUND_EXTENSIONS:
-            if lower.endswith(ext):
-                extension = ext
-                break
-        if extension is None and "." in raw:
-            simple = "." + raw.rsplit(".", 1)[1].lower()
-            if simple in rules.extension_map:
-                extension = simple
-
-        wrappers: list[str] = []
-        rest = lower
-        while True:
-            for suffix in WRAPPER_SUFFIXES:
-                if rest.endswith(suffix):
-                    wrappers.append(suffix)
-                    rest = rest[: -len(suffix)]
-                    break
-            else:
-                break
-        wrappers.reverse()  # name order: "x.tar.gz" -> (".tar", ".gz")
-
-        stem = raw[: -len(extension)] if extension else raw
-        return cls(raw=raw, stem=stem, extension=extension, wrappers=tuple(wrappers))

--- a/src/meta_disco/file_name.py
+++ b/src/meta_disco/file_name.py
@@ -2,15 +2,16 @@
 
 A file's name answers several unrelated questions at once — what tokens it
 carries (`rnaseq`, `chm13`), what its extension is, whether it is compressed or
-archived. ``FileName`` parses those apart once so the rest of the system reads a
-structured fact instead of re-deriving from a raw string (epic #242).
+archived. ``FileName`` parses those apart so a caller reads a structured fact
+instead of re-deriving from a raw string (epic #242).
 
 ``FileName`` is a pure data type; it is built by ``UnifiedRules.parse_file_name``
 (the parse is vocabulary-gated, so it lives with the rules). This is the
-foundation increment (#241): the engine consumes ``extension``; the follow-ups
-separate a derived ``format`` from the extension (#243), split the
-compression/archive wrappers out of the extension vocabulary (#244), and thread
-the parsed ``FileName`` from the load boundary (#246).
+foundation increment (#241): only ``extension`` is consumed so far — the engine
+parses at its own derivation site and reads it; the follow-ups separate a
+derived ``format`` from the extension (#243), split the compression/archive
+wrappers out of the extension vocabulary (#244), and thread the parsed
+``FileName`` from the load boundary (#246).
 """
 
 from dataclasses import dataclass
@@ -20,9 +21,10 @@ from dataclasses import dataclass
 class FileName:
     """A filename parsed into its parts.
 
-    ``raw`` is the name as given (never empty — the input contract guarantees
-    ``^.+$``, so a nameless record is diverted to ``validation_failed`` and
-    never reaches a parser). ``extension`` is the known extension the rules key
+    ``raw`` is the name as given. In the pipeline it is never empty — the input
+    contract (``^.+$``) diverts a nameless record to ``validation_failed`` before
+    it is parsed — though ``FileName`` itself does not re-validate. ``extension``
+    is the known extension the rules key
     on, or ``None`` when the name carries no known extension — never the junk
     last-dot suffix ``UnifiedRules.extract_extension`` returns
     (``"hprc-v1.0-mc-grch38"`` → ``".0-mc-grch38"``). ``wrappers`` are the

--- a/src/meta_disco/file_name.py
+++ b/src/meta_disco/file_name.py
@@ -26,8 +26,10 @@ class FileName:
     on, or ``None`` when the name carries no known extension — never the junk
     last-dot suffix ``UnifiedRules.extract_extension`` returns
     (``"hprc-v1.0-mc-grch38"`` → ``".0-mc-grch38"``). ``wrappers`` are the
-    trailing compression/archive suffixes, in name order. ``stem`` is the name
-    with the extension removed.
+    trailing compression/archive suffixes, in name order. ``stem`` is the
+    token-carrying part: the name with its known ``extension`` removed, or —
+    when there is none — its trailing ``wrappers`` stripped (an unknown suffix
+    like ``.xyz`` is kept, since it is neither a known extension nor a wrapper).
     """
 
     raw: str

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -113,7 +113,6 @@ def classify_from_header(
         filename=file_name or "",
         file_format=".bam",
         file_size=file_size,
-        file_size_gb=file_size / 1e9 if file_size is not None else None,
         bam_header=header_text,
     )
 
@@ -198,7 +197,6 @@ def classify_from_vcf_header(
         filename=file_name or "",
         file_format=".vcf.gz",
         file_size=file_size,
-        file_size_gb=file_size / 1e9 if file_size is not None else None,
         vcf_header=header_text,
     )
 
@@ -295,7 +293,6 @@ def classify_from_fastq_header(
         filename=file_name or "",
         file_format=".fastq.gz",
         file_size=file_size,
-        file_size_gb=file_size / 1e9 if file_size is not None else None,
         fastq_first_read=first_read,
     )
 
@@ -464,7 +461,6 @@ def classify_without_content(
     file_info = ExtendedFileInfo(
         filename=filename,
         file_size=file_size,
-        file_size_gb=file_size / 1e9 if file_size is not None else None,
     )
     result = _get_engine().classify_extended(file_info, include_tier3=False)
 
@@ -917,7 +913,6 @@ def classify_from_bed_signals(
         filename=file_name or "",
         file_format=".bed",
         file_size=file_size,
-        file_size_gb=file_size / 1e9 if file_size is not None else None,
         dataset_title=dataset_title,
     )
 

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -6,6 +6,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from .file_name import FileName
 from .models import (
     CLASSIFICATION_FIELDS,
     CLASSIFIED,
@@ -40,7 +41,6 @@ class ExtendedFileInfo:
 
     filename: str
     file_size: int | None = None
-    file_size_gb: float | None = None
     dataset_title: str | None = None
     file_format: str | None = None
 
@@ -61,17 +61,21 @@ class ExtendedFileInfo:
     _parsed_bam_header: "SAMHeader" = field(init=False, repr=False, compare=False)
     _parsed_vcf_header: "VCFHeader" = field(init=False, repr=False, compare=False)
 
+    @property
+    def file_size_gb(self) -> float | None:
+        """Size in decimal GB (not GiB), derived from ``file_size`` bytes.
+
+        Kept as a read-only accessor rather than stored state so bytes are the
+        single source of truth; the assay-size rules author their thresholds in
+        GB and read this (#241)."""
+        return self.file_size / 1e9 if self.file_size is not None else None
+
     @classmethod
     def from_file_info(cls, file_info: FileInfo) -> "ExtendedFileInfo":
         """Create ExtendedFileInfo from a FileInfo object."""
-        file_size_gb = None
-        if file_info.file_size is not None:
-            file_size_gb = file_info.file_size / 1e9  # Use decimal GB, not GiB
-
         return cls(
             filename=file_info.filename,
             file_size=file_info.file_size,
-            file_size_gb=file_size_gb,
             dataset_title=file_info.dataset_title,
         )
 
@@ -558,14 +562,15 @@ class RuleEngine:
         # Convert to ExtendedFileInfo if needed
         ext_info = ExtendedFileInfo.from_file_info(file_info) if isinstance(file_info, FileInfo) else file_info
 
-        # Extract the extension from the real filename when it yields one. A
-        # header-only call (or a name with no usable extension) sets file_format
-        # to the known file-type extension (e.g. ".bam"), so the extension rules
-        # still run without inventing a filename to carry it — the derived
-        # extension only overrides that fallback when it is itself non-empty (#152).
-        derived = self.rules.extract_extension(ext_info.filename) if ext_info.filename else ""
-        if derived:
-            ext_info.file_format = derived
+        # Extract the extension from the real filename when it yields a known
+        # one. FileName.parse returns None (not a junk last-dot suffix) for a
+        # name with no known extension, so an unknown name leaves the caller's
+        # file_format fallback intact — a header-only call sets it to the known
+        # file-type extension so the extension rules still run without inventing
+        # a filename to carry it (#152/#241).
+        parsed_ext = FileName.parse(ext_info.filename, self.rules).extension if ext_info.filename else None
+        if parsed_ext:
+            ext_info.file_format = parsed_ext
         extension = ext_info.file_format or ""
 
         # Initialize result
@@ -882,7 +887,6 @@ class RuleEngine:
         file_info = ExtendedFileInfo(
             filename=filename,
             file_size=file_size,
-            file_size_gb=file_size / 1e9 if file_size is not None else None,
             bam_header=bam_header,
         )
         return self.classify_extended(file_info, include_tier3=True)
@@ -909,7 +913,6 @@ class RuleEngine:
         file_info = ExtendedFileInfo(
             filename=filename,
             file_size=file_size,
-            file_size_gb=file_size / 1e9 if file_size is not None else None,
             vcf_header=vcf_header,
         )
         return self.classify_extended(file_info, include_tier3=True)
@@ -936,7 +939,6 @@ class RuleEngine:
         file_info = ExtendedFileInfo(
             filename=filename,
             file_size=file_size,
-            file_size_gb=file_size / 1e9 if file_size is not None else None,
             fastq_first_read=first_read,
         )
         return self.classify_extended(file_info, include_tier3=True)
@@ -965,7 +967,6 @@ class RuleEngine:
         file_info = ExtendedFileInfo(
             filename=filename,
             file_size=file_size,
-            file_size_gb=file_size / 1e9 if file_size is not None else None,
             fasta_contig_names=contig_names,
         )
         return self.classify_extended(file_info, include_tier3=False)

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -6,7 +6,6 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from .file_name import FileName
 from .models import (
     CLASSIFICATION_FIELDS,
     CLASSIFIED,
@@ -563,12 +562,12 @@ class RuleEngine:
         ext_info = ExtendedFileInfo.from_file_info(file_info) if isinstance(file_info, FileInfo) else file_info
 
         # Extract the extension from the real filename when it yields a known
-        # one. FileName.parse returns None (not a junk last-dot suffix) for a
+        # one. parse_file_name returns None (not a junk last-dot suffix) for a
         # name with no known extension, so an unknown name leaves the caller's
         # file_format fallback intact — a header-only call sets it to the known
         # file-type extension so the extension rules still run without inventing
         # a filename to carry it (#152/#241).
-        parsed_ext = FileName.parse(ext_info.filename, self.rules).extension if ext_info.filename else None
+        parsed_ext = self.rules.parse_file_name(ext_info.filename).extension if ext_info.filename else None
         if parsed_ext:
             ext_info.file_format = parsed_ext
         extension = ext_info.file_format or ""

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -178,7 +178,15 @@ class UnifiedRules:
                 break
         wrappers.reverse()  # name order: "x.tar.gz" -> (".tar", ".gz")
 
-        stem = filename[: -len(extension)] if extension else filename
+        # The stem carries the name tokens only. Remove the known extension when
+        # there is one (a compound extension already subsumes its wrappers, e.g.
+        # ".vcf.gz"); otherwise strip the trailing wrappers so the stem does not
+        # keep the compression/archive advice ("notes.txt.gz" -> "notes.txt").
+        if extension:
+            stem = filename[: -len(extension)]
+        else:
+            wrapper_len = sum(len(w) for w in wrappers)
+            stem = filename[:-wrapper_len] if wrapper_len else filename
         return FileName(raw=filename, stem=stem, extension=extension, wrappers=tuple(wrappers))
 
 

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -111,8 +111,10 @@ class UnifiedRules:
     # Compression and archive suffixes — "wrappers" around the format, not the
     # format itself (see FileName). Kept as advice; in this foundation they are
     # informational and may overlap the still-compound extension (the clean
-    # split is #244).
-    WRAPPER_SUFFIXES: ClassVar[tuple[str, ...]] = (".gz", ".bgz", ".bz2", ".xz", ".zip", ".tar")
+    # split is #244). Ordered longest-first (like COMPOUND_EXTENSIONS): the peel
+    # loop takes the first `endswith` match, so `.bgz` must precede `.gz` or a
+    # `.bgz` name would mis-peel as `.gz` and leave a dangling `b` in the stem.
+    WRAPPER_SUFFIXES: ClassVar[tuple[str, ...]] = (".bgz", ".bz2", ".zip", ".tar", ".gz", ".xz")
 
     def get_rules_by_scope(self, scope: str) -> list[UnifiedRule]:
         """Get all rules for a given scope."""

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar
 
 import yaml
 
+from .file_name import FileName
 from .models import CLASSIFICATION_FIELDS, NOT_APPLICABLE, NOT_CLASSIFIED
 
 
@@ -107,6 +108,12 @@ class UnifiedRules:
         ".mtx.gz",
     ]
 
+    # Compression and archive suffixes — "wrappers" around the format, not the
+    # format itself (see FileName). Kept as advice; in this foundation they are
+    # informational and may overlap the still-compound extension (the clean
+    # split is #244).
+    WRAPPER_SUFFIXES: ClassVar[tuple[str, ...]] = (".gz", ".bgz", ".bz2", ".xz", ".zip", ".tar")
+
     def get_rules_by_scope(self, scope: str) -> list[UnifiedRule]:
         """Get all rules for a given scope."""
         return [r for r in self.rules if r.scope == scope]
@@ -136,6 +143,43 @@ class UnifiedRules:
         if "." in filename:
             return "." + filename.rsplit(".", 1)[-1].lower()
         return ""
+
+    def parse_file_name(self, filename: str) -> "FileName":
+        """Parse ``filename`` into a :class:`FileName` against this vocabulary.
+
+        The parse is vocabulary-gated (it consults ``COMPOUND_EXTENSIONS`` /
+        ``extension_map``), so it lives here with the rules rather than on the
+        pure ``FileName`` data type. ``extension`` equals ``extract_extension``
+        for every name with a known extension, so rule routing is unchanged for
+        those; a name with no known extension yields ``None`` rather than the
+        junk suffix ``extract_extension`` returns (which matched no rules anyway).
+        """
+        lower = filename.lower()
+
+        extension = None
+        for ext in self.COMPOUND_EXTENSIONS:
+            if lower.endswith(ext):
+                extension = ext
+                break
+        if extension is None and "." in filename:
+            simple = "." + filename.rsplit(".", 1)[-1].lower()
+            if simple in self.extension_map:
+                extension = simple
+
+        wrappers: list[str] = []
+        rest = lower
+        while True:
+            for suffix in self.WRAPPER_SUFFIXES:
+                if rest.endswith(suffix):
+                    wrappers.append(suffix)
+                    rest = rest[: -len(suffix)]
+                    break
+            else:
+                break
+        wrappers.reverse()  # name order: "x.tar.gz" -> (".tar", ".gz")
+
+        stem = filename[: -len(extension)] if extension else filename
+        return FileName(raw=filename, stem=stem, extension=extension, wrappers=tuple(wrappers))
 
 
 class RuleLoader:

--- a/tests/test_file_name.py
+++ b/tests/test_file_name.py
@@ -85,3 +85,10 @@ class TestWrappers:
         assert fn.extension is None
         assert fn.wrappers == (".gz",)
         assert fn.stem == "notes.txt"
+
+    def test_bgz_is_not_mis_peeled_as_gz(self):
+        """`.bgz` ends with `.gz`; the wrapper list is ordered longest-first so
+        `.bgz` is captured whole, not mis-peeled as `.gz` leaving a dangling `b`."""
+        fn = parse("notes.txt.bgz")
+        assert fn.wrappers == (".bgz",)
+        assert fn.stem == "notes.txt"

--- a/tests/test_file_name.py
+++ b/tests/test_file_name.py
@@ -1,0 +1,83 @@
+"""Tests for the FileName parsed-filename fact (#241)."""
+
+import pytest
+
+from meta_disco.file_name import FileName
+from meta_disco.rule_engine import RuleEngine
+
+RULES = RuleEngine().rules
+
+
+def parse(name: str) -> FileName:
+    return FileName.parse(name, RULES)
+
+
+class TestExtension:
+    def test_simple_known_extension(self):
+        fn = parse("HG00741.final.cram")
+        assert fn.extension == ".cram"
+        assert fn.wrappers == ()
+        assert fn.stem == "HG00741.final"
+
+    def test_compound_extension_strips_to_stem(self):
+        fn = parse("sample.vcf.gz")
+        assert fn.extension == ".vcf.gz"
+        assert fn.wrappers == (".gz",)
+        assert fn.stem == "sample"
+
+    def test_archive_extension(self):
+        fn = parse("hprc-graph.tar.gz")
+        assert fn.extension == ".tar.gz"
+        assert fn.wrappers == (".tar", ".gz")
+        assert fn.stem == "hprc-graph"
+
+    def test_extensionless_name_is_none_not_junk(self):
+        """The bug this fixes: extract_extension returns a junk last-dot suffix
+        ('.0-mc-grch38'); the parsed extension is honestly None."""
+        fn = parse("hprc-v1.0-mc-grch38")
+        assert fn.extension is None
+        assert fn.wrappers == ()
+        assert fn.stem == "hprc-v1.0-mc-grch38"
+        # And the old parser did return the junk suffix — this is the contrast.
+        assert RULES.extract_extension("hprc-v1.0-mc-grch38") == ".0-mc-grch38"
+
+    def test_unknown_simple_extension_is_none(self):
+        fn = parse("readme.xyz")
+        assert fn.extension is None
+        assert fn.stem == "readme.xyz"
+
+
+class TestBehaviorPreservation:
+    """For every name that has a *known* extension, the parsed extension matches
+    what the engine derived before (extract_extension) — so rule routing is
+    unchanged. Only unknown/absent extensions differ (junk suffix -> None)."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "sample.bam",
+            "HG00741.final.cram",
+            "cohort.vcf.gz",
+            "cohort.g.vcf.gz",
+            "reads.fastq.gz",
+            "reads.fq.gz",
+            "genome.fasta",
+            "genome.fa.gz",
+            "regions.bed.gz",
+            "graph.gfa.gz",
+            "graph.rgfa",
+            "NUFIP1_quant.sf",
+            "archive.tar.gz",
+        ],
+    )
+    def test_known_extension_matches_extract_extension(self, name):
+        assert parse(name).extension == RULES.extract_extension(name)
+
+
+class TestWrappers:
+    def test_uncompressed_has_no_wrappers(self):
+        assert parse("sample.bam").wrappers == ()
+
+    def test_bare_compression_without_format(self):
+        fn = parse("notes.txt.gz")
+        assert fn.wrappers == (".gz",)

--- a/tests/test_file_name.py
+++ b/tests/test_file_name.py
@@ -79,5 +79,9 @@ class TestWrappers:
         assert parse("sample.bam").wrappers == ()
 
     def test_bare_compression_without_format(self):
+        """No known core extension (.txt isn't in the vocabulary), so extension is
+        None; the .gz is captured as a wrapper and stripped from the stem."""
         fn = parse("notes.txt.gz")
+        assert fn.extension is None
         assert fn.wrappers == (".gz",)
+        assert fn.stem == "notes.txt"

--- a/tests/test_file_name.py
+++ b/tests/test_file_name.py
@@ -9,7 +9,7 @@ RULES = RuleEngine().rules
 
 
 def parse(name: str) -> FileName:
-    return FileName.parse(name, RULES)
+    return RULES.parse_file_name(name)
 
 
 class TestExtension:

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -841,7 +841,6 @@ class TestAssayTypeInference:
         file_info = ExtendedFileInfo(
             filename="sample.bam",
             file_size=60_000_000_000,
-            file_size_gb=60.0,
             file_format=".bam",
         )
         result = engine.classify_extended(FileInfo(filename="sample.bam", file_size=60_000_000_000))
@@ -861,7 +860,6 @@ class TestAssayTypeInference:
         file_info = ExtendedFileInfo(
             filename="sample.bam",
             file_size=60_000_000_000,
-            file_size_gb=60.0,
             file_format=".bam",
         )
         result = engine.classify_extended(FileInfo(filename="sample.bam", file_size=60_000_000_000))
@@ -948,7 +946,7 @@ class TestSentinelValues:
 
     def test_bam_without_header_not_classified(self, engine):
         """BAM without header should leave modality as not_classified."""
-        result = engine.classify_extended(ExtendedFileInfo(filename="sample.bam", file_size_gb=60.0))
+        result = engine.classify_extended(ExtendedFileInfo(filename="sample.bam", file_size=60_000_000_000))
         # No header = no modality evidence, even for large files
         assert result.status_of("data_modality") == NOT_CLASSIFIED
 
@@ -984,7 +982,7 @@ class TestOutputDictStatus:
         n_a = engine.classify_extended(FileInfo(filename="plot.png")).to_output_dict()["reference_assembly"]
         assert (n_a["value"], n_a["status"]) == (None, NOT_APPLICABLE)
 
-        n_c = engine.classify_extended(ExtendedFileInfo(filename="sample.bam", file_size_gb=60.0)).to_output_dict()[
-            "data_modality"
-        ]
+        n_c = engine.classify_extended(
+            ExtendedFileInfo(filename="sample.bam", file_size=60_000_000_000)
+        ).to_output_dict()["data_modality"]
         assert (n_c["value"], n_c["status"]) == (None, NOT_CLASSIFIED)


### PR DESCRIPTION
Closes #241 — foundation increment of epic #242 (model the filename as a structured fact).

## What changed

- **New `FileName` value object** (`src/meta_disco/file_name.py`) — a pure frozen dataclass of `raw` / `stem` / `extension: str | None` / `wrappers`. Built by **`UnifiedRules.parse_file_name(raw)`** (the parse is vocabulary-gated, so it lives with the rules, next to `extract_extension`; `FileName` itself has no upward import).
- **The engine routes through it** — `RuleEngine.classify_extended` derives the extension via `self.rules.parse_file_name(filename).extension` instead of `extract_extension`. A name with **no known extension now yields `None`** rather than the junk last-dot suffix `extract_extension` returns (`hprc-v1.0-mc-grch38` → `.0-mc-grch38`).
- **Bytes-only size** — `ExtendedFileInfo.file_size_gb` is now a read-only **property** derived from `file_size` (bytes), so bytes are the single source of truth. The `file_size / 1e9` boilerplate is gone from ~9 construction sites; the assay-size rules still author thresholds in GB and read the property.

## Why

One overloaded `filename` string was answering four unrelated questions at once, and the engine derived the extension *from* it — the root of `filename_for_rules`, fabricated `sample.bam` names, the junk-suffix bug, and `file_size_gb` duplication (see epic #242). This lands the value object and routes the engine through it, so the honest `extension=None` and the parsed parts exist for the follow-ups to build on.

## Assumptions I made

- **Behavior-preserving is the bar for this increment.** For every name with a *known* extension, `parse_file_name(...).extension == extract_extension(...)`, so rule routing is identical; only unknown/extensionless names differ (junk → `None`), and those matched no rules anyway. Verified over **254,800 cached corpus filenames: 0 routing-relevant differences**, and the golden fixture is unchanged.
- **`extension` stays in the current compound vocabulary** (`.vcf.gz`) for now; `wrappers` is parsed as separate informational advice and may overlap it. The clean split rides with #244.
- **Parsing happens at the engine's single derivation site**, not yet threaded from the load boundary (#246), and there is **no explicit `format` field yet** (#243). `stem`/`wrappers` are modelled but only `extension` is consumed this increment.
- `file_size_gb` was never serialized and no caller set it independently of `file_size`, so the property returns the same value the stored field did.

## How to verify

Definition of done (#241):

- [x] `FileName` parses correctly; `extension` is `None` for unknown/extensionless names (junk-suffix bug gone) — `tests/test_file_name.py`.
- [x] `file_size_gb` removed as stored state; assay-size rules (WGS/WES/CRAM thresholds) still fire identically — `tests/test_rule_engine.py`.
- [x] Golden unchanged; behavior-preserving.

```bash
make test          # 759 pass (20 new in test_file_name.py)
make lint
make format-check
```

Corpus drift check (the routing-key change): comparing `extract_extension(name)` vs `parse_file_name(name).extension` over all cached evidence filenames yields **0** cases where the old key was a known extension but differs from the new — i.e. the engine routes every real file identically.

The deferred pieces are tracked as sub-issues of #242: explicit `format` (#243), wrapper/extension vocabulary split (#244), retiring `filename_for_rules` (#245), load-boundary threading (#246).