### PR TITLE
Split compression/archive wrappers out of the core extension (#244)

### DIFF
--- a/src/meta_disco/file_name.py
+++ b/src/meta_disco/file_name.py
@@ -8,15 +8,16 @@ string (epic #242).
 
 ``FileName`` is a pure data type; it is built by ``UnifiedRules.parse_file_name``
 (the parse is vocabulary-gated, so it lives with the rules). ``extension`` is
-syntactic — the exact suffix, ``.cram`` distinct from ``.bam`` — while
-``format`` is *derived*: what the file actually is, collapsing spelling and
-compression variants of one format to a single identity (``.fa``/``.fasta`` →
-``FASTA``). This increment (#243) derives the stage-1 format (from the extension
-alone, at parse time, no I/O) and records that provenance in ``format_source``;
-the follow-ups add the later derivation stages — stem/filename pattern
-(``FormatSource.STEM``) and a content/header read (``FormatSource.CONTENT``) —
-split the compression/archive wrappers out of the extension vocabulary (#244),
-and thread the parsed ``FileName`` from the load boundary (#246).
+syntactic — the exact core suffix, ``.cram`` distinct from ``.bam`` — with any
+compression/archive kept apart in ``wrappers`` (#244: ``sample.vcf.gz`` →
+extension ``.vcf`` + wrappers ``(".gz",)``). ``format`` is *derived*: what the
+file actually is, collapsing spelling and compression variants of one format to
+a single identity (``.fa``/``.fasta`` → ``FASTA``). #243 derives the stage-1
+format (from the core extension alone, at parse time, no I/O) and records that
+provenance in ``format_source``; the remaining follow-up adds the later
+derivation stages — stem/filename pattern (``FormatSource.STEM``) and a
+content/header read (``FormatSource.CONTENT``) — and threads the parsed
+``FileName`` from the load boundary (#246).
 """
 
 from dataclasses import dataclass
@@ -79,14 +80,16 @@ class FileName:
     ``raw`` is the name as given. In the pipeline it is never empty — the input
     contract (``^.+$``) diverts a nameless record to ``validation_failed`` before
     it is parsed — though ``FileName`` itself does not re-validate. ``extension``
-    is the known extension the rules key
-    on, or ``None`` when the name carries no known extension — never the junk
-    last-dot suffix ``UnifiedRules.extract_extension`` returns
-    (``"hprc-v1.0-mc-grch38"`` → ``".0-mc-grch38"``). ``wrappers`` are the
-    trailing compression/archive suffixes, in name order. ``stem`` is the
-    token-carrying part: the name with its known ``extension`` removed, or —
-    when there is none — its trailing ``wrappers`` stripped (an unknown suffix
-    like ``.xyz`` is kept, since it is neither a known extension nor a wrapper).
+    is the clean core suffix the rules key on (``.vcf``, not ``.vcf.gz``), or
+    ``None`` when the name carries no known extension — never the junk last-dot
+    suffix ``UnifiedRules.extract_extension`` returns (``"hprc-v1.0-mc-grch38"``
+    → ``".0-mc-grch38"``). ``wrappers`` are the trailing compression/archive
+    suffixes split off that core, in name order (#244: ``sample.vcf.gz`` →
+    extension ``.vcf``, wrappers ``(".gz",)``). ``stem`` is the token-carrying
+    part: the name with its whole recognized extension (core + wrappers) removed,
+    or — when there is none — its trailing ``wrappers`` stripped (an unknown
+    suffix like ``.xyz`` is kept, since it is neither a known extension nor a
+    wrapper).
 
     ``format`` is the derived canonical format (see :class:`Format`), ``None``
     when the extension maps to no seeded format (or there is no known extension).

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -575,16 +575,20 @@ class RuleEngine:
         # a filename to carry it (#152/#241).
         parsed_ext = self.rules.parse_file_name(ext_info.filename).extension if ext_info.filename else None
         if parsed_ext:
+            # From the real name: already the clean core, lower-cased by the parse.
             ext_info.file_format = parsed_ext
-        # Normalize the settled file_format to lower-case once, so every downstream
-        # comparison — the extensions filter, `when.file_format`, and the assay
-        # `file_format`/`file_format_not` conditions — is case-insensitive and
-        # consistent with matches_extension's own lowering. A header-only call may
-        # pass a mixed-case file_format (".CRAM"); parsed_ext is already lower-case
-        # (parse_file_name lowers it). Normalizing here means the matchers can
-        # compare directly without each re-lowering (#243).
-        if ext_info.file_format:
-            ext_info.file_format = ext_info.file_format.lower()
+        elif ext_info.file_format:
+            # No usable name — normalize the caller's file_format fallback to the
+            # clean core suffix, so it matches the core-keyed rules (#244) and is
+            # case-insensitive. Routing it back through parse_file_name (treating the
+            # token as a degenerate name) turns a compound fallback (".fastq.gz",
+            # passed by a header-only call) into its core (".fastq"); a non-extension
+            # label ("Other") parses to None and keeps its lower-cased self so it
+            # still matches nothing, as before (#152/#243). Only the fallback is
+            # normalized: parsed_ext is already core, and re-parsing e.g. ".g.vcf"
+            # as a name would wrongly collapse it to ".vcf" (its simple suffix).
+            core = self.rules.parse_file_name(ext_info.file_format).extension
+            ext_info.file_format = core if core is not None else ext_info.file_format.lower()
         extension = ext_info.file_format or ""
 
         # Derive the canonical format from the extension the engine settled on

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -580,15 +580,22 @@ class RuleEngine:
         elif ext_info.file_format:
             # No usable name — normalize the caller's file_format fallback to the
             # clean core suffix, so it matches the core-keyed rules (#244) and is
-            # case-insensitive. Routing it back through parse_file_name (treating the
-            # token as a degenerate name) turns a compound fallback (".fastq.gz",
-            # passed by a header-only call) into its core (".fastq"); a non-extension
-            # label ("Other") parses to None and keeps its lower-cased self so it
-            # still matches nothing, as before (#152/#243). Only the fallback is
-            # normalized: parsed_ext is already core, and re-parsing e.g. ".g.vcf"
-            # as a name would wrongly collapse it to ".vcf" (its simple suffix).
-            core = self.rules.parse_file_name(ext_info.file_format).extension
-            ext_info.file_format = core if core is not None else ext_info.file_format.lower()
+            # case-insensitive.
+            token = ext_info.file_format.lower()
+            if token in self.rules.EXTENSION_TO_FORMAT:
+                # Already a known core (e.g. ".g.vcf") — keep it. Re-parsing it as a
+                # name would collapse ".g.vcf" to ".vcf" via the simple-suffix gate,
+                # contradicting EXTENSION_TO_FORMAT[".g.vcf"] = GVCF. EXTENSION_TO_FORMAT
+                # is a sufficient "known core" test here because ".g.vcf" is the only
+                # core the gate mis-resolves; single-dot cores already re-parse to
+                # themselves. #246 will replace this proxy with an explicit core set.
+                ext_info.file_format = token
+            else:
+                # Normalize a compound fallback (".fastq.gz" -> ".fastq", passed by a
+                # header-only call); a non-extension label ("Other") parses to None and
+                # keeps its lower-cased self so it still matches nothing (#152/#243).
+                core = self.rules.parse_file_name(token).extension
+                ext_info.file_format = core if core is not None else token
         extension = ext_info.file_format or ""
 
         # Derive the canonical format from the extension the engine settled on

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -109,45 +109,38 @@ class UnifiedRules:
     ]
 
     # Compression and archive suffixes — "wrappers" around the format, not the
-    # format itself (see FileName). Kept as advice; in this foundation they are
-    # informational and may overlap the still-compound extension (the clean
-    # split is #244). Ordered longest-first (like COMPOUND_EXTENSIONS): the peel
-    # loop takes the first `endswith` match, so `.bgz` must precede `.gz` or a
-    # `.bgz` name would mis-peel as `.gz` and leave a dangling `b` in the stem.
+    # format itself (see FileName). Since #244 these do the real work of the
+    # extension/format split: parse_file_name splits a recognized extension token
+    # into its clean core suffix and these trailing wrappers (".vcf.gz" -> ".vcf"
+    # + (".gz",)). Ordered longest-first: the split/peel loop takes the first
+    # `endswith` match, so `.bgz` must precede `.gz` or a `.bgz` token would
+    # mis-peel as `.gz` and leave a dangling `b` on the core.
     WRAPPER_SUFFIXES: ClassVar[tuple[str, ...]] = (".bgz", ".bz2", ".zip", ".tar", ".gz", ".xz")
 
-    # Known extension -> canonical file Format (#243). Collapses the spelling and
-    # compression variants of one format to a single identity (.fa/.fasta/.fa.gz/
-    # .fasta.gz -> FASTA), the stage-1 derivation the rules key on via `format`.
-    # Seeded with the core sequencing formats; extensions with no clean canonical
-    # collapse are absent, so their format is None until a migrating group adds
-    # its identity (see Format). Keys are lower-case: extension_to_format lowers
-    # its argument before the lookup.
+    # Known core extension -> canonical file Format (#243). Keyed on the clean
+    # core suffix the parse now yields (#244): the compression/archive variants
+    # (.vcf.gz, .fastq.gz, .fast5.tar.gz, ...) collapse to their core at parse
+    # time, so a single core key (.vcf) covers every compressed spelling. Formats
+    # the size-threshold assay rules must tell apart stay distinct (.bam vs
+    # .cram). Seeded with the core sequencing formats; core extensions with no
+    # clean canonical collapse are absent, so their format is None until a
+    # migrating group adds its identity (see Format). Keys are lower-case:
+    # extension_to_format lowers its argument before the lookup.
     EXTENSION_TO_FORMAT: ClassVar[dict[str, Format]] = {
         ".bam": Format.BAM,
         ".cram": Format.CRAM,
         ".sam": Format.SAM,
-        ".sam.gz": Format.SAM,
         ".vcf": Format.VCF,
-        ".vcf.gz": Format.VCF,
         ".bcf": Format.BCF,
         ".gvcf": Format.GVCF,
-        ".gvcf.gz": Format.GVCF,
-        ".g.vcf.gz": Format.GVCF,
+        ".g.vcf": Format.GVCF,
         ".fastq": Format.FASTQ,
         ".fq": Format.FASTQ,
-        ".fastq.gz": Format.FASTQ,
-        ".fq.gz": Format.FASTQ,
         ".fasta": Format.FASTA,
         ".fa": Format.FASTA,
-        ".fasta.gz": Format.FASTA,
-        ".fa.gz": Format.FASTA,
         ".bed": Format.BED,
-        ".bed.gz": Format.BED,
         ".gfa": Format.GFA,
-        ".gfa.gz": Format.GFA,
         ".rgfa": Format.RGFA,
-        ".rgfa.gz": Format.RGFA,
     }
 
     def get_rules_by_scope(self, scope: str) -> list[UnifiedRule]:
@@ -192,50 +185,76 @@ class UnifiedRules:
             return "." + filename.rsplit(".", 1)[-1].lower()
         return ""
 
-    def parse_file_name(self, filename: str) -> "FileName":
-        """Parse ``filename`` into a :class:`FileName` against this vocabulary.
+    @classmethod
+    def _peel_wrappers(cls, token: str, *, keep_last: bool) -> tuple[str, tuple[str, ...]]:
+        """Peel trailing compression/archive ``WRAPPER_SUFFIXES`` off ``token``.
 
-        The parse is vocabulary-gated (it consults ``COMPOUND_EXTENSIONS`` /
-        ``extension_map`` / ``EXTENSION_TO_FORMAT``), so it lives here with the
-        rules rather than on the pure ``FileName`` data type. ``extension`` equals
-        ``extract_extension`` for every name with a known extension, so rule
-        routing is unchanged for those; a name with no known extension yields
-        ``None`` rather than the junk suffix ``extract_extension`` returns (which
-        matched no rules anyway). ``format`` is the stage-1 derivation from that
-        extension (``extension_to_format``), with ``format_source`` recording the
-        provenance — set together or both ``None`` (#243).
+        Peels longest-first and returns ``(remainder, wrappers)`` with the
+        wrappers in name order. ``keep_last`` chooses between the two uses:
+
+        - ``keep_last=True`` splits a *recognized* extension token into its core
+          and wrappers, stopping before the last remaining token so an archive
+          extension keeps its own suffix: ``.vcf.gz`` -> (``.vcf``, ``(".gz",)``);
+          ``.fast5.tar.gz`` -> (``.fast5``, ``(".tar", ".gz")``); ``.tar.gz`` ->
+          (``.tar``, ``(".gz",)``); ``.tar`` -> (``.tar``, ``()``).
+        - ``keep_last=False`` peels *every* trailing wrapper off an unrecognized
+          name, where no core is claimed and the remainder is only used to trim
+          the stem: ``notes.txt.gz`` -> (``notes.txt``, ``(".gz",)``).
         """
-        lower = filename.lower()
-
-        extension = None
-        for ext in self.COMPOUND_EXTENSIONS:
-            if lower.endswith(ext):
-                extension = ext
-                break
-        if extension is None and "." in filename:
-            simple = "." + filename.rsplit(".", 1)[-1].lower()
-            if simple in self.extension_map:
-                extension = simple
-
+        rest = token
         wrappers: list[str] = []
-        rest = lower
         while True:
-            for suffix in self.WRAPPER_SUFFIXES:
-                if rest.endswith(suffix):
+            for suffix in cls.WRAPPER_SUFFIXES:
+                if rest.endswith(suffix) and not (keep_last and rest == suffix):
                     wrappers.append(suffix)
                     rest = rest[: -len(suffix)]
                     break
             else:
                 break
-        wrappers.reverse()  # name order: "x.tar.gz" -> (".tar", ".gz")
+        wrappers.reverse()  # name order: ".tar.gz" -> (".tar", ".gz")
+        return rest, tuple(wrappers)
 
-        # The stem carries the name tokens only. Remove the known extension when
-        # there is one (a compound extension already subsumes its wrappers, e.g.
-        # ".vcf.gz"); otherwise strip the trailing wrappers so the stem does not
-        # keep the compression/archive advice ("notes.txt.gz" -> "notes.txt").
-        if extension:
-            stem = filename[: -len(extension)]
+    def parse_file_name(self, filename: str) -> "FileName":
+        """Parse ``filename`` into a :class:`FileName` against this vocabulary.
+
+        The parse is vocabulary-gated (it consults ``COMPOUND_EXTENSIONS`` /
+        ``extension_map`` / ``EXTENSION_TO_FORMAT``), so it lives here with the
+        rules rather than on the pure ``FileName`` data type.
+
+        *Which* names carry a routable extension is preserved: this recognizes the
+        same compound extensions as ``extract_extension``, then gates the simple
+        suffix on ``extension_map`` — so an unknown suffix yields ``None`` here,
+        where ``extract_extension`` returns the junk last-dot suffix (which matched
+        no rule anyway). What changed in #244 is the *representation*: the
+        recognized token is split into a clean core ``extension`` (``.vcf``) and the
+        ``wrappers`` it bundled (``(".gz",)``) — where before ``extension`` was the
+        whole compound (``.vcf.gz``). ``format`` is the stage-1 derivation
+        from the core extension (``extension_to_format``), with ``format_source``
+        recording the provenance — set together or both ``None`` (#243).
+        """
+        lower = filename.lower()
+
+        recognized = None
+        for ext in self.COMPOUND_EXTENSIONS:
+            if lower.endswith(ext):
+                recognized = ext
+                break
+        if recognized is None and "." in filename:
+            simple = "." + filename.rsplit(".", 1)[-1].lower()
+            if simple in self.extension_map:
+                recognized = simple
+
+        if recognized is not None:
+            # Split the recognized token into its clean core and wrappers (#244).
+            # The stem drops the whole recognized token (core + wrappers), so it
+            # carries only the name's tokens — unchanged from before the split.
+            extension, wrappers = self._peel_wrappers(recognized, keep_last=True)
+            stem = filename[: -len(recognized)]
         else:
+            # No known extension: peel every trailing wrapper as informational
+            # advice and strip them from the stem, but claim no core extension.
+            extension = None
+            _, wrappers = self._peel_wrappers(lower, keep_last=False)
             wrapper_len = sum(len(w) for w in wrappers)
             stem = filename[:-wrapper_len] if wrapper_len else filename
 
@@ -245,7 +264,7 @@ class UnifiedRules:
             raw=filename,
             stem=stem,
             extension=extension,
-            wrappers=tuple(wrappers),
+            wrappers=wrappers,
             format=fmt,
             format_source=format_source,
         )

--- a/src/meta_disco/rules/unified_rules.yaml
+++ b/src/meta_disco/rules/unified_rules.yaml
@@ -79,8 +79,11 @@
 # Extension/filename conditions:
 # - extensions: list of clean core file extensions to match (e.g., [".bam",
 #     ".cram"]). Compression/archive is split off into wrappers at parse time
-#     (#244), so a core matches every compressed spelling: ".vcf" matches both
-#     sample.vcf and sample.vcf.gz — never list ".vcf.gz" here. gVCF keeps its
+#     (#244), so a core matches every compressed spelling the parser recognizes
+#     — those enumerated in COMPOUND_EXTENSIONS (rule_loader.py): ".vcf" matches
+#     both sample.vcf and sample.vcf.gz (never list ".vcf.gz" here), but an
+#     unlisted spelling like sample.bam.gz is not recognized and matches nothing.
+#     gVCF keeps its
 #     own core (".g.vcf"): both classify as data_type variants, but ".g.vcf"
 #     derives Format.GVCF (vs Format.VCF), so the distinction is not lost.
 # - format: canonical file format to match (e.g., FASTA) — collapses the

--- a/src/meta_disco/rules/unified_rules.yaml
+++ b/src/meta_disco/rules/unified_rules.yaml
@@ -77,7 +77,11 @@
 # CONDITION TYPES (in 'when')
 # ---------------------------
 # Extension/filename conditions:
-# - extensions: list of file extensions to match (e.g., [".bam", ".cram"])
+# - extensions: list of clean core file extensions to match (e.g., [".bam",
+#     ".cram"]). Compression/archive is split off into wrappers at parse time
+#     (#244), so a core matches every compressed spelling: ".vcf" matches both
+#     sample.vcf and sample.vcf.gz — never list ".vcf.gz" here. gVCF keeps its
+#     own core (".g.vcf") because it is a distinct data_type signal, not just VCF.
 # - format: canonical file format to match (e.g., FASTA) — collapses the
 #     spelling/compression variants of one format (.fa/.fasta/.fa.gz/.fasta.gz)
 #     to a single identity, so key on this instead of re-listing extensions
@@ -347,7 +351,7 @@ rules:
     tier: 1
     scope: extension
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
     then:
       data_modality: genomic
       data_type: variants
@@ -387,7 +391,7 @@ rules:
     tier: 1
     scope: extension
     when:
-      extensions: [".h5ad", ".loom", ".mtx", ".mtx.gz"]
+      extensions: [".h5ad", ".loom", ".mtx"]
     then:
       data_modality: transcriptomic.single_cell
       data_type: expression_matrix
@@ -434,7 +438,7 @@ rules:
     tier: 2
     scope: extension
     when:
-      extensions: [".fast5", ".fast5.tar", ".fast5.tar.gz"]
+      extensions: [".fast5"]
     then:
       data_type: raw_signal
       platform: ONT
@@ -461,7 +465,7 @@ rules:
     tier: 2
     scope: extension
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
     then:
       data_type: reads
       status:
@@ -496,7 +500,7 @@ rules:
     tier: 1
     scope: extension
     when:
-      extensions: [".gfa", ".gfa.gz", ".rgfa", ".rgfa.gz", ".gbz", ".vg", ".gbwt", ".xg"]
+      extensions: [".gfa", ".rgfa", ".gbz", ".vg", ".gbwt", ".xg"]
     then:
       data_modality: genomic
       data_type: pangenome
@@ -516,7 +520,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bam", ".cram", ".sam", ".sam.gz"]
+      extensions: [".bam", ".cram", ".sam"]
       filename_pattern: "(?i)_rna_|rnaseq|rna-seq|transcriptome|_RNA\\."
     then:
       data_modality: transcriptomic.bulk
@@ -538,7 +542,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bam", ".cram", ".sam", ".sam.gz"]
+      extensions: [".bam", ".cram", ".sam"]
       filename_pattern: "(?i)scrna|sc_rna|single.?cell|10x|chromium"
     then:
       data_modality: transcriptomic.single_cell
@@ -549,7 +553,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bam", ".cram", ".sam", ".sam.gz"]
+      extensions: [".bam", ".cram", ".sam"]
       filename_pattern: "(?i)atac|_ATAC_"
     then:
       data_modality: epigenomic.chromatin_accessibility
@@ -561,7 +565,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bam", ".cram", ".sam", ".sam.gz"]
+      extensions: [".bam", ".cram", ".sam"]
       filename_pattern: "(?i)chip|_ChIP_|chipseq"
     then:
       data_modality: epigenomic.histone_modification
@@ -573,7 +577,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bam", ".cram", ".sam", ".sam.gz"]
+      extensions: [".bam", ".cram", ".sam"]
       filename_pattern: "(?i)_wgs_|_WGS\\.|whole.?genome"
     then:
       data_modality: genomic
@@ -585,7 +589,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bam", ".cram", ".sam", ".sam.gz"]
+      extensions: [".bam", ".cram", ".sam"]
       filename_pattern: "(?i)_wes_|exome|_WES\\."
     then:
       data_modality: genomic
@@ -597,7 +601,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bam", ".cram", ".sam", ".sam.gz"]
+      extensions: [".bam", ".cram", ".sam"]
       filename_pattern: "(?i)hifi|\\.hifi_reads\\.|pacbio|_pb_"
     then:
       data_modality: genomic
@@ -610,7 +614,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bam", ".cram", ".sam", ".sam.gz"]
+      extensions: [".bam", ".cram", ".sam"]
       filename_pattern: "(?i)Aligned\\.sortedByCoord|_STAR_|\\.star\\."
     then:
       data_modality: transcriptomic.bulk
@@ -630,7 +634,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".gfa", ".gfa.gz", ".rgfa", ".rgfa.gz", ".gbz", ".vg", ".gbwt", ".xg"]
+      extensions: [".gfa", ".rgfa", ".gbz", ".vg", ".gbwt", ".xg"]
       filename_pattern: "(?i)-mc-"
     then:
       data_modality: genomic
@@ -691,7 +695,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       filename_pattern: "(?i)_rna_|rnaseq|transcriptome"
     then:
       data_modality: transcriptomic.bulk
@@ -702,7 +706,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       filename_pattern: "(?i)scrna|single.?cell|10x"
     then:
       data_modality: transcriptomic.single_cell
@@ -713,7 +717,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       filename_pattern: "(?i)atac"
     then:
       data_modality: epigenomic.chromatin_accessibility
@@ -725,7 +729,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       filename_pattern: "(?i)_wgs_|whole.?genome"
     then:
       data_modality: genomic
@@ -769,7 +773,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".h5ad", ".loom", ".mtx", ".mtx.gz"]
+      extensions: [".h5ad", ".loom", ".mtx"]
       filename_pattern: "(?i)atac|peaks"
     then:
       data_modality: epigenomic.chromatin_accessibility
@@ -784,7 +788,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".fast5", ".pod5", ".fast5.tar", ".fast5.tar.gz"]
+      extensions: [".fast5", ".pod5"]
       filename_pattern: "(?i)rna|direct.?rna"
     then:
       data_modality: transcriptomic.bulk
@@ -799,7 +803,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bed", ".bed.gz"]
+      extensions: [".bed"]
       filename_pattern: "(?i)(modbam2bed|cpg|methylat|bisulfite|wgbs)"
     then:
       data_modality: epigenomic.methylation
@@ -811,7 +815,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bed", ".bed.gz"]
+      extensions: [".bed"]
       filename_pattern: "(?i)(TMM|TPM|RPKM|FPKM|counts|expression|leafcutter|\\.TSS\\.)"
     then:
       data_modality: transcriptomic.bulk
@@ -823,7 +827,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bed", ".bed.gz"]
+      extensions: [".bed"]
       filename_pattern: "(?i)(\\.atac\\.|atac[-_]?seq|atacseq)"
     then:
       data_modality: epigenomic.chromatin_accessibility
@@ -835,7 +839,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bed", ".bed.gz"]
+      extensions: [".bed"]
       filename_pattern: "(?i)(\\.chip\\.|chip[-_]?seq|chipseq|histone|h3k\\d+)"
     then:
       data_modality: epigenomic.histone_modification
@@ -847,7 +851,7 @@ rules:
     tier: 1
     scope: filename
     when:
-      extensions: [".bed", ".bed.gz", ".narrowpeak", ".broadpeak"]
+      extensions: [".bed", ".narrowpeak", ".broadpeak"]
       filename_pattern: "(?i)(peak|summit|narrowPeak|broadPeak)"
     then:
       data_modality: epigenomic.chromatin_accessibility
@@ -858,7 +862,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bed", ".bed.gz"]
+      extensions: [".bed"]
       filename_pattern: "(?i)(\\.hap[12]\\.|[\\./_]paternal[\\./_]|[\\./_]maternal[\\./_]|\\.dip\\.bed|\\.switch\\.|flagger|\\.lowQ\\.|unreliable|issues\\.bed|_genbank\\.)"
     then:
       data_modality: genomic
@@ -869,7 +873,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bed", ".bed.gz"]
+      extensions: [".bed"]
       filename_pattern: "\\.regions\\.bed"
     then:
       data_modality: genomic
@@ -921,7 +925,7 @@ rules:
     tier: 1
     scope: filename
     when:
-      extensions: [".bed", ".bed.gz"]
+      extensions: [".bed"]
       filename_pattern: "(?i)targets?|regions?|capture|exome"
     then:
       status:
@@ -938,7 +942,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bed", ".bed.gz", ".narrowpeak", ".broadpeak"]
+      extensions: [".bed", ".narrowpeak", ".broadpeak"]
       filename_pattern: "(?i)chip|h3k|histone"
     then:
       data_modality: epigenomic.histone_modification
@@ -993,7 +997,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".tar", ".tar.gz"]
+      extensions: [".tar"]
       filename_pattern: "^chr[0-9XY]+\\.[0-9]+_[0-9]+\\.tar$"
       dataset_pattern: "(?i)t2t"
     then:
