### PR TITLE
Make the core-extension vocabulary explicit; recognize .g.vcf (#249)

### DIFF
--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -578,24 +578,18 @@ class RuleEngine:
             # From the real name: already the clean core, lower-cased by the parse.
             ext_info.file_format = parsed_ext
         elif ext_info.file_format:
-            # No usable name — normalize the caller's file_format fallback to the
+            # No usable name — normalize the caller's file_format fallback to its
             # clean core suffix, so it matches the core-keyed rules (#244) and is
-            # case-insensitive.
-            token = ext_info.file_format.lower()
-            if token in self.rules.EXTENSION_TO_FORMAT:
-                # Already a known core (e.g. ".g.vcf") — keep it. Re-parsing it as a
-                # name would collapse ".g.vcf" to ".vcf" via the simple-suffix gate,
-                # contradicting EXTENSION_TO_FORMAT[".g.vcf"] = GVCF. EXTENSION_TO_FORMAT
-                # is a sufficient "known core" test here because ".g.vcf" is the only
-                # core the gate mis-resolves; single-dot cores already re-parse to
-                # themselves. #246 will replace this proxy with an explicit core set.
-                ext_info.file_format = token
-            else:
-                # Normalize a compound fallback (".fastq.gz" -> ".fastq", passed by a
-                # header-only call); a non-extension label ("Other") parses to None and
-                # keeps its lower-cased self so it still matches nothing (#152/#243).
-                core = self.rules.parse_file_name(token).extension
-                ext_info.file_format = core if core is not None else token
+            # case-insensitive. Route it through parse_file_name (treating the token
+            # as a degenerate name): a compound fallback (".fastq.gz", passed by a
+            # header-only call) becomes its core (".fastq"), and since #249 the parser
+            # recognizes multi-dot cores directly, so ".g.vcf" stays ".g.vcf"
+            # (Format.GVCF) rather than collapsing to ".vcf" — which is why the #244
+            # known-core short-circuit is no longer needed. A non-extension label
+            # ("Other") parses to None and keeps its lower-cased self, matching
+            # nothing (#152/#243).
+            core = self.rules.parse_file_name(ext_info.file_format).extension
+            ext_info.file_format = core if core is not None else ext_info.file_format.lower()
         extension = ext_info.file_format or ""
 
         # Derive the canonical format from the extension the engine settled on

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -1,6 +1,7 @@
 """Loader for unified classification rules from YAML."""
 
 from dataclasses import dataclass, field
+from functools import cached_property
 from importlib.resources import files
 from pathlib import Path
 from typing import Any, ClassVar
@@ -159,6 +160,37 @@ class UnifiedRules:
         """Get the file type for an extension."""
         return self.extension_map.get(extension.lower())
 
+    @cached_property
+    def core_extensions(self) -> frozenset[str]:
+        """The explicit set of producible core extensions (#249).
+
+        The single source of truth for which clean core suffixes the parse can
+        yield — previously only implicit, emergent from ``COMPOUND_EXTENSIONS`` and
+        the ``extension_map`` gate. Derived from every in-code source of core
+        truth, so it cannot drift from them: every compound extension with its
+        wrappers stripped (which is where the multi-dot core ``.g.vcf`` comes from
+        — ``peel(".g.vcf.gz")``), the single-dot ``extension_map`` keys (the simple
+        extensions), and the ``EXTENSION_TO_FORMAT`` keys (a format-mapped
+        extension is a producible core by definition, so unioning it keeps ``.g.vcf``
+        producible even if its compressed spelling were removed). Lower-cased, since
+        recognition matches against a lower-cased name. Consumed by
+        ``parse_file_name`` (the single-dot recognition lookup and, via
+        :attr:`_multi_dot_cores`, the multi-dot scan) and pinned by the
+        rule-vocabulary drift tests.
+        """
+        cores = {self._peel_wrappers(c, keep_last=True)[0] for c in self.COMPOUND_EXTENSIONS}
+        cores |= {k.lower() for k in self.extension_map if k.count(".") == 1}
+        cores |= {k.lower() for k in self.EXTENSION_TO_FORMAT}
+        return frozenset(cores)
+
+    @cached_property
+    def _multi_dot_cores(self) -> tuple[str, ...]:
+        """The core extensions with more than one dot (e.g. ``.g.vcf``), longest-
+        first. These are the only cores a last-dot-token lookup cannot recognize,
+        so ``parse_file_name`` scans just these before the O(1) single-dot lookup;
+        longest-first lets a multi-dot core win over a shorter multi-dot tail."""
+        return tuple(sorted((c for c in self.core_extensions if c.count(".") > 1), key=len, reverse=True))
+
     def extension_to_format(self, extension: str | None) -> Format | None:
         """Derive the canonical :class:`Format` for an extension (#243).
 
@@ -218,19 +250,22 @@ class UnifiedRules:
         """Parse ``filename`` into a :class:`FileName` against this vocabulary.
 
         The parse is vocabulary-gated (it consults ``COMPOUND_EXTENSIONS`` /
-        ``extension_map`` / ``EXTENSION_TO_FORMAT``), so it lives here with the
+        ``core_extensions`` / ``EXTENSION_TO_FORMAT``), so it lives here with the
         rules rather than on the pure ``FileName`` data type.
 
