### PR TITLE
Derive an explicit canonical `format` fact from the extension (#243)

### DIFF
--- a/src/meta_disco/file_name.py
+++ b/src/meta_disco/file_name.py
@@ -2,19 +2,74 @@
 
 A file's name answers several unrelated questions at once — what tokens it
 carries (`rnaseq`, `chm13`), what its extension is, whether it is compressed or
-archived. ``FileName`` parses those apart so a caller reads a structured fact
-instead of re-deriving from a raw string (epic #242).
+archived, and what file *format* it therefore is. ``FileName`` parses those
+apart so a caller reads a structured fact instead of re-deriving from a raw
+string (epic #242).
 
 ``FileName`` is a pure data type; it is built by ``UnifiedRules.parse_file_name``
-(the parse is vocabulary-gated, so it lives with the rules). This is the
-foundation increment (#241): only ``extension`` is consumed so far — the engine
-parses at its own derivation site and reads it; the follow-ups separate a
-derived ``format`` from the extension (#243), split the compression/archive
-wrappers out of the extension vocabulary (#244), and thread the parsed
-``FileName`` from the load boundary (#246).
+(the parse is vocabulary-gated, so it lives with the rules). ``extension`` is
+syntactic — the exact suffix, ``.cram`` distinct from ``.bam`` — while
+``format`` is *derived*: what the file actually is, collapsing spelling and
+compression variants of one format to a single identity (``.fa``/``.fasta`` →
+``FASTA``). This increment (#243) derives the stage-1 format (from the extension
+alone, at parse time, no I/O) and records that provenance in ``format_source``;
+the follow-ups add the later derivation stages — stem/filename pattern
+(``FormatSource.STEM``) and a content/header read (``FormatSource.CONTENT``) —
+split the compression/archive wrappers out of the extension vocabulary (#244),
+and thread the parsed ``FileName`` from the load boundary (#246).
 """
 
 from dataclasses import dataclass
+from enum import Enum
+
+
+class Format(str, Enum):
+    """A canonical file-format identity — what the file *is*, not how its name is
+    spelled.
+
+    One format collapses the spelling and compression variants of the same
+    format (``.fa``/``.fasta``/``.fa.gz``/``.fasta.gz`` → ``FASTA``), so a rule
+    keys on ``format: FASTA`` once instead of re-listing every extension. Formats
+    that the size-threshold assay rules must still tell apart stay distinct —
+    ``BAM`` and ``CRAM`` are separate identities, keyed at the ``extension``
+    level.
+
+    Seeded with the core sequencing formats — the ones with a clear canonical
+    identity and the repeated extension groups the rules key on. Extensions with
+    no clean collapse (peaks, signal tracks, images, text, archives, single-cell
+    matrices, nanopore) are deliberately left unmapped, so their ``format`` is
+    ``None`` until a group that needs it migrates and adds its identity here.
+    """
+
+    BAM = "BAM"
+    CRAM = "CRAM"
+    SAM = "SAM"
+    VCF = "VCF"
+    BCF = "BCF"
+    GVCF = "GVCF"
+    FASTQ = "FASTQ"
+    FASTA = "FASTA"
+    BED = "BED"
+    GFA = "GFA"
+    RGFA = "RGFA"
+
+
+class FormatSource(str, Enum):
+    """How a ``format`` was derived — its resolution stage (epic #242).
+
+    ``format`` resolves on a timeline of increasing cost: from the extension
+    alone (no I/O), then from the stem / filename pattern (no I/O), then from a
+    content or header read (after fetch, I/O). The source records which stage
+    answered, so a cheap answer is never mistaken for one that read bytes.
+
+    Only ``EXTENSION`` is produced today (#243). ``STEM`` and ``CONTENT`` are the
+    reserved seam the later stages plug into — defined so the representation is
+    settled now, but never set in this increment.
+    """
+
+    EXTENSION = "extension"
+    STEM = "stem"  # reserved: stage-2 stem / filename-pattern derivation
+    CONTENT = "content"  # reserved: stage-3 content / header read
 
 
 @dataclass(frozen=True)
@@ -32,9 +87,18 @@ class FileName:
     token-carrying part: the name with its known ``extension`` removed, or —
     when there is none — its trailing ``wrappers`` stripped (an unknown suffix
     like ``.xyz`` is kept, since it is neither a known extension nor a wrapper).
+
+    ``format`` is the derived canonical format (see :class:`Format`), ``None``
+    when the extension maps to no seeded format (or there is no known extension).
+    ``format_source`` records how it was derived — ``FormatSource.EXTENSION`` for
+    the stage-1 (extension-only) derivation, ``None`` when ``format`` is
+    unresolved. The two move together: ``format`` and ``format_source`` are both
+    set or both ``None``.
     """
 
     raw: str
     stem: str
     extension: str | None
     wrappers: tuple[str, ...]
+    format: Format | None = None
+    format_source: FormatSource | None = None

--- a/src/meta_disco/file_name.py
+++ b/src/meta_disco/file_name.py
@@ -92,8 +92,9 @@ class FileName:
     when the extension maps to no seeded format (or there is no known extension).
     ``format_source`` records how it was derived — ``FormatSource.EXTENSION`` for
     the stage-1 (extension-only) derivation, ``None`` when ``format`` is
-    unresolved. The two move together: ``format`` and ``format_source`` are both
-    set or both ``None``.
+    unresolved. As built by ``UnifiedRules.parse_file_name`` the two move
+    together — both set or both ``None`` — though ``FileName`` itself does not
+    enforce that of a directly-constructed instance.
     """
 
     raw: str

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -627,8 +627,14 @@ class RuleEngine:
         if when.get("always"):
             return True
 
-        # Check extension filter
-        if "extensions" in when and file_info.file_format not in [e.lower() for e in when["extensions"]]:
+        # Check extension filter. Lower-case file_format to match matches_extension's
+        # own normalization — the rule pre-filter lower-cases both sides, so a caller
+        # supplying a mixed-case file_format (e.g. ".CRAM") would otherwise be
+        # pre-filtered as applicable yet rejected here and never match. `or ""` keeps
+        # a None file_format from raising on .lower() (it then matches no extension).
+        if "extensions" in when and (file_info.file_format or "").lower() not in [
+            e.lower() for e in when["extensions"]
+        ]:
             return False
 
         # Check format filter (#243), a peer of the extensions filter above and

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -6,6 +6,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from .file_name import Format
 from .models import (
     CLASSIFICATION_FIELDS,
     CLASSIFIED,
@@ -42,6 +43,11 @@ class ExtendedFileInfo:
     file_size: int | None = None
     dataset_title: str | None = None
     file_format: str | None = None
+    # Canonical file Format derived from the extension (#243). Set by
+    # classify_extended from the extension it settles on, so it always agrees
+    # with file_format; None when that extension maps to no seeded format. Rules
+    # key on it via `when.format`.
+    format: Format | None = None
 
     # Header data (populated when available)
     bam_header: str | None = None
@@ -572,6 +578,11 @@ class RuleEngine:
             ext_info.file_format = parsed_ext
         extension = ext_info.file_format or ""
 
+        # Derive the canonical format from the extension the engine settled on
+        # (parsed name or the caller's file_format fallback), so format and
+        # extension always agree — one funnel through extension_to_format (#243).
+        ext_info.format = self.rules.extension_to_format(extension)
+
         # Initialize result
         result = ExtendedClassificationResult()
 
@@ -618,6 +629,14 @@ class RuleEngine:
 
         # Check extension filter
         if "extensions" in when and file_info.file_format not in [e.lower() for e in when["extensions"]]:
+            return False
+
+        # Check format filter (#243). `when.format` is a canonical Format value
+        # (a string like "FASTA"); file_info.format is a Format, which is a str
+        # enum, so the equality compares by value. An unresolved (None) or
+        # differing format fails the match — a format-only rule is considered for
+        # every file and skipped for those whose format does not match.
+        if (fmt := when.get("format")) and file_info.format != fmt:
             return False
 
         # Check filename pattern

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -576,6 +576,15 @@ class RuleEngine:
         parsed_ext = self.rules.parse_file_name(ext_info.filename).extension if ext_info.filename else None
         if parsed_ext:
             ext_info.file_format = parsed_ext
+        # Normalize the settled file_format to lower-case once, so every downstream
+        # comparison — the extensions filter, `when.file_format`, and the assay
+        # `file_format`/`file_format_not` conditions — is case-insensitive and
+        # consistent with matches_extension's own lowering. A header-only call may
+        # pass a mixed-case file_format (".CRAM"); parsed_ext is already lower-case
+        # (parse_file_name lowers it). Normalizing here means the matchers can
+        # compare directly without each re-lowering (#248).
+        if ext_info.file_format:
+            ext_info.file_format = ext_info.file_format.lower()
         extension = ext_info.file_format or ""
 
         # Derive the canonical format from the extension the engine settled on
@@ -627,14 +636,10 @@ class RuleEngine:
         if when.get("always"):
             return True
 
-        # Check extension filter. Lower-case file_format to match matches_extension's
-        # own normalization — the rule pre-filter lower-cases both sides, so a caller
-        # supplying a mixed-case file_format (e.g. ".CRAM") would otherwise be
-        # pre-filtered as applicable yet rejected here and never match. `or ""` keeps
-        # a None file_format from raising on .lower() (it then matches no extension).
-        if "extensions" in when and (file_info.file_format or "").lower() not in [
-            e.lower() for e in when["extensions"]
-        ]:
+        # Check extension filter. file_format is already lower-cased by
+        # classify_extended, so this compares consistently with matches_extension's
+        # own lowering (a mixed-case caller file_format was normalized upstream).
+        if "extensions" in when and file_info.file_format not in [e.lower() for e in when["extensions"]]:
             return False
 
         # Check format filter (#243), a peer of the extensions filter above and

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -582,7 +582,7 @@ class RuleEngine:
         # consistent with matches_extension's own lowering. A header-only call may
         # pass a mixed-case file_format (".CRAM"); parsed_ext is already lower-case
         # (parse_file_name lowers it). Normalizing here means the matchers can
-        # compare directly without each re-lowering (#248).
+        # compare directly without each re-lowering (#243).
         if ext_info.file_format:
             ext_info.file_format = ext_info.file_format.lower()
         extension = ext_info.file_format or ""

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -631,12 +631,14 @@ class RuleEngine:
         if "extensions" in when and file_info.file_format not in [e.lower() for e in when["extensions"]]:
             return False
 
-        # Check format filter (#243). `when.format` is a canonical Format value
-        # (a string like "FASTA"); file_info.format is a Format, which is a str
-        # enum, so the equality compares by value. An unresolved (None) or
-        # differing format fails the match — a format-only rule is considered for
-        # every file and skipped for those whose format does not match.
-        if (fmt := when.get("format")) and file_info.format != fmt:
+        # Check format filter (#243), a peer of the extensions filter above and
+        # keyed by presence like it: when `format` is present the rule matches
+        # only a file whose derived format equals it. `when.format` is a Format
+        # value string ("FASTA"); file_info.format is a Format (a str enum), so
+        # equality compares by value. A present-but-non-matching format — an
+        # unresolved (None) format, a different one, or a stray falsy value the
+        # loader does not value-check — fails the match rather than being skipped.
+        if "format" in when and file_info.format != when["format"]:
             return False
 
         # Check filename pattern

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar
 
 import yaml
 
-from .file_name import FileName
+from .file_name import FileName, Format, FormatSource
 from .models import CLASSIFICATION_FIELDS, NOT_APPLICABLE, NOT_CLASSIFIED
 
 
@@ -116,6 +116,40 @@ class UnifiedRules:
     # `.bgz` name would mis-peel as `.gz` and leave a dangling `b` in the stem.
     WRAPPER_SUFFIXES: ClassVar[tuple[str, ...]] = (".bgz", ".bz2", ".zip", ".tar", ".gz", ".xz")
 
+    # Known extension -> canonical file Format (#243). Collapses the spelling and
+    # compression variants of one format to a single identity (.fa/.fasta/.fa.gz/
+    # .fasta.gz -> FASTA), the stage-1 derivation the rules key on via `format`.
+    # Seeded with the core sequencing formats; extensions with no clean canonical
+    # collapse are absent, so their format is None until a migrating group adds
+    # its identity (see Format). Keys are lower-case: extension_to_format lowers
+    # its argument before the lookup.
+    EXTENSION_TO_FORMAT: ClassVar[dict[str, Format]] = {
+        ".bam": Format.BAM,
+        ".cram": Format.CRAM,
+        ".sam": Format.SAM,
+        ".sam.gz": Format.SAM,
+        ".vcf": Format.VCF,
+        ".vcf.gz": Format.VCF,
+        ".bcf": Format.BCF,
+        ".gvcf": Format.GVCF,
+        ".gvcf.gz": Format.GVCF,
+        ".g.vcf.gz": Format.GVCF,
+        ".fastq": Format.FASTQ,
+        ".fq": Format.FASTQ,
+        ".fastq.gz": Format.FASTQ,
+        ".fq.gz": Format.FASTQ,
+        ".fasta": Format.FASTA,
+        ".fa": Format.FASTA,
+        ".fasta.gz": Format.FASTA,
+        ".fa.gz": Format.FASTA,
+        ".bed": Format.BED,
+        ".bed.gz": Format.BED,
+        ".gfa": Format.GFA,
+        ".gfa.gz": Format.GFA,
+        ".rgfa": Format.RGFA,
+        ".rgfa.gz": Format.RGFA,
+    }
+
     def get_rules_by_scope(self, scope: str) -> list[UnifiedRule]:
         """Get all rules for a given scope."""
         return [r for r in self.rules if r.scope == scope]
@@ -131,6 +165,18 @@ class UnifiedRules:
     def get_file_type(self, extension: str) -> str | None:
         """Get the file type for an extension."""
         return self.extension_map.get(extension.lower())
+
+    def extension_to_format(self, extension: str | None) -> Format | None:
+        """Derive the canonical :class:`Format` for an extension (#243).
+
+        The stage-1 derivation — from the extension alone, no I/O. Returns
+        ``None`` when the extension is ``None`` or maps to no seeded format
+        (``EXTENSION_TO_FORMAT``), so an unmapped or absent extension leaves the
+        format honestly unresolved rather than guessed.
+        """
+        if extension is None:
+            return None
+        return self.EXTENSION_TO_FORMAT.get(extension.lower())
 
     def extract_extension(self, filename: str) -> str:
         """Extract the file extension, handling compound extensions."""
@@ -150,11 +196,14 @@ class UnifiedRules:
         """Parse ``filename`` into a :class:`FileName` against this vocabulary.
 
         The parse is vocabulary-gated (it consults ``COMPOUND_EXTENSIONS`` /
-        ``extension_map``), so it lives here with the rules rather than on the
-        pure ``FileName`` data type. ``extension`` equals ``extract_extension``
-        for every name with a known extension, so rule routing is unchanged for
-        those; a name with no known extension yields ``None`` rather than the
-        junk suffix ``extract_extension`` returns (which matched no rules anyway).
+        ``extension_map`` / ``EXTENSION_TO_FORMAT``), so it lives here with the
+        rules rather than on the pure ``FileName`` data type. ``extension`` equals
+        ``extract_extension`` for every name with a known extension, so rule
+        routing is unchanged for those; a name with no known extension yields
+        ``None`` rather than the junk suffix ``extract_extension`` returns (which
+        matched no rules anyway). ``format`` is the stage-1 derivation from that
+        extension (``extension_to_format``), with ``format_source`` recording the
+        provenance — set together or both ``None`` (#243).
         """
         lower = filename.lower()
 
@@ -189,7 +238,17 @@ class UnifiedRules:
         else:
             wrapper_len = sum(len(w) for w in wrappers)
             stem = filename[:-wrapper_len] if wrapper_len else filename
-        return FileName(raw=filename, stem=stem, extension=extension, wrappers=tuple(wrappers))
+
+        fmt = self.extension_to_format(extension)
+        format_source = FormatSource.EXTENSION if fmt is not None else None
+        return FileName(
+            raw=filename,
+            stem=stem,
+            extension=extension,
+            wrappers=tuple(wrappers),
+            format=fmt,
+            format_source=format_source,
+        )
 
 
 class RuleLoader:
@@ -205,6 +264,7 @@ class RuleLoader:
     VALID_WHEN_KEYS: ClassVar[set[str]] = {
         "always",
         "extensions",
+        "format",
         "filename_pattern",
         "dataset_pattern",
         "file_format",

--- a/src/meta_disco/rules/unified_rules.yaml
+++ b/src/meta_disco/rules/unified_rules.yaml
@@ -78,6 +78,10 @@
 # ---------------------------
 # Extension/filename conditions:
 # - extensions: list of file extensions to match (e.g., [".bam", ".cram"])
+# - format: canonical file format to match (e.g., FASTA) — collapses the
+#     spelling/compression variants of one format (.fa/.fasta/.fa.gz/.fasta.gz)
+#     to a single identity, so key on this instead of re-listing extensions
+#     (see EXTENSION_TO_FORMAT in rule_loader.py; issue #243)
 # - filename_pattern: regex pattern for filename (case-insensitive)
 # - dataset_pattern: regex pattern for dataset title
 # - file_format: required format (.bam, .cram, etc)
@@ -471,7 +475,7 @@ rules:
     tier: 1
     scope: extension
     when:
-      extensions: [".fasta", ".fa", ".fasta.gz", ".fa.gz"]
+      format: FASTA
     then:
       data_type: sequence
       status:
@@ -736,7 +740,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".fasta", ".fa", ".fasta.gz", ".fa.gz"]
+      format: FASTA
       filename_pattern: "(?i)(assembly|hifiasm|verkko|flye|canu|wtdbg|hap[12]|diploid|[._](pat|mat)(ernal)?[._])"
     then:
       data_modality: genomic
@@ -749,7 +753,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".fasta", ".fa", ".fasta.gz", ".fa.gz"]
+      format: FASTA
       filename_pattern: "(?i)(haplotype|phased|hapdup|purge_dups)"
     then:
       data_modality: genomic

--- a/src/meta_disco/schema_vocab.py
+++ b/src/meta_disco/schema_vocab.py
@@ -36,7 +36,10 @@ MARKER_ENUM = "evidence_marker_enum"
 # qualifies today; the other ``when`` keys carry regexes, header field codes,
 # numeric bounds, or booleans, none of which are dimension-enum-backed.
 # ``when.file_format`` is checked against extension_map keys, not a dimension enum
-# (see issue #114). Keep in sync with rule_engine.RuleEngine._rule_matches().
+# (see issue #114). ``when.format`` is backed by the in-code ``Format`` enum
+# rather than a schema dimension, so its value drift is checked directly against
+# that enum in test_rule_vocabulary (not through this registry) — #243. Keep in
+# sync with rule_engine.RuleEngine._rule_matches().
 ENUM_BACKED_WHEN_KEYS = {"platform": "platform"}
 
 # assay_type_rules ``conditions`` keys whose value(s) must be dimension-enum

--- a/tests/test_file_name.py
+++ b/tests/test_file_name.py
@@ -1,8 +1,8 @@
-"""Tests for the FileName parsed-filename fact (#241)."""
+"""Tests for the FileName parsed-filename fact (#241, #243)."""
 
 import pytest
 
-from meta_disco.file_name import FileName
+from meta_disco.file_name import FileName, Format, FormatSource
 from meta_disco.rule_engine import RuleEngine
 
 RULES = RuleEngine().rules
@@ -72,6 +72,42 @@ class TestBehaviorPreservation:
     )
     def test_known_extension_matches_extract_extension(self, name):
         assert parse(name).extension == RULES.extract_extension(name)
+
+
+class TestFormat:
+    """The stage-1 derived format (#243): extension -> canonical Format, with
+    the provenance recorded in format_source. Set together or both None."""
+
+    def test_spelling_and_compression_variants_collapse_to_one_format(self):
+        """The point of format: four extensions, one identity."""
+        for name in ("genome.fa", "genome.fasta", "genome.fa.gz", "genome.fasta.gz"):
+            fn = parse(name)
+            assert fn.format is Format.FASTA
+            assert fn.format_source is FormatSource.EXTENSION
+
+    def test_distinct_formats_stay_distinct(self):
+        """.bam and .cram are separate identities — the assay rules key on the
+        extension to tell them apart, so format must not collapse them."""
+        assert parse("x.bam").format is Format.BAM
+        assert parse("x.cram").format is Format.CRAM
+
+    def test_compound_extension_resolves_format(self):
+        assert parse("cohort.g.vcf.gz").format is Format.GVCF
+        assert parse("cohort.vcf.gz").format is Format.VCF
+
+    def test_unmapped_extension_has_no_format(self):
+        """A known extension with no seeded format (e.g. an image) is honestly
+        unresolved — format and its source are both None."""
+        fn = parse("slide.svs")
+        assert fn.extension == ".svs"
+        assert fn.format is None
+        assert fn.format_source is None
+
+    def test_absent_extension_has_no_format(self):
+        fn = parse("hprc-v1.0-mc-grch38")
+        assert fn.extension is None
+        assert fn.format is None
+        assert fn.format_source is None
 
 
 class TestWrappers:

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -220,18 +220,23 @@ class TestFormatMatching:
         real_fmt = UnifiedRule(id="y", tier=1, scope="extension", when={"format": "FASTA"}, then={}, rationale="")
         assert engine._rule_matches(real_fmt, fasta, result) is True
 
-    def test_extensions_guard_is_case_insensitive(self, engine):
-        """A mixed-case file_format matches an extensions rule, consistent with
-        matches_extension's lower-casing — a rule pre-filtered as applicable is
-        not then rejected on case alone (Copilot, PR #248)."""
-        from meta_disco.rule_loader import UnifiedRule
-
-        result = ExtendedClassificationResult()
-        rule = UnifiedRule(id="z", tier=1, scope="extension", when={"extensions": [".cram"]}, then={}, rationale="")
-        assert engine._rule_matches(rule, ExtendedFileInfo(filename="x", file_format=".CRAM"), result) is True
-        assert engine._rule_matches(rule, ExtendedFileInfo(filename="x", file_format=".cram"), result) is True
-        # A None file_format matches no extension rather than raising on .lower().
-        assert engine._rule_matches(rule, ExtendedFileInfo(filename="x", file_format=None), result) is False
+    def test_classify_extended_normalizes_file_format_case(self, engine):
+        """A mixed-case header-only file_format is lower-cased once at the source,
+        so the extensions / when.file_format / assay conditions all match case-
+        insensitively — a `.CRAM` classifies identically to a `.cram` (Copilot,
+        PR #248)."""
+        upper = ExtendedFileInfo(filename="", file_format=".CRAM")
+        lower = ExtendedFileInfo(filename="", file_format=".cram")
+        r_upper = engine.classify_extended(upper)
+        r_lower = engine.classify_extended(lower)
+        assert upper.file_format == ".cram"  # normalized in place
+        assert upper.format is Format.CRAM
+        assert r_upper.data_type == r_lower.data_type  # downstream matching is case-insensitive
+        # A None file_format is left as-is (no crash) and derives no format.
+        none_info = ExtendedFileInfo(filename="", file_format=None)
+        engine.classify_extended(none_info)
+        assert none_info.file_format is None
+        assert none_info.format is None
 
 
 class TestThenStatus:

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -205,6 +205,21 @@ class TestFormatMatching:
         engine.classify_extended(ext_info)
         assert ext_info.format is Format.CRAM
 
+    def test_present_but_falsy_format_fails_match(self, engine):
+        """A present-but-falsy `when.format` (e.g. an authoring slip `format: ""`
+        the loader does not value-check) fails the match rather than being
+        silently skipped — the guard keys on presence, not truthiness (Copilot,
+        PR #248)."""
+        from meta_disco.rule_loader import UnifiedRule
+
+        fasta = ExtendedFileInfo(filename="genome.fa", format=Format.FASTA)
+        result = ExtendedClassificationResult()
+        empty_fmt = UnifiedRule(id="x", tier=1, scope="extension", when={"format": ""}, then={}, rationale="")
+        assert engine._rule_matches(empty_fmt, fasta, result) is False
+        # Control: the same rule keyed on the real format still matches.
+        real_fmt = UnifiedRule(id="y", tier=1, scope="extension", when={"format": "FASTA"}, then={}, rationale="")
+        assert engine._rule_matches(real_fmt, fasta, result) is True
+
 
 class TestThenStatus:
     """A rule authoring a non-classified status via `then.status` (#133)."""

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from meta_disco.file_name import Format
 from meta_disco.models import (
     CLASSIFICATION_FIELDS,
     CLASSIFIED,
@@ -170,6 +171,39 @@ class TestVariantFiles:
         ext_info = ExtendedFileInfo(filename="sample.vcf.gz", vcf_header=header_line)
         result = engine.classify_extended(ext_info, include_tier3=True)
         assert result.reference_assembly == expected
+
+
+class TestFormatMatching:
+    """Rules keyed on `format` instead of `extensions` (#243). The FASTA rules
+    were migrated to `format: FASTA`, so these both prove the new keying works
+    and pin the migration as behavior-preserving."""
+
+    @pytest.mark.parametrize("name", ["genome.fa", "genome.fasta", "genome.fa.gz", "genome.fasta.gz"])
+    def test_format_keyed_rule_matches_every_spelling(self, engine, name):
+        """One `format: FASTA` rule fires for every FASTA spelling/compression
+        variant — the collapse the extension list used to enumerate by hand."""
+        result = engine.classify_extended(FileInfo(filename=name))
+        assert result.data_type == "sequence"
+
+    def test_format_keyed_filename_rule_still_fires(self, engine):
+        """A tier-2 rule that pairs `format: FASTA` with a filename_pattern still
+        matches on both conditions (fasta_assembly_filename)."""
+        result = engine.classify_extended(FileInfo(filename="HG002.hifiasm.bp.p_ctg.fa"))
+        assert result.data_modality == "genomic"
+        assert result.data_type == "assembly"
+
+    def test_format_keyed_rule_skipped_for_other_formats(self, engine):
+        """A format-only rule is considered for every file but must not fire when
+        the format differs — a BAM is not classified as FASTA sequence."""
+        result = engine.classify_extended(FileInfo(filename="sample.bam"))
+        assert result.data_type != "sequence"
+
+    def test_engine_derives_format_from_settled_extension(self, engine):
+        """classify_extended sets file_info.format from the extension it settles
+        on, agreeing with file_format even on a header-only (name-less) call."""
+        ext_info = ExtendedFileInfo(filename="", file_format=".cram")
+        engine.classify_extended(ext_info)
+        assert ext_info.format is Format.CRAM
 
 
 class TestThenStatus:

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -208,8 +208,7 @@ class TestFormatMatching:
     def test_present_but_falsy_format_fails_match(self, engine):
         """A present-but-falsy `when.format` (e.g. an authoring slip `format: ""`
         the loader does not value-check) fails the match rather than being
-        silently skipped — the guard keys on presence, not truthiness (Copilot,
-        PR #248)."""
+        silently skipped — the guard keys on presence, not truthiness (#243)."""
         from meta_disco.rule_loader import UnifiedRule
 
         fasta = ExtendedFileInfo(filename="genome.fa", format=Format.FASTA)
@@ -223,8 +222,7 @@ class TestFormatMatching:
     def test_classify_extended_normalizes_file_format_case(self, engine):
         """A mixed-case header-only file_format is lower-cased once at the source,
         so the extensions / when.file_format / assay conditions all match case-
-        insensitively — a `.CRAM` classifies identically to a `.cram` (Copilot,
-        PR #248)."""
+        insensitively — a `.CRAM` classifies identically to a `.cram` (#243)."""
         upper = ExtendedFileInfo(filename="", file_format=".CRAM")
         lower = ExtendedFileInfo(filename="", file_format=".cram")
         r_upper = engine.classify_extended(upper)

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -220,6 +220,19 @@ class TestFormatMatching:
         real_fmt = UnifiedRule(id="y", tier=1, scope="extension", when={"format": "FASTA"}, then={}, rationale="")
         assert engine._rule_matches(real_fmt, fasta, result) is True
 
+    def test_extensions_guard_is_case_insensitive(self, engine):
+        """A mixed-case file_format matches an extensions rule, consistent with
+        matches_extension's lower-casing — a rule pre-filtered as applicable is
+        not then rejected on case alone (Copilot, PR #248)."""
+        from meta_disco.rule_loader import UnifiedRule
+
+        result = ExtendedClassificationResult()
+        rule = UnifiedRule(id="z", tier=1, scope="extension", when={"extensions": [".cram"]}, then={}, rationale="")
+        assert engine._rule_matches(rule, ExtendedFileInfo(filename="x", file_format=".CRAM"), result) is True
+        assert engine._rule_matches(rule, ExtendedFileInfo(filename="x", file_format=".cram"), result) is True
+        # A None file_format matches no extension rather than raising on .lower().
+        assert engine._rule_matches(rule, ExtendedFileInfo(filename="x", file_format=None), result) is False
+
 
 class TestThenStatus:
     """A rule authoring a non-classified status via `then.status` (#133)."""

--- a/tests/test_rule_vocabulary.py
+++ b/tests/test_rule_vocabulary.py
@@ -44,13 +44,22 @@ def _when_format_violations(rules):
     enum instead of through schema_vocab (#243) — but it is the same antecedent-
     value drift check, in the same test layer (the loader validates when *keys*,
     values are checked here). Shared by the suite-wide and negative tests.
+
+    A present `format` must be a string in the Format vocabulary; anything else
+    is a violation — including ``null`` and non-string types (e.g. a list), which
+    the ``isinstance`` guard reports rather than raising ``TypeError`` on the
+    ``not in`` hash. Mirrors value_in_vocabulary's non-string handling.
     """
     valid = {f.value for f in Format}
-    return [
-        f"{rule.id}: when.format={(rule.when or {})['format']!r}"
-        for rule in rules.rules
-        if (rule.when or {}).get("format") is not None and (rule.when or {})["format"] not in valid
-    ]
+    violations = []
+    for rule in rules.rules:
+        when = rule.when or {}
+        if "format" not in when:
+            continue
+        value = when["format"]
+        if not isinstance(value, str) or value not in valid:
+            violations.append(f"{rule.id}: when.format={value!r}")
+    return violations
 
 
 def test_rule_then_values_in_vocabulary():
@@ -380,6 +389,24 @@ def test_format_value_check_rejects_bogus_format(tmp_path):
     )
     violations = _when_format_violations(RuleLoader(path).load())
     assert violations == ["bogus_format: when.format='FASTAA'"]
+
+
+@pytest.mark.parametrize("bad", [None, ["FASTA"]])
+def test_format_check_flags_null_and_nonstring(tmp_path, bad):
+    """A present `format` that is null or a non-string is flagged, not skipped or
+    crashed on — the scan guards the hash with isinstance (PR #248)."""
+    path = _write_rules_file(
+        tmp_path,
+        {
+            "id": "bad_format",
+            "tier": 1,
+            "scope": "extension",
+            "when": {"format": bad},
+            "then": {"data_type": "sequence"},
+        },
+    )
+    violations = _when_format_violations(RuleLoader(path).load())
+    assert violations == [f"bad_format: when.format={bad!r}"]
 
 
 def test_loader_rejects_unknown_then_key(tmp_path):

--- a/tests/test_rule_vocabulary.py
+++ b/tests/test_rule_vocabulary.py
@@ -16,6 +16,7 @@ import pytest
 import yaml
 
 from meta_disco import schema_vocab
+from meta_disco.file_name import Format
 from meta_disco.rule_loader import RuleLoader, get_unified_rules
 
 
@@ -33,6 +34,23 @@ def _when_value_violations(rules):
             if value is not None and not schema_vocab.value_in_vocabulary(dimension, value):
                 violations.append(f"{rule.id}: when.{key}={value!r}")
     return violations
+
+
+def _when_format_violations(rules):
+    """`when.format` values that are not real Format members.
+
+    The format counterpart to _when_value_violations. Format is an in-code enum
+    rather than a LinkML schema dimension, so it is checked directly against the
+    enum instead of through schema_vocab (#243) — but it is the same antecedent-
+    value drift check, in the same test layer (the loader validates when *keys*,
+    values are checked here). Shared by the suite-wide and negative tests.
+    """
+    valid = {f.value for f in Format}
+    return [
+        f"{rule.id}: when.format={(rule.when or {})['format']!r}"
+        for rule in rules.rules
+        if (rule.when or {}).get("format") is not None and (rule.when or {})["format"] not in valid
+    ]
 
 
 def test_rule_then_values_in_vocabulary():
@@ -89,6 +107,21 @@ def test_rule_when_values_in_vocabulary():
     assert not violations, (
         "Rules use `when` condition values not in the LinkML schema vocabulary.\n"
         "Add them to classification.yaml or fix the rule:\n  " + "\n  ".join(violations)
+    )
+
+
+def test_rule_when_format_values_valid():
+    """Every `when.format` value must be a real Format member (#243).
+
+    The in-code counterpart to test_rule_when_values_in_vocabulary: `format` is
+    backed by the Format enum, not the schema, so it is drift-checked directly
+    against the enum. Catches a typo'd format (which would silently never match)
+    the same way the platform check catches a typo'd platform.
+    """
+    violations = _when_format_violations(get_unified_rules())
+    assert not violations, (
+        "Rules use `when.format` values that are not real Format members.\n"
+        "Add the format to meta_disco.file_name.Format or fix the rule:\n  " + "\n  ".join(violations)
     )
 
 
@@ -325,6 +358,28 @@ def test_loader_rejects_unknown_when_key(tmp_path):
     )
     with pytest.raises(ValueError, match="unknown 'when' condition key"):
         RuleLoader(path).load()
+
+
+def test_format_value_check_rejects_bogus_format(tmp_path):
+    """The format drift check catches a typo'd Format value (#243).
+
+    The format analogue of test_when_value_check_rejects_bogus_platform. The
+    loader accepts the `format` *key* (it is a valid when key); the *value* gap
+    is closed by the _when_format_violations scan, so this exercises that scan
+    over a rule whose when.format is bogus.
+    """
+    path = _write_rules_file(
+        tmp_path,
+        {
+            "id": "bogus_format",
+            "tier": 1,
+            "scope": "extension",
+            "when": {"format": "FASTAA"},  # typo: should be FASTA
+            "then": {"data_type": "sequence"},
+        },
+    )
+    violations = _when_format_violations(RuleLoader(path).load())
+    assert violations == ["bogus_format: when.format='FASTAA'"]
 
 
 def test_loader_rejects_unknown_then_key(tmp_path):

--- a/tests/test_rule_vocabulary.py
+++ b/tests/test_rule_vocabulary.py
@@ -394,7 +394,7 @@ def test_format_value_check_rejects_bogus_format(tmp_path):
 @pytest.mark.parametrize("bad", [None, ["FASTA"]])
 def test_format_check_flags_null_and_nonstring(tmp_path, bad):
     """A present `format` that is null or a non-string is flagged, not skipped or
-    crashed on — the scan guards the hash with isinstance (PR #248)."""
+    crashed on — the scan guards the hash with isinstance (#243)."""
     path = _write_rules_file(
         tmp_path,
         {


### PR DESCRIPTION
Closes #243. Part of epic #242 (the filename fact model); builds on #241 (the `FileName` value object).

## What changed
Introduces a derived **`format`** fact — a canonical file-format identity distinct from the syntactic extension.

- **`file_name.py`**: `Format` and `FormatSource` enums (pure leaf types) + `FileName.format` / `FileName.format_source`. `Format` collapses spelling/compression variants of one format to a single identity (`.fa`/`.fasta`/`.fa.gz`/`.fasta.gz` → `FASTA`) while keeping formats the assay rules must distinguish separate (`BAM` vs `CRAM`).
- **`rule_loader.py`**: `EXTENSION_TO_FORMAT` map + `extension_to_format()`; `parse_file_name` derives the **stage-1** format eagerly (from the extension alone, no I/O) with `FormatSource.EXTENSION` provenance. `format` is added to `VALID_WHEN_KEYS` (a valid `when` *key*).
- **`rule_engine.py`**: `ExtendedFileInfo.format`, derived once in `classify_extended` from the extension the engine settles on; a `when.format` guard in `_rule_matches`, a peer of `when.extensions`.
- **`unified_rules.yaml`**: the 3 FASTA rules migrate from `extensions: [".fasta", ".fa", ".fasta.gz", ".fa.gz"]` to `format: FASTA` — the proof group.
- **`schema_vocab.py`**: comment notes `when.format` is backed by the in-code `Format` enum, so its value drift is checked directly (not via the schema registry).
- **tests**: format derivation, format-keyed matching, and a `_when_format_violations` drift scan (suite-wide + negative), mirroring the `platform` pattern.

## Why
The `extensions:` list is duplicated across 125 rules (`[".fastq",".fq",".fastq.gz",".fq.gz"]` alone appears 24×). A canonical `format` lets a rule key on the format once. This PR lands the foundation and one proof group; the other groups migrate under their own follow-ups so each stays reviewable and behavior-preserving.

## Assumptions I made
- **Foundation + one proof group**, not a wholesale 125-rule migration — matches #241's behavior-preserving discipline (golden fixture unchanged; 774 tests pass).
- **Canonical per-format identity** (not the coarse `extension_map` category): `.bam`/`.cram` stay distinct because the size-threshold assay rules key on the extension to tell them apart.
- **`Format` is seeded with the core sequencing formats** (BAM, CRAM, SAM, VCF, BCF, GVCF, FASTQ, FASTA, BED, GFA, RGFA). Extensions with no clean canonical collapse (peaks, signal tracks, images, text, archives, single-cell, nanopore) are deliberately unmapped → `format is None` until a migrating group adds its identity.
- **`FormatSource.STEM`/`CONTENT` are defined but never produced** — the reserved seam the stage-2 (filename pattern) and stage-3 (content read) issues plug into. This settles the "how is an unresolved format represented" crux the issue flagged.
- **`when.format` value validation lives in the test drift-scan layer**, not the loader — the loader validates `when` *keys*, values are checked by `test_rule_vocabulary` (the same split `platform` uses). Chosen at review over a load-time raise.

## How to verify
Definition of done from #243:

1. **Explicit derived `format` field** → `FileName.format` / `ExtendedFileInfo.format` exist and are populated.
2. **Stage-1 format derived eagerly from extension at parse time** → run:
   ```bash
   uv run python -c "from meta_disco.rule_engine import RuleEngine; r=RuleEngine().rules; fn=r.parse_file_name('genome.fasta.gz'); print(fn.format, fn.format_source)"
   ```
   Expect: `Format.FASTA FormatSource.EXTENSION`. Try `hprc-v1.0-mc-grch38` (no known extension) → `None None`.
3. **Unresolved-format representation settled** → `Format | None` + `FormatSource` (EXTENSION only; STEM/CONTENT reserved) — see `file_name.py`.
4. **Rules key on `extension` OR `format`** → the migrated FASTA rules use `format: FASTA`; `uv run pytest tests/test_rule_engine.py -k TestFormatMatching -q` proves every FASTA spelling collapses to one rule, a `.bam` is skipped, and the tier-2 `format`+`filename_pattern` rule still fires.
5. **Behavior-preserving** → `make test` (774 pass), golden fixture `tests/fixtures/golden/expected_output.json` unchanged, `make lint` / `make format-check` / `uv run pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)