@@ -1354,7 +1358,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##reference"
       vcf_pattern: "(?i)(grch38|hg38|hs38|GCA_000001405\\.(1[5-9]|[2-9]\\d|\\d{3,}))"
     then:
@@ -1365,7 +1369,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##reference"
       vcf_pattern: "(?i)(grch37|hg19|hs37|GCA_000001405\\.(1[0-4]|[1-9])(?!\\d)|b37)"
     then:
@@ -1376,7 +1380,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##reference"
       vcf_pattern: "(?i)(chm13|t2t|hs1)"
     then:
@@ -1387,7 +1391,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##contig"
       vcf_pattern: "(?i)(grch38|hg38|hs38|GCA_000001405\\.(1[5-9]|[2-9]\\d|\\d{3,}))"
     then:
@@ -1398,7 +1402,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##contig"
       vcf_pattern: "(?i)(grch37|hg19|hs37|GCA_000001405\\.(1[0-4]|[1-9])(?!\\d)|b37)"
     then:
@@ -1409,7 +1413,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##contig"
       vcf_pattern: "(?i)(chm13|t2t|hs1)"
     then:
@@ -1423,7 +1427,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)haplotypecaller"
     then:
@@ -1435,7 +1439,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)deepvariant"
     then:
@@ -1447,7 +1451,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)genotypegvcfs"
     then:
@@ -1459,7 +1463,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)glnexus"
     then:
@@ -1471,7 +1475,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)bcftools.*call"
     then:
@@ -1483,7 +1487,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)freebayes"
     then:
@@ -1495,7 +1499,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)strelka2.*germline|strelka2(?!.*somatic)"
     then:
@@ -1510,7 +1514,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)mutect2?"
     then:
@@ -1522,7 +1526,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)strelka.*somatic|strelka(?!.*germline)"
     then:
@@ -1534,7 +1538,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)varscan.*somatic"
     then:
@@ -1546,7 +1550,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)somaticsniper"
     then:
@@ -1558,7 +1562,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)muse"
     then:
@@ -1573,7 +1577,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf"]
+      extensions: [".vcf", ".bcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)manta"
     then:
@@ -1585,7 +1589,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf"]
+      extensions: [".vcf", ".bcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)delly"
     then:
@@ -1597,7 +1601,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf"]
+      extensions: [".vcf", ".bcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)lumpy"
     then:
@@ -1609,7 +1613,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf"]
+      extensions: [".vcf", ".bcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)smoove"
     then:
@@ -1621,7 +1625,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf"]
+      extensions: [".vcf", ".bcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)svim"
     then:
@@ -1633,7 +1637,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf"]
+      extensions: [".vcf", ".bcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)sniffles"
     then:
@@ -1645,7 +1649,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf"]
+      extensions: [".vcf", ".bcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)pbsv"
     then:
@@ -1657,7 +1661,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf"]
+      extensions: [".vcf", ".bcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)cutesv"
     then:
@@ -1672,7 +1676,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf"]
+      extensions: [".vcf", ".bcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)cnvkit"
     then:
@@ -1684,7 +1688,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf"]
+      extensions: [".vcf", ".bcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)gatk.*(cnv|copynumber)|modelsegments"
     then:
@@ -1696,7 +1700,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf"]
+      extensions: [".vcf", ".bcf"]
       vcf_header_type: "##source"
       vcf_pattern: "(?i)canvas"
     then:
@@ -1711,7 +1715,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf", ".gvcf", ".gvcf.gz", ".g.vcf.gz"]
+      extensions: [".vcf", ".bcf", ".gvcf", ".g.vcf"]
       vcf_header_type: "##INFO"
       vcf_pattern: "^(SOMATIC|TUMOR_|NORMAL_|TumorVAF|NormalVAF)"
     then:
@@ -1722,7 +1726,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf"]
+      extensions: [".vcf", ".bcf"]
       vcf_header_type: "##INFO"
       vcf_pattern: "^(SVTYPE|SVLEN|CIPOS|CIEND|MATEID|IMPRECISE)$"
     then:
@@ -1733,7 +1737,7 @@ rules:
     tier: 3
     scope: vcf_header
     when:
-      extensions: [".vcf", ".vcf.gz", ".bcf"]
+      extensions: [".vcf", ".bcf"]
       vcf_header_type: "##INFO"
       vcf_pattern: "^(CN|FOLD_CHANGE|PROBES|LOG2_COPY_RATIO)$"
     then:
@@ -1751,7 +1755,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@[A-Z0-9-]+:\\d+:[A-Z0-9]+:\\d+:\\d+:\\d+:\\d+"
     then:
       platform: ILLUMINA
@@ -1761,7 +1765,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@[A-Z0-9-]+:\\d+:\\d+:\\d+:\\d+#"
     then:
       platform: ILLUMINA
@@ -1771,7 +1775,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@SRR\\d+\\.\\d+"
     then:
       platform: ILLUMINA
@@ -1781,7 +1785,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: " HS2[05]00[-_]"
     then:
       platform: ILLUMINA
@@ -1791,7 +1795,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@[EDS]RR\\d+\\.\\d+ HS2[05]00"
     then:
       platform: ILLUMINA
@@ -1804,7 +1808,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@m\\d+[A-Za-z]*_\\d+_\\d+/\\d+/ccs"
     then:
       platform: PACBIO
@@ -1815,7 +1819,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@m\\d+[A-Za-z]*_\\d+_\\d+/\\d+/\\d+_\\d+"
     then:
       platform: PACBIO
@@ -1826,7 +1830,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@m\\d+[A-Za-z]*_\\d+_\\d+/\\d+"
     then:
       platform: PACBIO
@@ -1840,7 +1844,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
     then:
       platform: ONT
@@ -1851,7 +1855,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "runid=[a-f0-9]+"
     then:
       platform: ONT
@@ -1865,7 +1869,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@[A-Z]\\d{9}L\\dC\\d{3}R\\d{3}\\d+"
     then:
       platform: MGI
@@ -1875,7 +1879,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@[A-Z]\\d+L\\d+C\\d+R\\d+"
     then:
       platform: MGI
@@ -1888,7 +1892,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@[A-Z0-9]+:[A-Z0-9]+:\\d+:\\d+:\\d+:\\d+:\\d+"
     then:
       platform: ELEMENT
@@ -1901,7 +1905,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@[A-Z0-9]+_\\d+_\\d+_\\d+_[ACGT]+"
     then:
       platform: ULTIMA
@@ -1914,7 +1918,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@ERR\\d+\\.\\d+"
     then: {}
     rationale: "ERR accessions indicate data from the European Nucleotide Archive (ENA)"
@@ -1923,7 +1927,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@SRR\\d+\\.\\d+"
     then: {}
     rationale: "SRR accessions indicate data from NCBI Sequence Read Archive (SRA)"
@@ -1932,7 +1936,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "^@DRR\\d+\\.\\d+"
     then: {}
     rationale: "DRR accessions indicate data from DDBJ Sequence Read Archive (Japan)"
@@ -1944,7 +1948,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       fastq_pattern: "[/\\s][12]$|[/\\s][12]:|_R[12]_|\\.R[12]\\.|_r[12]_|\\.r[12]\\."
     then: {}
     rationale: "Read 1/2 indicators (/1, /2, _R1_, _R2_) suggest paired-end sequencing"
@@ -1956,7 +1960,7 @@ rules:
     tier: 3
     scope: fastq_header
     when:
-      extensions: [".fastq", ".fq", ".fastq.gz", ".fq.gz"]
+      extensions: [".fastq", ".fq"]
       modality_not_set: true
     then:
       status:
@@ -1971,7 +1975,7 @@ rules:
     tier: 2
     scope: filename
     when:
-      extensions: [".bed", ".bed.gz", ".narrowpeak", ".broadpeak"]
+      extensions: [".bed", ".narrowpeak", ".broadpeak"]
       modality_not_set: true
     then:
       data_modality: genomic

--- a/src/meta_disco/rules/unified_rules.yaml
+++ b/src/meta_disco/rules/unified_rules.yaml
@@ -81,7 +81,8 @@
 #     ".cram"]). Compression/archive is split off into wrappers at parse time
 #     (#244), so a core matches every compressed spelling: ".vcf" matches both
 #     sample.vcf and sample.vcf.gz — never list ".vcf.gz" here. gVCF keeps its
-#     own core (".g.vcf") because it is a distinct data_type signal, not just VCF.
+#     own core (".g.vcf"): both classify as data_type variants, but ".g.vcf"
+#     derives Format.GVCF (vs Format.VCF), so the distinction is not lost.
 # - format: canonical file format to match (e.g., FASTA) — collapses the
 #     spelling/compression variants of one format (.fa/.fasta/.fa.gz/.fasta.gz)
 #     to a single identity, so key on this instead of re-listing extensions

--- a/tests/test_file_name.py
+++ b/tests/test_file_name.py
@@ -19,17 +19,37 @@ class TestExtension:
         assert fn.wrappers == ()
         assert fn.stem == "HG00741.final"
 
-    def test_compound_extension_strips_to_stem(self):
+    def test_compound_extension_splits_core_from_wrapper(self):
+        """#244: the compression is split off, so extension is the clean core
+        (``.vcf``) with ``.gz`` recorded as a wrapper."""
         fn = parse("sample.vcf.gz")
-        assert fn.extension == ".vcf.gz"
+        assert fn.extension == ".vcf"
         assert fn.wrappers == (".gz",)
         assert fn.stem == "sample"
 
-    def test_archive_extension(self):
+    def test_archive_extension_keeps_tar_as_core(self):
+        """A gzipped tarball: ``.tar`` is the core extension (an archive is a real
+        file type), ``.gz`` the wrapper — the last token is never peeled away."""
         fn = parse("hprc-graph.tar.gz")
-        assert fn.extension == ".tar.gz"
-        assert fn.wrappers == (".tar", ".gz")
+        assert fn.extension == ".tar"
+        assert fn.wrappers == (".gz",)
         assert fn.stem == "hprc-graph"
+
+    def test_gvcf_keeps_its_own_core(self):
+        """``.g.vcf.gz`` splits to the ``.g.vcf`` core (a distinct gVCF signal),
+        not ``.vcf`` — only the ``.gz`` wrapper is peeled."""
+        fn = parse("HG002.deepvariant.g.vcf.gz")
+        assert fn.extension == ".g.vcf"
+        assert fn.wrappers == (".gz",)
+        assert fn.stem == "HG002.deepvariant"
+
+    def test_double_wrapper_peels_both(self):
+        """``.fast5.tar.gz`` is tar-archived and gzip-compressed around a
+        ``.fast5`` core — both wrappers peel, in name order."""
+        fn = parse("run.fast5.tar.gz")
+        assert fn.extension == ".fast5"
+        assert fn.wrappers == (".tar", ".gz")
+        assert fn.stem == "run"
 
     def test_extensionless_name_is_none_not_junk(self):
         """The bug this fixes: extract_extension returns a junk last-dot suffix
@@ -48,9 +68,11 @@ class TestExtension:
 
 
 class TestBehaviorPreservation:
-    """For every name that has a *known* extension, the parsed extension matches
-    what the engine derived before (extract_extension) — so rule routing is
-    unchanged. Only unknown/absent extensions differ (junk suffix -> None)."""
+    """For every name with a *known* extension, the core extension plus its
+    wrappers reconstruct exactly what the engine derived before (the compound
+    ``extract_extension``) — so #244 changes the *representation*, not *which*
+    names carry an extension. Rule routing is preserved: the core now stands in
+    for the old compound (the rule ``extensions:`` lists were migrated in step)."""
 
     @pytest.mark.parametrize(
         "name",
@@ -68,10 +90,13 @@ class TestBehaviorPreservation:
             "graph.rgfa",
             "NUFIP1_quant.sf",
             "archive.tar.gz",
+            "run.fast5.tar.gz",
         ],
     )
-    def test_known_extension_matches_extract_extension(self, name):
-        assert parse(name).extension == RULES.extract_extension(name)
+    def test_core_plus_wrappers_reconstructs_old_compound(self, name):
+        fn = parse(name)
+        assert fn.extension is not None
+        assert fn.extension + "".join(fn.wrappers) == RULES.extract_extension(name)
 
 
 class TestFormat:

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -239,9 +239,11 @@ class TestFormatMatching:
 
 class TestWrapperSplitMatching:
     """#244: rule `extensions:` are the clean core suffix; compression/archive is
-    split into wrappers at parse time. A core matches both the compressed and
-    uncompressed spelling, so classification is unchanged by whether a file is
-    gzipped."""
+    split into wrappers at parse time. A core matches the uncompressed spelling
+    and every compressed spelling the parser recognizes (those in
+    COMPOUND_EXTENSIONS), so classification is unchanged by whether such a file is
+    gzipped — an unlisted spelling like ".bam.gz" is not recognized and matches
+    nothing."""
 
     @pytest.mark.parametrize("name", ["cohort.vcf.gz", "reads.fastq.gz", "reads.fq.gz"])
     def test_core_keyed_rule_matches_compressed_and_uncompressed(self, engine, name):
@@ -269,6 +271,16 @@ class TestWrapperSplitMatching:
         assert ext_info.file_format == ".fastq"
         assert ext_info.format is Format.FASTQ
         assert result.data_type == "reads"
+
+    def test_known_core_file_format_fallback_not_collapsed(self, engine):
+        """A header-only fallback that is already a known core (".g.vcf") is kept,
+        not re-parsed — re-parsing would collapse it to ".vcf" via the simple-suffix
+        gate and derive Format.VCF, contradicting EXTENSION_TO_FORMAT[".g.vcf"]=GVCF
+        (Copilot review, #244)."""
+        ext_info = ExtendedFileInfo(filename="", file_format=".g.vcf")
+        engine.classify_extended(ext_info)
+        assert ext_info.file_format == ".g.vcf"
+        assert ext_info.format is Format.GVCF
 
 
 class TestThenStatus:

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -237,6 +237,40 @@ class TestFormatMatching:
         assert none_info.format is None
 
 
+class TestWrapperSplitMatching:
+    """#244: rule `extensions:` are the clean core suffix; compression/archive is
+    split into wrappers at parse time. A core matches both the compressed and
+    uncompressed spelling, so classification is unchanged by whether a file is
+    gzipped."""
+
+    @pytest.mark.parametrize("name", ["cohort.vcf.gz", "reads.fastq.gz", "reads.fq.gz"])
+    def test_core_keyed_rule_matches_compressed_and_uncompressed(self, engine, name):
+        """The extension rules list only the core (".vcf"), yet both sample.vcf and
+        sample.vcf.gz route through it — the compression no longer needs listing."""
+        compressed = engine.classify_extended(FileInfo(filename=name))
+        bare = engine.classify_extended(FileInfo(filename=name.replace(".gz", "")))
+        assert compressed.data_type == bare.data_type
+        assert compressed.data_type is not None
+
+    def test_gvcf_core_keeps_its_distinct_signal(self, engine):
+        """`.g.vcf.gz` splits to the `.g.vcf` core, which derives Format.GVCF and
+        still matches the VCF rules that list `.g.vcf` (behavior-preserved)."""
+        ext_info = ExtendedFileInfo(filename="HG002.deepvariant.g.vcf.gz")
+        result = engine.classify_extended(ext_info)
+        assert ext_info.format is Format.GVCF
+        assert result.data_type == "variants"
+
+    def test_compound_file_format_fallback_normalized_to_core(self, engine):
+        """A header-only call passing a compound file_format (".fastq.gz") with no
+        filename settles to the core (".fastq") so the core-keyed rules still fire
+        — the regression the #244 core-keying would otherwise introduce."""
+        ext_info = ExtendedFileInfo(filename="", file_format=".fastq.gz")
+        result = engine.classify_extended(ext_info)
+        assert ext_info.file_format == ".fastq"
+        assert ext_info.format is Format.FASTQ
+        assert result.data_type == "reads"
+
+
 class TestThenStatus:
     """A rule authoring a non-classified status via `then.status` (#133)."""
 


### PR DESCRIPTION
Closes #244. Part of epic #242; depends on #241 and #243 (both merged).

## What changed

The rule vocabulary used to key on **compound** extensions that baked in compression/archive — `.vcf.gz`, `.g.vcf.gz`, `.fastq.gz`, `.fast5.tar.gz`, `.tar.gz`. This makes the extension/wrapper split real:

- **`parse_file_name`** now yields a clean core `extension` (`.vcf`) with compression/archive split into `wrappers` (`(".gz",)`). It recognizes an extension token exactly as before (same `COMPOUND_EXTENSIONS` + `extension_map` gate — so *which* names carry an extension is unchanged), then splits the recognized token via one new helper `_peel_wrappers(token, *, keep_last)`.
- The gnarly compounds are handled: `.g.vcf.gz` → `.g.vcf` (gVCF keeps its own distinct core), `.fast5.tar.gz` → `.fast5` + `(".tar", ".gz")`, `.tar.gz` → `.tar` + `(".gz",)` (an archive keeps its own `.tar` core — the last token is never peeled).
- **`EXTENSION_TO_FORMAT`** re-keyed to cores (adds `.g.vcf` → `GVCF`).
- **`unified_rules.yaml`**: ~30 `extensions:` lists drop the now-redundant compressed spellings; the 20 gVCF-matching VCF rules gain `.g.vcf`.
- **`classify_extended`** normalizes a caller's compound `file_format` fallback to its core, so header-only calls still match the core-keyed rules.

## Why

Every rule that listed a compressed variant (`.vcf.gz`) already listed its uncompressed core (`.vcf`) beside it and treated them identically — so compression was duplicated across ~30 lists and never actually branched a classification. Collapsing to the core removes that duplication and lets a rule say the format once, with compression as a separate fact (the epic's `extension ≠ format` goal).

## Assumptions I made

- **Behavior-preserving is the hard requirement.** No classification output may change. Verified two ways: all 786 tests (incl. the end-to-end golden fixture) pass unchanged, and an extension+filename A/B of the rule engine over **100,670 unique real AnVIL file names** shows **zero drift** vs `main`.
- **gVCF stays a distinct core (`.g.vcf`), not collapsed to `.vcf`** (chosen over the issue's "profile hint" framing). gVCF is the same *format* as VCF but a distinct content profile; `.g.vcf` is a clean self-contained core, so keeping it is fully behavior-preserving and needs no new `profile` concept. `Format.GVCF` (from #243) already carries the identity.
- **No `compressed`/wrapper condition was added.** Analysis showed **no** classification rule branches on compression, so adding an unused condition would be YAGNI. The one archive rule keeps working via its core `.tar` + its existing `filename_pattern`.
- **`extract_extension` stays compound.** It feeds the record-routing / `filename_for_rules` graft path, which operates on raw names and is a separate concern from rule-matching. Leaving it untouched keeps routing byte-for-byte identical.
- Follow-ups filed as **#249** (eliminate fabricated filename/extension fallbacks per the epic's "no fabricated names" goal; make the core-extension vocabulary explicit; prune dead `extension_map` compound keys).

## How to verify

Issue #244 definition of done → steps:

1. **Extension is the clean core, wrappers split out.**
   `uv run python -c "from meta_disco.rule_loader import get_unified_rules as g; r=g(); [print(n, r.parse_file_name(n).extension, r.parse_file_name(n).wrappers) for n in ['a.vcf.gz','a.g.vcf.gz','a.fast5.tar.gz','a.tar.gz','a.tar']]"`
   Expect: `.vcf ('.gz',)` / `.g.vcf ('.gz',)` / `.fast5 ('.tar', '.gz')` / `.tar ('.gz',)` / `.tar ()`.

2. **Gnarly compounds handled** (`.g.vcf.gz`, `.fast5.tar.gz`) — covered by step 1 and by `tests/test_file_name.py::TestExtension` (`test_gvcf_keeps_its_own_core`, `test_double_wrapper_peels_both`) and `tests/test_rule_engine.py::TestWrapperSplitMatching`.

3. **Behavior-preserving (golden + corpus spot-check).**
   - `make test` → 786 passed (the golden fixture is the end-to-end gate).
   - Corpus A/B: run the rule engine over a strided sample of `data/anvil/anvil_files_metadata_no_md5.ndjson` on this branch and on `main`, diff every field → **0 differing lines** across 100,670 unique names. (Method: `engine.classify_extended(FileInfo(filename=name)).to_output_dict()` per unique name, sorted, `diff`.)

4. **Coordinated with `format`.** `.g.vcf.gz` still resolves `Format.GVCF`; VCF rules still fire — `tests/test_rule_engine.py::TestWrapperSplitMatching::test_gvcf_core_keeps_its_distinct_signal`.

5. Gate: `make test`, `make lint`, `make format-check`, `uv run pyright src/meta_disco/` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)