-        *Which* names carry a routable extension is preserved: this recognizes the
-        same compound extensions as ``extract_extension``, then gates the simple
-        suffix on ``extension_map`` — so an unknown suffix yields ``None`` here,
-        where ``extract_extension`` returns the junk last-dot suffix (which matched
-        no rule anyway). What changed in #244 is the *representation*: the
-        recognized token is split into a clean core ``extension`` (``.vcf``) and the
-        ``wrappers`` it bundled (``(".gz",)``) — where before ``extension`` was the
-        whole compound (``.vcf.gz``). ``format`` is the stage-1 derivation
-        from the core extension (``extension_to_format``), with ``format_source``
-        recording the provenance — set together or both ``None`` (#243).
+        Recognition is a wrapper-bearing ``COMPOUND_EXTENSIONS`` match, else the
+        known core the name ends with — the multi-dot cores scanned longest-first,
+        then an O(1) lookup of the single-dot last token (#249); an unknown suffix
+        yields ``None`` here, where ``extract_extension`` returns the junk last-dot
+        suffix (which
+        matched no rule anyway). #244 made the *representation* a clean core
+        ``extension`` (``.vcf``) plus the ``wrappers`` it bundled (``(".gz",)``),
+        not the whole compound (``.vcf.gz``); #249 made the core set explicit, which
+        also lets a multi-dot core be recognized in its uncompressed spelling
+        (``sample.g.vcf`` → ``.g.vcf``, matching the compressed ``.g.vcf.gz`` form).
+        ``format`` is the stage-1 derivation from the core extension
+        (``extension_to_format``), with ``format_source`` recording the provenance
+        — set together or both ``None`` (#243).
         """
         lower = filename.lower()
 
@@ -239,10 +274,23 @@ class UnifiedRules:
             if lower.endswith(ext):
                 recognized = ext
                 break
-        if recognized is None and "." in filename:
-            simple = "." + filename.rsplit(".", 1)[-1].lower()
-            if simple in self.extension_map:
-                recognized = simple
+        if recognized is None:
+            # No wrapper-bearing compound matched — recognize the known core the
+            # name ends with (#249). Multi-dot cores (".g.vcf") are scanned first,
+            # longest-first, so one wins over its shorter tail (".vcf"); the common
+            # single-dot case is then an O(1) lookup of the last dot-token. Every
+            # core's leading dot makes both a genuine extension-boundary match, so
+            # the single-dot path is equivalent to the old extension_map gate and
+            # only the multi-dot scan is new (an uncompressed ".g.vcf").
+            for core in self._multi_dot_cores:
+                if lower.endswith(core):
+                    recognized = core
+                    break
+            else:
+                if "." in filename:
+                    simple = "." + filename.rsplit(".", 1)[-1].lower()
+                    if simple in self.core_extensions:
+                        recognized = simple
 
         if recognized is not None:
             # Split the recognized token into its clean core and wrappers (#244).

--- a/tests/test_file_name.py
+++ b/tests/test_file_name.py
@@ -43,6 +43,17 @@ class TestExtension:
         assert fn.wrappers == (".gz",)
         assert fn.stem == "HG002.deepvariant"
 
+    def test_uncompressed_gvcf_recognized_as_core(self):
+        """#249: an uncompressed ``sample.g.vcf`` is recognized as the ``.g.vcf``
+        core (→ Format.GVCF), consistent with the compressed spelling — where the
+        old single-suffix gate resolved it to ``.vcf``. Longest-first core matching
+        picks ``.g.vcf`` over its ``.vcf`` tail."""
+        fn = parse("HG002.deepvariant.g.vcf")
+        assert fn.extension == ".g.vcf"
+        assert fn.format is Format.GVCF
+        assert fn.wrappers == ()
+        assert fn.stem == "HG002.deepvariant"
+
     def test_double_wrapper_peels_both(self):
         """``.fast5.tar.gz`` is tar-archived and gzip-compressed around a
         ``.fast5`` core — both wrappers peel, in name order."""

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -273,10 +273,11 @@ class TestWrapperSplitMatching:
         assert result.data_type == "reads"
 
     def test_known_core_file_format_fallback_not_collapsed(self, engine):
-        """A header-only fallback that is already a known core (".g.vcf") is kept,
-        not re-parsed — re-parsing would collapse it to ".vcf" via the simple-suffix
-        gate and derive Format.VCF, contradicting EXTENSION_TO_FORMAT[".g.vcf"]=GVCF
-        (Copilot review, #244)."""
+        """A header-only fallback that is a multi-dot core (".g.vcf") stays ".g.vcf"
+        (→ Format.GVCF), not collapsed to ".vcf". Before #249 the parser's simple
+        gate collapsed it, and #244 needed a known-core short-circuit to compensate;
+        #249 made the parser recognize ".g.vcf" directly, so the plain normalization
+        keeps it correctly and the short-circuit is gone."""
         ext_info = ExtendedFileInfo(filename="", file_format=".g.vcf")
         engine.classify_extended(ext_info)
         assert ext_info.file_format == ".g.vcf"

--- a/tests/test_rule_vocabulary.py
+++ b/tests/test_rule_vocabulary.py
@@ -134,6 +134,63 @@ def test_rule_when_format_values_valid():
     )
 
 
+def test_core_extensions_derivation():
+    """`core_extensions` is the explicit set of producible core extensions (#249).
+
+    Pins the derivation: every compound extension with its wrappers stripped (where
+    the multi-dot core `.g.vcf` comes from), unioned with the single-dot
+    `extension_map` keys and the `EXTENSION_TO_FORMAT` keys, all lower-cased, with
+    no compound left in.
+    """
+    rules = get_unified_rules()
+    core = rules.core_extensions
+    expected = {rules._peel_wrappers(c, keep_last=True)[0] for c in rules.COMPOUND_EXTENSIONS}
+    expected |= {k.lower() for k in rules.extension_map if k.count(".") == 1}
+    expected |= {k.lower() for k in rules.EXTENSION_TO_FORMAT}
+    assert core == expected
+    assert ".g.vcf" in core  # the multi-dot core
+    # No core may carry a compression/archive wrapper: a member that *ends with* a
+    # wrapper but is more than that wrapper (".vcf.gz", ".foo.bz2") is a compound
+    # that leaked in — e.g. from an unfiltered EXTENSION_TO_FORMAT key. ".tar"/".zip"
+    # are themselves archive cores (member == wrapper), so they are exempt.
+    leaked = sorted(c for c in core for w in rules.WRAPPER_SUFFIXES if c.endswith(w) and c != w)
+    assert not leaked, f"compound/wrapper-bearing extensions leaked into the core set: {leaked}"
+
+
+def test_every_format_mapped_extension_is_producible():
+    """Every `EXTENSION_TO_FORMAT` key must be a producible core (#249).
+
+    A format mapping for an extension the parser can never yield is a dead entry:
+    `extension_to_format` would never be reached for it. Pinning this invariant is
+    what makes `.g.vcf`'s format resolution robust — it must not rest on the
+    coincidence that a compressed `.g.vcf.gz` spelling happens to exist.
+    """
+    rules = get_unified_rules()
+    dead = sorted(k for k in rules.EXTENSION_TO_FORMAT if k.lower() not in rules.core_extensions)
+    assert not dead, f"EXTENSION_TO_FORMAT keys not producible by parse_file_name: {dead}"
+
+
+def test_rule_extensions_are_producible_cores():
+    """Every extension a rule keys on must be a member of `core_extensions` (#249).
+
+    A rule listing an extension the parser can never produce (e.g. a leftover
+    compound `.vcf.gz`, or a typo) is a dead condition that silently never matches.
+    This drift check ties the rule vocabulary to what `parse_file_name` yields.
+    """
+    rules = get_unified_rules()
+    core = rules.core_extensions
+    dead = sorted(
+        f"{rule.id}: {ext!r}"
+        for rule in rules.rules
+        for ext in (rule.when.get("extensions") or [])
+        if ext.lower() not in core
+    )
+    assert not dead, (
+        "Rules key on extensions that parse_file_name can never produce "
+        "(dead conditions). Use a core extension or fix the rule:\n  " + "\n  ".join(dead)
+    )
+
+
 def test_when_value_check_rejects_bogus_platform(tmp_path):
     """The when-value drift check catches a typo'd enum-backed value (issue #113).
 


### PR DESCRIPTION
Closes #249. Part of epic #242; first increment of the #246 area.

## What changed

The set of *producible* core extensions was implicit — emergent from `COMPOUND_EXTENSIONS` × wrappers plus the `extension_map` single-suffix gate in `parse_file_name`. This makes it explicit:

- **`core_extensions`** — a derived, cached `frozenset`, the single source of truth: every compound extension wrapper-stripped (where the multi-dot core `.g.vcf` comes from) ∪ single-dot `extension_map` keys ∪ `EXTENSION_TO_FORMAT` keys (a format-mapped extension is a producible core by definition).
- **`parse_file_name`** recognizes cores via this set — multi-dot cores scanned longest-first, then an O(1) single-dot last-token lookup — so an uncompressed `sample.g.vcf` → `.g.vcf`/`Format.GVCF`, consistent with the compressed `.g.vcf.gz`. Every single-dot case is unchanged.
- **`classify_extended`**: the #244 known-core short-circuit is **removed** — the parser now recognizes `.g.vcf` directly, so a plain re-parse yields the right core for every fallback token.
- **Drift tests** pin the vocabulary (derivation, no rule keys outside the set, every `EXTENSION_TO_FORMAT` key producible, no wrapper-bearing compound leaks in).

## Why

`.g.vcf`'s identity previously rested on the coincidence that a compressed `.g.vcf.gz` spelling exists in `COMPOUND_EXTENSIONS`; an uncompressed `sample.g.vcf` silently became `.vcf`/`Format.VCF`. An explicit core set makes each core recognizable in every spelling by construction, and retires the `EXTENSION_TO_FORMAT`-membership proxy #244 used as a stand-in for a real known-core test.

## Assumptions I made

- **`.g.vcf` recognition is a deliberate behavior change** (your call), but it affects **zero** corpus files — no uncompressed `.g.vcf` exists across the 758K records (only 2,504 compressed `.g.vcf.gz`, already handled). So it is drift-free in practice.
- **`core_extensions` is derived, not hand-declared** — `.g.vcf` falls out as `peel(".g.vcf.gz")`, so no magic entry; the three unioned sources are the real in-code cores.
- **The dead compound `extension_map` keys are NOT pruned here** — deferred to #245. `filename_for_rules`' `allowed_extensions=None` fallback tests the compound `extract_extension(name)` against `extension_map`, so those keys aren't dead while that helper lives (a Surprise found during the build; noted on #245).
- Single-dot recognition via `core_extensions` is provably equivalent to the old `extension_map` gate (single-dot members of `core_extensions` == single-dot `extension_map` keys).

## How to verify

Issue #249 definition of done → steps:

1. **Explicit `CORE_EXTENSIONS` with a drift test.** `uv run pytest tests/test_rule_vocabulary.py -k core_extensions -q` — the derivation test pins `core_extensions == peel(COMPOUND) ∪ single-dot(extension_map) ∪ EXTENSION_TO_FORMAT`, and rejects any wrapper-bearing leak.
2. **`.g.vcf` recognized; single-dot unchanged.** `uv run python -c "from meta_disco.rule_loader import get_unified_rules as g; r=g(); print(r.parse_file_name('sample.g.vcf').extension, r.parse_file_name('sample.g.vcf').format); print(r.parse_file_name('sample.vcf').extension)"` → `.g.vcf Format.GVCF` then `.vcf`.
3. **#244 proxy removed.** `git show` the `rule_engine.py` hunk — the `if token in EXTENSION_TO_FORMAT` branch is gone; `tests/test_rule_engine.py::TestWrapperSplitMatching::test_known_core_file_format_fallback_not_collapsed` proves `.g.vcf` still resolves GVCF via the plain re-parse.
4. **Behavior-preserving except the deliberate `.g.vcf`.** `make test` (791 pass incl. the golden fixture); the extension/filename corpus A/B over 100,670 unique real names shows **0 differing lines** vs `main`.
5. Gate: `make test`, `make lint`, `make format-check`, `uv run pyright src/meta_disco/` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)