### PR TITLE
Parse FileName at the load boundary and thread it as a first-class fact (#246)

### DIFF
--- a/scripts/classify_auxiliary_genomic.py
+++ b/scripts/classify_auxiliary_genomic.py
@@ -49,8 +49,8 @@ def classify_auxiliary_genomic(metadata_path: Path, output_path: Path):
             continue
 
         # Classify using RuleEngine
-        file_info = FileInfo(
-            filename=name,
+        file_info = FileInfo.from_filename(
+            name,
             file_size=f.get("file_size"),
             dataset_title=dataset_title,
         )

--- a/scripts/classify_bed_files.py
+++ b/scripts/classify_bed_files.py
@@ -83,7 +83,9 @@ def classify_bed_files(metadata_path: Path, output_path: Path):
     }
 
     for f in bed_files:
-        name = f.get("file_name", "")
+        # str(... or ""): a present-but-null or drifted file_name must not raise in
+        # FileName.parse — coerce to "" as the pre-#246 path did.
+        name = str(f.get("file_name") or "")
         dataset_title = f.get("dataset_title", "")
         md5 = f.get("file_md5sum")
         stats["total"] += 1

--- a/scripts/classify_bed_files.py
+++ b/scripts/classify_bed_files.py
@@ -16,6 +16,7 @@ import json
 from pathlib import Path
 
 # Add project root to path for imports
+from meta_disco.file_name import FileName
 from meta_disco.header_classifier import BedSignals, classify_from_bed_signals
 from meta_disco.models import CLASSIFIED, field_label, field_status
 
@@ -99,7 +100,7 @@ def classify_bed_files(metadata_path: Path, output_path: Path):
         # Classify using unified classifier (rule engine + coordinate detection)
         classifications = classify_from_bed_signals(
             signals,
-            file_name=name,
+            name=FileName.parse(name),
             file_size=f.get("file_size"),
             dataset_title=dataset_title,
         )

--- a/scripts/classify_hprc_files.py
+++ b/scripts/classify_hprc_files.py
@@ -23,6 +23,7 @@ from meta_disco.fetchers import (
     fetch_fasta_headers,
     fetch_fastq_reads,
 )
+from meta_disco.file_name import FileName
 from meta_disco.header_classifier import (
     classify_from_fasta_header,
     classify_from_fastq_header,
@@ -89,7 +90,7 @@ def classify_sequencing_data(
                 )
                 classifications = classify_from_header(
                     raw_data,
-                    file_name=fn,
+                    name=FileName.parse(fn),
                     file_size=file_size,
                     file_format=".cram" if fn.endswith(".cram") else ".bam",
                 )
@@ -107,7 +108,7 @@ def classify_sequencing_data(
                 )
                 classifications = classify_from_fastq_header(
                     raw_data,
-                    file_name=fn,
+                    name=FileName.parse(fn),
                     file_size=file_size,
                 )
             except FetchError:
@@ -115,7 +116,7 @@ def classify_sequencing_data(
         else:
             # FAST5, POD5, etc. — classify from filename only
             skipped += 1
-            result = engine.classify_extended(FileInfo(filename=fn, file_size=file_size))
+            result = engine.classify_extended(FileInfo.from_filename(fn, file_size=file_size))
             classifications = result.to_output_dict()
 
         if classifications:
@@ -174,7 +175,7 @@ def classify_assemblies(
 
         classifications = classify_from_fasta_header(
             raw_data,
-            file_name=fn,
+            name=FileName.parse(fn),
             file_size=file_size,
         )
         success += 1
@@ -207,7 +208,7 @@ def classify_filename_only(
         if not fn:
             continue
         file_size = rec.get("fileSize")
-        result = engine.classify_extended(FileInfo(filename=fn, file_size=file_size))
+        result = engine.classify_extended(FileInfo.from_filename(fn, file_size=file_size))
         results.append(
             {
                 "file_name": fn,

--- a/scripts/classify_images.py
+++ b/scripts/classify_images.py
@@ -45,8 +45,8 @@ def classify_images(metadata_path: Path, output_path: Path):
             continue
 
         # Classify using RuleEngine
-        file_info = FileInfo(
-            filename=name,
+        file_info = FileInfo.from_filename(
+            name,
             file_size=f.get("file_size"),
             dataset_title=f.get("dataset_title"),
         )

--- a/scripts/classify_remaining_files.py
+++ b/scripts/classify_remaining_files.py
@@ -55,8 +55,8 @@ def classify_remaining(metadata_path: Path, output_path: Path, classification_pa
         if not name or name in already:
             continue
 
-        file_info = FileInfo(
-            filename=name,
+        file_info = FileInfo.from_filename(
+            name,
             file_size=rec.get("file_size"),
             dataset_title=rec.get("dataset_title", ""),
         )

--- a/scripts/fetch_bed_headers.py
+++ b/scripts/fetch_bed_headers.py
@@ -23,6 +23,7 @@ from threading import Lock
 # Add project root to path
 import requests
 
+from meta_disco.file_name import FileName
 from meta_disco.header_classifier import BedSignals, classify_from_bed_signals
 from meta_disco.models import field_label
 
@@ -219,7 +220,7 @@ def classify_bed_file(
     # Classify using the unified classifier
     classifications = classify_from_bed_signals(
         signals,
-        file_name=file_name,
+        name=FileName.parse(file_name),
         file_size=file_size,
     )
 

--- a/scripts/run_batch_classification.py
+++ b/scripts/run_batch_classification.py
@@ -37,8 +37,10 @@ def run_classification(files: list[dict], engine: RuleEngine) -> list[dict]:
         if (i + 1) % 10000 == 0:
             print(f"\rClassifying... {i + 1:,}/{total:,} ({100 * (i + 1) / total:.1f}%)", end="", flush=True)
 
+        # str(... or ""): a present-but-null or drifted (non-string) file_name must
+        # not raise in FileName.parse — coerce to "" as the pre-#246 path did.
         file_info = FileInfo.from_filename(
-            file_data.get("file_name", ""),
+            str(file_data.get("file_name") or ""),
             file_size=file_data.get("file_size"),
             dataset_title=file_data.get("dataset_title"),
         )

--- a/scripts/run_batch_classification.py
+++ b/scripts/run_batch_classification.py
@@ -37,8 +37,8 @@ def run_classification(files: list[dict], engine: RuleEngine) -> list[dict]:
         if (i + 1) % 10000 == 0:
             print(f"\rClassifying... {i + 1:,}/{total:,} ({100 * (i + 1) / total:.1f}%)", end="", flush=True)
 
-        file_info = FileInfo(
-            filename=file_data.get("file_name", ""),
+        file_info = FileInfo.from_filename(
+            file_data.get("file_name", ""),
             file_size=file_data.get("file_size"),
             dataset_title=file_data.get("dataset_title"),
         )

--- a/scripts/validate_ena_accessions.py
+++ b/scripts/validate_ena_accessions.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import requests
 
 # Add project root to path
+from meta_disco.file_name import FileName
 from meta_disco.header_classifier import classify_from_fastq_header
 
 ENA_API = "https://www.ebi.ac.uk/ena/portal/api/filereport"
@@ -96,7 +97,7 @@ def validate_against_ena(
 
         # Re-classify with current rules
         if sample_reads:
-            new_class = classify_from_fastq_header(sample_reads, file_name=file_name)
+            new_class = classify_from_fastq_header(sample_reads, name=FileName.parse(file_name))
             our_platform = (new_class.get("platform") or "").upper()
             our_modality = new_class.get("data_modality") or ""
         else:

--- a/scripts/validate_ena_accessions.py
+++ b/scripts/validate_ena_accessions.py
@@ -93,7 +93,9 @@ def validate_against_ena(
         """Process a single record and return validation result."""
         acc = rec["archive_accession"]
         sample_reads = rec.get("sample_reads", [])
-        file_name = rec.get("file_name", "")
+        # str(... or ""): a present-but-null or drifted file_name must not raise in
+        # FileName.parse — coerce to "" as the pre-#246 path did.
+        file_name = str(rec.get("file_name") or "")
 
         # Re-classify with current rules
         if sample_reads:

--- a/src/meta_disco/file_name.py
+++ b/src/meta_disco/file_name.py
@@ -22,6 +22,7 @@ remaining follow-up threads the parsed ``FileName`` from the load boundary (#246
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import ClassVar
 
 
 class Format(str, Enum):
@@ -138,7 +139,7 @@ EXTENSION_TO_FORMAT: dict[str, Format] = {
 
 # Extension -> file-type category. Hoisted in-code from unified_rules.yaml (#252)
 # — the last YAML-loaded parse vocabulary. Still carries the compound spellings
-# (.vcf.gz, ...) that #249 deferred pruning to #245 (they back filename_for_rules'
+# (.vcf.gz, ...) that #249 deferred pruning to #245 (they back file_name_for_rules'
 # fallback). The parse consumes only its *keys* (via CORE_EXTENSIONS); the
 # category values feed get_file_type and the when.file_format validation (#114).
 EXTENSION_MAP: dict[str, str] = {
@@ -266,9 +267,11 @@ def extract_extension(filename: str) -> str:
     """Extract the file extension, handling compound extensions.
 
     The legacy compound-or-junk extractor (returns the whole compound ``.vcf.gz``,
-    or the junk last-dot suffix for an unknown name). Kept for the record-routing
-    / ``filename_for_rules`` path that still works on raw names; the rule-matching
-    path uses :meth:`FileName.parse` (clean core + wrappers) instead.
+    or the junk last-dot suffix for an unknown name). No longer on the classify
+    path — ``file_name_for_rules`` reconstructs the compound from the parsed
+    ``FileName`` (core + wrappers) since #246, and rule matching uses
+    :meth:`FileName.parse` directly. Retained as the leaf raw-name extractor and
+    the behavior reference its tests pin; retired with #245.
     """
     filename_lower = filename.lower()
 
@@ -329,6 +332,13 @@ class FileName:
     wrappers: tuple[str, ...]
     format: Format | None = None
     format_source: FormatSource | None = None
+
+    # The nameless FileName — a header-only call with no filename. Assigned below the
+    # class. It reads identically to any name with no known extension (``extension``
+    # is None, ``raw`` is falsy), so downstream code can thread it as the "no name"
+    # value and treat "no name" and "unrecognized name" uniformly, without a
+    # ``FileName | None`` branch at every reader.
+    EMPTY: ClassVar["FileName"]
 
     @classmethod
     def parse(cls, filename: str) -> "FileName":
@@ -396,3 +406,6 @@ class FileName:
             format=fmt,
             format_source=format_source,
         )
+
+
+FileName.EMPTY = FileName.parse("")

--- a/src/meta_disco/file_name.py
+++ b/src/meta_disco/file_name.py
@@ -334,10 +334,13 @@ class FileName:
     format_source: FormatSource | None = None
 
     # The nameless FileName — a header-only call with no filename. Assigned below the
-    # class. It reads identically to any name with no known extension (``extension``
-    # is None, ``raw`` is falsy), so downstream code can thread it as the "no name"
-    # value and treat "no name" and "unrecognized name" uniformly, without a
-    # ``FileName | None`` branch at every reader.
+    # class; ``raw`` is "" and ``extension`` is None. Its *extension* is None like any
+    # name with no known extension, so extension-based readers (the file_format
+    # fallback in classify_extended) treat "no name" and "unrecognized name"
+    # uniformly. It differs in ``raw``: an unrecognized-but-present name keeps its
+    # truthy raw and still matches filename_pattern rules, whereas the sentinel's ""
+    # matches none — exactly the header-only intent. Threading it as the "no name"
+    # value avoids a ``FileName | None`` branch at every reader.
     EMPTY: ClassVar["FileName"]
 
     @classmethod

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -14,6 +14,7 @@ from functools import cache
 from typing import TYPE_CHECKING
 
 from .evidence import SegmentTag
+from .file_name import FileName
 from .models import CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED, build_field_entry
 from .validators.read_name_parsers import (
     detect_paired_end_indicators,
@@ -32,6 +33,12 @@ if TYPE_CHECKING:
 # GFA_CONFIG.extensions is this same tuple — defined here so the classifier and
 # the config cannot disagree about which names it may trust.
 GRAPH_TEXT_EXTENSIONS = (".gfa", ".gfa.gz", ".rgfa", ".rgfa.gz")
+
+# Parsed-once graph fallback name for ``file_name_for_rules`` — a module constant so
+# the literal is not re-parsed on every graph classification call (a last resort when
+# the name is empty and no file_format is grafted). The empty-name fallback uses the
+# shared :data:`FileName.EMPTY`.
+_DEFAULT_GRAPH_NAME = FileName.parse("graph.gfa")
 
 
 @dataclass(frozen=True)
@@ -81,7 +88,7 @@ def _get_engine() -> "RuleEngine":
 def classify_from_header(
     header_text: str,
     *,
-    file_name: str | None = None,
+    name: FileName = FileName.EMPTY,
     file_size: int | None = None,
     file_format: str | None = None,
 ) -> dict:
@@ -93,10 +100,12 @@ def classify_from_header(
 
     Args:
         header_text: Raw SAM/BAM header text (lines starting with @)
-        file_name: Optional real filename; its tokens (hifi_reads / rnaseq /
+        name: Optional parsed :class:`FileName`; its tokens (hifi_reads / rnaseq /
             assembly) drive the tier-2 filename rules
         file_size: Optional file size in bytes (used for WGS/WES inference)
-        file_format: Optional file format string (e.g., ".bam", ".cram")
+        file_format: Optional file format string (e.g., ".bam", ".cram");
+            accepted for call uniformity but not consulted — the extension is
+            hardcoded ".bam" below
 
     Returns:
         Dict with per-field classifications:
@@ -110,7 +119,7 @@ def classify_from_header(
     # there is no name (a header-only call), the engine reads the extension from
     # the file_format we set — the known ".bam" — instead of a fabricated name.
     file_info = ExtendedFileInfo(
-        filename=file_name or "",
+        name=name,
         file_format=".bam",
         file_size=file_size,
         bam_header=header_text,
@@ -165,7 +174,7 @@ def classify_from_header(
 def classify_from_vcf_header(
     header_text: str,
     *,
-    file_name: str | None = None,
+    name: FileName = FileName.EMPTY,
     file_size: int | None = None,
     file_format: str | None = None,
 ) -> dict:
@@ -177,10 +186,12 @@ def classify_from_vcf_header(
 
     Args:
         header_text: VCF header text (lines starting with ##)
-        file_name: Optional real filename; its tokens (e.g. a chm13 assembly
+        name: Optional parsed :class:`FileName`; its tokens (e.g. a chm13 assembly
             hint) drive the tier-2 filename rules
         file_size: Optional file size in bytes
-        file_format: Optional file format string (e.g., ".vcf", ".vcf.gz")
+        file_format: Optional file format string (e.g., ".vcf", ".vcf.gz");
+            accepted for call uniformity but not consulted — the extension is
+            hardcoded ".vcf.gz" below
 
     Returns:
         Dict with per-field classifications:
@@ -194,7 +205,7 @@ def classify_from_vcf_header(
     # there is no name (a header-only call), the engine reads the extension from
     # the file_format we set — the known ".vcf.gz" — instead of a fabricated name.
     file_info = ExtendedFileInfo(
-        filename=file_name or "",
+        name=name,
         file_format=".vcf.gz",
         file_size=file_size,
         vcf_header=header_text,
@@ -233,7 +244,7 @@ def classify_from_vcf_header(
 def classify_from_fastq_header(
     reads: list[str],
     *,
-    file_name: str | None = None,
+    name: FileName = FileName.EMPTY,
     file_size: int | None = None,
     file_format: str | None = None,
 ) -> dict:
@@ -245,7 +256,7 @@ def classify_from_fastq_header(
 
     Args:
         reads: List of read name lines (first few reads from file)
-        file_name: Optional filename for pattern matching
+        name: Optional parsed :class:`FileName` for pattern matching
         file_size: Optional file size in bytes
 
     Returns:
@@ -290,7 +301,7 @@ def classify_from_fastq_header(
     # drives the tier-2 rules; with no name, the engine reads the extension from
     # the known ".fastq.gz" file_format rather than a fabricated name (#152).
     file_info = ExtendedFileInfo(
-        filename=file_name or "",
+        name=name,
         file_format=".fastq.gz",
         file_size=file_size,
         fastq_first_read=first_read,
@@ -326,8 +337,8 @@ def classify_from_fastq_header(
         if detect_paired_end_indicators(read):
             is_paired_end = True
             break
-    if is_paired_end is None and file_name:
-        is_paired_end = detect_paired_end_indicators(file_name)
+    if is_paired_end is None and name.raw:
+        is_paired_end = detect_paired_end_indicators(name.raw)
 
     # Extract instrument model and archive info from read names
     instrument_model = None
@@ -378,28 +389,25 @@ _ASSEMBLER_PATTERN = re.compile(
 _TRANSCRIPT_PATTERN = re.compile(r"^(ENST\d|NM_\d|NR_\d|XM_\d|rna-)", re.IGNORECASE)
 
 
-def filename_for_rules(
-    file_name: str | None,
+def file_name_for_rules(
+    name: FileName,
     file_format: str | None,
-    default: str,
+    default: FileName,
     allowed_extensions: tuple[str, ...] | None = None,
-) -> str:
-    """The filename to hand the rule engine, which reads the extension from it.
+) -> FileName:
+    """The :class:`FileName` to hand the rule engine, which reads its extension.
 
     ``ClassifyPipeline._filter_records`` selects a record when *either* its
     ``file_name`` or its ``file_format`` carries a matching extension, so a
-    selected record's ``file_name`` may not carry one. The engine derives
-    ``file_format`` strictly from the filename (``UnifiedRules.extract_extension``),
-    so an extensionless name silently disables every extension-scoped rule — and
-    worse, ``extract_extension("hprc-v1.0-mc-grch38")`` returns ``".0-mc-grch38"``,
-    a nonsense suffix taken from the last dot.
+    selected record's parsed ``name`` may carry no known extension.
 
-    So: keep ``file_name`` when it already yields a *usable* extension, otherwise
-    append ``file_format`` to it, preserving the filename tokens the tier-2 rules
-    match (``-mc-``, ``grch38``). Testing "already usable" rather than "ends with
-    file_format" matters: 5,227 corpus records are named ``*.fastq.gz`` while
-    declaring ``file_format: ".fastq"``, and appending there would produce
-    ``*.fastq.gz.fastq``.
+    So: keep the parsed ``name`` when it already carries a *usable* extension,
+    otherwise graft ``file_format`` onto its raw string and re-parse — preserving
+    the filename tokens the tier-2 rules match (``-mc-``, ``grch38``). "Usable" is
+    tested against the *compound* spelling (core + wrappers, e.g. ``.gfa.gz``), the
+    same value the old ``extract_extension`` returned, rather than "ends with
+    file_format": 5,227 corpus records are named ``*.fastq.gz`` while declaring
+    ``file_format: ".fastq"``, and grafting there would produce ``*.fastq.gz.fastq``.
 
     ``allowed_extensions`` narrows "usable" to the extensions the caller can
     actually handle. Without it, a graph record named ``graph.tar.gz`` would be
@@ -408,24 +416,33 @@ def filename_for_rules(
     ``data_modality`` is not_classified. Pass the calling config's extensions.
 
     ``file_format`` is only grafted on when it looks like an extension. The
-    corpus carries ``file_format: "Other"`` on ~108k records; appending that
+    corpus carries ``file_format: "Other"`` on ~108k records; grafting that
     would yield ``graphOther``, which matches nothing.
+
+    The threaded ``name`` is *reused* on the usable path — no re-parse — so the raw
+    file_name is parsed exactly once (at the load boundary, #242); only the graft
+    path parses a *different* string (the file_format-extended name). This helper is
+    the sole remaining reader of the compound ``extension_map`` keys and is retired
+    in #245, which pushes the allowed-extension override into the engine.
     """
     rules = _get_engine().rules
-    if file_name:
-        ext = rules.extract_extension(file_name)
-        usable = ext in allowed_extensions if allowed_extensions else ext in rules.extension_map
+    if name.extension is not None:
+        # Reconstruct the compound extension (core + wrappers) the old
+        # ``extract_extension`` returned, and test it exactly as before — against the
+        # caller's allowed set, or the (still compound-keyed) extension_map.
+        compound = name.extension + "".join(name.wrappers)
+        usable = compound in allowed_extensions if allowed_extensions else compound in rules.extension_map
         if usable:
-            return file_name
+            return name
     if file_format and file_format.startswith("."):
-        return f"{file_name or 'file'}{file_format}"
-    return file_name or default
+        return FileName.parse(f"{name.raw or 'file'}{file_format}")
+    return name if name.raw else default
 
 
 def classify_without_content(
     reason: str,
     *,
-    file_name: str | None = None,
+    name: FileName = FileName.EMPTY,
     file_size: int | None = None,
     file_format: str | None = None,
     allowed_extensions: tuple[str, ...] | None = None,
@@ -457,9 +474,9 @@ def classify_without_content(
     """
     from .rule_engine import ExtendedFileInfo
 
-    filename = filename_for_rules(file_name, file_format, default="", allowed_extensions=allowed_extensions)
+    rule_name = file_name_for_rules(name, file_format, default=FileName.EMPTY, allowed_extensions=allowed_extensions)
     file_info = ExtendedFileInfo(
-        filename=filename,
+        name=rule_name,
         file_size=file_size,
     )
     result = _get_engine().classify_extended(file_info, include_tier3=False)
@@ -480,7 +497,7 @@ def classify_without_content(
 def classify_from_gfa_segment_tags(
     segment_tags: list[SegmentTag],
     *,
-    file_name: str | None = None,
+    name: FileName = FileName.EMPTY,
     file_size: int | None = None,
     file_format: str | None = None,
 ) -> dict:
@@ -502,10 +519,10 @@ def classify_from_gfa_segment_tags(
 
     Args:
         segment_tags: Per-segment :class:`SegmentTag`s from fetchers.parse_gfa_segment_tags
-        file_name: Optional filename for extension/filename rules
+        name: Optional parsed :class:`FileName` for extension/filename rules
         file_format: Optional extension (e.g. ".rgfa.gz"), used to drive the
-            extension rules when file_name carries no known extension
-            (see filename_for_rules)
+            extension rules when the name carries no known extension
+            (see file_name_for_rules)
         file_size: Unused. Accepted because ``pipeline._fetch_and_classify`` calls
             every classifier with the same keyword arguments; no graph rule keys
             on file size. ``classify_from_fasta_header`` accepts it unused too.
@@ -515,16 +532,16 @@ def classify_from_gfa_segment_tags(
     """
     from .rule_engine import CONTENT_TIER, ExtendedFileInfo
 
-    filename = filename_for_rules(
-        file_name,
+    rule_name = file_name_for_rules(
+        name,
         file_format,
-        default="graph.gfa",
+        default=_DEFAULT_GRAPH_NAME,
         allowed_extensions=GRAPH_TEXT_EXTENSIONS,
     )
 
     # Tier 1/2 rules give the `pangenome` base, the `-mc-` reference refinement,
     # and reference_assembly from the filename.
-    file_info = ExtendedFileInfo(filename=filename)
+    file_info = ExtendedFileInfo(name=rule_name)
     engine = _get_engine()
     result = engine.classify_extended(file_info, include_tier3=False)
 
@@ -571,7 +588,7 @@ def _get_ref_chrom_names() -> set[str]:
 def classify_from_fasta_header(
     contig_names: list[str],
     *,
-    file_name: str | None = None,
+    name: FileName = FileName.EMPTY,
     file_size: int | None = None,
     file_format: str | None = None,
 ) -> dict:
@@ -583,7 +600,7 @@ def classify_from_fasta_header(
 
     Args:
         contig_names: List of contig/sequence names (without > prefix)
-        file_name: Optional filename for pattern matching
+        name: Optional parsed :class:`FileName` for pattern matching
 
     Returns:
         Per-field classification dict (same format as classify_from_fastq_header)
@@ -594,7 +611,7 @@ def classify_from_fasta_header(
     # Run rule engine for extension/filename-based rules. The real filename drives
     # the tier-2 rules; with no name, the engine reads the extension from the known
     # ".fa.gz" file_format rather than a fabricated name (#152).
-    file_info = ExtendedFileInfo(filename=file_name or "", file_format=".fa.gz")
+    file_info = ExtendedFileInfo(name=name, file_format=".fa.gz")
     engine = _get_engine()
     result = engine.classify_extended(file_info, include_tier3=False)
 
@@ -609,13 +626,13 @@ def classify_from_fasta_header(
     assembler_contigs = []
     transcript_contigs = []
 
-    for name in contig_names:
-        if name in ref_chrom_names:
-            ref_matches.append(name)
-        elif _ASSEMBLER_PATTERN.search(name):
-            assembler_contigs.append(name)
-        elif _TRANSCRIPT_PATTERN.match(name):
-            transcript_contigs.append(name)
+    for contig in contig_names:
+        if contig in ref_chrom_names:
+            ref_matches.append(contig)
+        elif _ASSEMBLER_PATTERN.search(contig):
+            assembler_contigs.append(contig)
+        elif _TRANSCRIPT_PATTERN.match(contig):
+            transcript_contigs.append(contig)
 
     # Classification logic
 
@@ -885,7 +902,7 @@ def _infer_bed_reference(signals: BedSignals) -> tuple[str | None, str]:
 def classify_from_bed_signals(
     signals: BedSignals,
     *,
-    file_name: str | None = None,
+    name: FileName = FileName.EMPTY,
     file_size: int | None = None,
     dataset_title: str | None = None,
 ) -> dict:
@@ -896,7 +913,7 @@ def classify_from_bed_signals(
 
     Args:
         signals: Typed BED coordinate signals
-        file_name: Filename for pattern matching
+        name: Parsed :class:`FileName` for pattern matching
         file_size: Optional file size in bytes
         dataset_title: Optional dataset title for context rules
 
@@ -910,7 +927,7 @@ def classify_from_bed_signals(
     # The real filename drives the tier-2 rules; with no name, the engine reads the
     # extension from the known ".bed" file_format rather than a fabricated name (#152).
     file_info = ExtendedFileInfo(
-        filename=file_name or "",
+        name=name,
         file_format=".bed",
         file_size=file_size,
         dataset_title=dataset_title,

--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass, field
 
+from .file_name import FileName
+
 # Classification status constants. NOT_APPLICABLE / NOT_CLASSIFIED are today
 # smuggled into a field's `value`; the sentinel→status migration (epic #116) is
 # splitting them into a dedicated `status` field. CLASSIFIED is the status when a
@@ -176,12 +178,30 @@ def field_label(record: dict, field_name: str) -> str | None:
 
 @dataclass
 class FileInfo:
-    """Input file information for classification."""
+    """Input file information for classification.
 
-    filename: str
+    Carries the filename as a parsed :class:`FileName` fact rather than a raw string
+    (epic #242): the name is parsed once, at whatever boundary constructs the
+    ``FileInfo``, and everything downstream reads the parsed attributes instead of
+    re-deriving the extension. Build one from a raw filename via
+    :meth:`from_filename`, which is the single parse site on this path.
+    """
+
+    name: FileName = FileName.EMPTY
     file_size: int | None = None
     dataset_title: str | None = None
     # Future: bam_header, vcf_header for Tier 5
+
+    @classmethod
+    def from_filename(cls, filename: str, **kwargs) -> "FileInfo":
+        """Build a ``FileInfo`` from a raw filename string, parsing it once.
+
+        The entry-point convenience for callers that hold a raw name (scripts, the
+        engine's single-file conveniences, tests): it funnels the raw string through
+        ``FileName.parse`` so the parse happens exactly once here, honoring the
+        "parse once" invariant of epic #242.
+        """
+        return cls(name=FileName.parse(filename), **kwargs)
 
 
 @dataclass

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -15,6 +15,7 @@ from threading import Lock
 from typing import NamedTuple, TypeGuard
 
 from .fetchers import FetchError
+from .file_name import FileName
 from .header_classifier import classify_without_content
 from .metadata_schema import (
     classification_blocking_reasons,
@@ -100,6 +101,7 @@ def _fetch_and_classify(
     md5sum: str,
     *,
     file_name: str,
+    name: FileName,
     file_size: int | None,
     file_format: str | None,
     is_gzipped: bool,
@@ -119,6 +121,10 @@ def _fetch_and_classify(
     propagates. Shared by ``ClassifyPipeline.classify_single`` and
     ``_process_single_record`` so the fallback cannot drift between the single-file
     and batch paths.
+
+    ``file_name`` (the raw string) goes to the fetcher and the progress line; ``name``
+    (the parsed :class:`FileName`, #242) goes to the classifiers, which read the
+    extension and filename tokens from it without re-parsing.
     """
     try:
         raw_data = config.fetcher(
@@ -132,7 +138,7 @@ def _fetch_and_classify(
         print(f"Content unreadable, classifying from filename — {file_name or md5sum}: {e.reason}")
         return classify_without_content(
             e.reason,
-            file_name=file_name,
+            name=name,
             file_size=file_size,
             file_format=file_format,
             allowed_extensions=config.extensions,
@@ -141,7 +147,7 @@ def _fetch_and_classify(
 
     return config.classifier(
         raw_data,
-        file_name=file_name,
+        name=name,
         file_size=file_size,
         file_format=file_format,
     ), False
@@ -297,6 +303,7 @@ class ClassifyPipeline:
             evidence_dir,
             md5sum,
             file_name=file_name,
+            name=FileName.parse(file_name),
             file_size=file_size,
             file_format=file_format,
             is_gzipped=is_gzipped,
@@ -455,6 +462,7 @@ class ClassifyPipeline:
             self.evidence_dir,
             item.file_md5sum,
             file_name=item.file_name,
+            name=item.name,
             file_size=item.file_size,
             file_format=item.file_format,
             is_gzipped=is_gzipped,

--- a/src/meta_disco/records.py
+++ b/src/meta_disco/records.py
@@ -36,6 +36,8 @@ from __future__ import annotations
 from dataclasses import dataclass, fields
 from typing import Any
 
+from .file_name import FileName
+
 
 def _coerce_identity(value: Any) -> str:
     """Stringify a drifted identity value for echo; null (``None``) becomes ``""``.
@@ -62,6 +64,12 @@ class ClassifierRecord:
     either drifted still reaches the valid stream. They are echoed into the output
     row untouched — typed ``Any`` and passed through as-is, exactly as the raw-dict
     path did.
+
+    ``name`` is the raw ``file_name`` parsed into a :class:`FileName` once, here at
+    the load boundary (epic #242), and threaded through the fetch/classify path so
+    nothing downstream re-parses. The raw ``file_name`` string is kept alongside it:
+    it is the identity echoed into the output row and the shared attribute the
+    ``InvalidRecord`` stream also exposes (``name`` is a valid-stream-only fact).
     """
 
     file_name: str
@@ -70,6 +78,7 @@ class ClassifierRecord:
     file_md5sum: str
     dataset_title: Any
     entry_id: Any
+    name: FileName
 
     @classmethod
     def from_record(cls, record: dict) -> ClassifierRecord:
@@ -81,6 +90,9 @@ class ClassifierRecord:
         input to defend against (CLAUDE.md error-handling philosophy). A ``KeyError``
         or wrong type surfacing here means the split routed a record it should not
         have.
+
+        ``file_name`` is parsed into a :class:`FileName` exactly once here — the
+        single parse site on the pipeline path (#242).
         """
         return cls(
             file_name=record["file_name"],
@@ -89,6 +101,7 @@ class ClassifierRecord:
             file_md5sum=record["file_md5sum"],
             dataset_title=record.get("dataset_title"),
             entry_id=record.get("entry_id"),
+            name=FileName.parse(record["file_name"]),
         )
 
 

--- a/src/meta_disco/rule_engine.py
+++ b/src/meta_disco/rule_engine.py
@@ -6,7 +6,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from .file_name import Format
+from .file_name import FileName, Format
 from .models import (
     CLASSIFICATION_FIELDS,
     CLASSIFIED,
@@ -37,9 +37,17 @@ CONTENT_TIER = 4
 
 @dataclass
 class ExtendedFileInfo:
-    """Extended file information including header data for tier 3 rules."""
+    """Extended file information including header data for tier 3 rules.
 
-    filename: str
+    Carries the filename as a parsed :class:`FileName` fact (epic #242): the name is
+    parsed once at the load boundary and threaded here, so ``classify_extended``
+    reads the pre-parsed extension and the filename-pattern matcher reads ``name.raw``
+    rather than re-parsing. Defaults to :data:`FileName.EMPTY` for a header-only call
+    with no filename — which reads as an unresolved extension, so the engine falls
+    back to the ``file_format`` the caller set.
+    """
+
+    name: FileName = FileName.EMPTY
     file_size: int | None = None
     dataset_title: str | None = None
     file_format: str | None = None
@@ -77,9 +85,14 @@ class ExtendedFileInfo:
 
     @classmethod
     def from_file_info(cls, file_info: FileInfo) -> "ExtendedFileInfo":
-        """Create ExtendedFileInfo from a FileInfo object."""
+        """Create ExtendedFileInfo from a FileInfo object.
+
+        Copies the parsed :class:`FileName` across as-is — no re-parse — so a name
+        parsed once when the ``FileInfo`` was built is threaded through unchanged
+        (epic #242).
+        """
         return cls(
-            filename=file_info.filename,
+            name=file_info.name,
             file_size=file_info.file_size,
             dataset_title=file_info.dataset_title,
         )
@@ -567,13 +580,13 @@ class RuleEngine:
         # Convert to ExtendedFileInfo if needed
         ext_info = ExtendedFileInfo.from_file_info(file_info) if isinstance(file_info, FileInfo) else file_info
 
-        # Extract the extension from the real filename when it yields a known
-        # one. parse_file_name returns None (not a junk last-dot suffix) for a
-        # name with no known extension, so an unknown name leaves the caller's
-        # file_format fallback intact — a header-only call sets it to the known
-        # file-type extension so the extension rules still run without inventing
-        # a filename to carry it (#152/#241).
-        parsed_ext = self.rules.parse_file_name(ext_info.filename).extension if ext_info.filename else None
+        # Read the extension from the pre-parsed FileName (parsed once at the load
+        # boundary, #242) — no re-parse here. FileName.parse yields None (not a junk
+        # last-dot suffix) for a name with no known extension, so an unknown name
+        # leaves the caller's file_format fallback intact — a header-only call
+        # (name is FileName.EMPTY) yields None here too, so file_format sets the
+        # extension and the rules still run without inventing a filename (#152/#241).
+        parsed_ext = ext_info.name.extension
         if parsed_ext:
             # From the real name: already the clean core, lower-cased by the parse.
             ext_info.file_format = parsed_ext
@@ -657,8 +670,10 @@ class RuleEngine:
         if "format" in when and file_info.format != when["format"]:
             return False
 
-        # Check filename pattern
-        if (pattern := when.get("filename_pattern")) and not re.search(pattern, file_info.filename, re.IGNORECASE):
+        # Check filename pattern against the parsed name's raw string (#242). A
+        # header-only call carries FileName.EMPTY (raw ""), so a filename_pattern rule
+        # simply does not match rather than raising.
+        if (pattern := when.get("filename_pattern")) and not re.search(pattern, file_info.name.raw, re.IGNORECASE):
             return False
 
         # Check dataset pattern
@@ -921,7 +936,7 @@ class RuleEngine:
             ExtendedClassificationResult with classification and metadata
         """
         file_info = ExtendedFileInfo(
-            filename=filename,
+            name=FileName.parse(filename),
             file_size=file_size,
             bam_header=bam_header,
         )
@@ -947,7 +962,7 @@ class RuleEngine:
             ExtendedClassificationResult with classification and metadata
         """
         file_info = ExtendedFileInfo(
-            filename=filename,
+            name=FileName.parse(filename),
             file_size=file_size,
             vcf_header=vcf_header,
         )
@@ -973,7 +988,7 @@ class RuleEngine:
             ExtendedClassificationResult with classification and metadata
         """
         file_info = ExtendedFileInfo(
-            filename=filename,
+            name=FileName.parse(filename),
             file_size=file_size,
             fastq_first_read=first_read,
         )
@@ -1001,7 +1016,7 @@ class RuleEngine:
             ExtendedClassificationResult with classification and metadata
         """
         file_info = ExtendedFileInfo(
-            filename=filename,
+            name=FileName.parse(filename),
             file_size=file_size,
             fasta_contig_names=contig_names,
         )

--- a/tests/test_bed_classification.py
+++ b/tests/test_bed_classification.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from meta_disco.file_name import FileName
 from meta_disco.header_classifier import BedSignals, classify_from_bed_signals
 from meta_disco.models import (
     NOT_APPLICABLE,
@@ -18,8 +19,8 @@ engine = RuleEngine()
 
 def classify_bed(filename: str, dataset_title: str = "") -> dict:
     """Classify a BED file and return the result as a dict."""
-    file_info = FileInfo(
-        filename=filename,
+    file_info = FileInfo.from_filename(
+        filename,
         dataset_title=dataset_title,
     )
     result = engine.classify_extended(file_info)
@@ -280,7 +281,7 @@ class TestBedCoordinateClassification:
             # GRCh38 chr1=248956422; use a value close but under
             max_coordinates={"chr1": 248956000, "chr2": 242193000},
         )
-        result = classify_from_bed_signals(signals, file_name="sample.regions.bed.gz")
+        result = classify_from_bed_signals(signals, name=FileName.parse("sample.regions.bed.gz"))
         ref = _get_val(result, "reference_assembly")
         assert ref in ("GRCh38", "CHM13"), f"Expected GRCh38 or CHM13, got {ref}"
 
@@ -291,7 +292,7 @@ class TestBedCoordinateClassification:
             has_chr_prefix=False,
             max_coordinates={"1": 200000000},
         )
-        result = classify_from_bed_signals(signals, file_name="sample.bed")
+        result = classify_from_bed_signals(signals, name=FileName.parse("sample.bed"))
         assert _get_val(result, "reference_assembly") == "GRCh37"
 
     def test_nonstandard_chroms_not_applicable(self):
@@ -301,19 +302,19 @@ class TestBedCoordinateClassification:
             has_chr_prefix=False,
             max_coordinates={"HG01106#1#JAHAMC010000001.1": 92310948},
         )
-        result = classify_from_bed_signals(signals, file_name="sample.bed")
+        result = classify_from_bed_signals(signals, name=FileName.parse("sample.bed"))
         assert field_status(result, "reference_assembly") == NOT_APPLICABLE
 
     def test_empty_signals_preserves_filename_classification(self):
         """Empty signals still returns rule engine classification from filename."""
         signals = BedSignals.empty()
-        result = classify_from_bed_signals(signals, file_name="sample.modbam2bed.cpg.bed")
+        result = classify_from_bed_signals(signals, name=FileName.parse("sample.modbam2bed.cpg.bed"))
         assert _get_val(result, "data_modality") == "epigenomic.methylation"
 
     def test_empty_signals_no_reference(self):
         """Empty signals should leave reference as not_classified."""
         signals = BedSignals.empty()
-        result = classify_from_bed_signals(signals, file_name="sample.bed")
+        result = classify_from_bed_signals(signals, name=FileName.parse("sample.bed"))
         assert field_status(result, "reference_assembly") == NOT_CLASSIFIED
 
     def test_coordinates_exceeding_grch38_rule_it_out(self):
@@ -326,7 +327,7 @@ class TestBedCoordinateClassification:
             has_chr_prefix=True,
             max_coordinates={"chr8": 145500000},
         )
-        result = classify_from_bed_signals(signals, file_name="sample.bed")
+        result = classify_from_bed_signals(signals, name=FileName.parse("sample.bed"))
         ref = _get_val(result, "reference_assembly")
         assert ref != "GRCh38", f"GRCh38 should be ruled out, got {ref}"
 
@@ -337,7 +338,7 @@ class TestBedCoordinateClassification:
             has_chr_prefix=True,
             max_coordinates={},
         )
-        result = classify_from_bed_signals(signals, file_name="sample.bed")
+        result = classify_from_bed_signals(signals, name=FileName.parse("sample.bed"))
         assert field_status(result, "reference_assembly") == NOT_CLASSIFIED
 
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -24,7 +24,8 @@ from classify_vcf_files import classify_single_vcf as classify_vcf
 
 from meta_disco.evidence import SegmentTag
 from meta_disco.fetchers import parse_gfa_segment_tags
-from meta_disco.header_classifier import classify_from_gfa_segment_tags, filename_for_rules
+from meta_disco.file_name import FileName
+from meta_disco.header_classifier import classify_from_gfa_segment_tags, file_name_for_rules
 from meta_disco.models import (
     NOT_APPLICABLE,
     NOT_CLASSIFIED,
@@ -283,20 +284,20 @@ class TestRuleEngineE2E:
     """Rule engine classification from filename/metadata only."""
 
     def test_histology_svs(self):
-        result = engine.classify_extended(FileInfo(filename="GTEX-18A6Q-1126.svs"))
+        result = engine.classify_extended(FileInfo.from_filename("GTEX-18A6Q-1126.svs"))
         assert result.data_modality == "imaging.histology"
         assert result.status_of("platform") == NOT_APPLICABLE
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_fast5_raw_signal(self):
-        result = engine.classify_extended(FileInfo(filename="PAK57726.fast5"))
+        result = engine.classify_extended(FileInfo.from_filename("PAK57726.fast5"))
         assert result.status_of("data_modality") == NOT_CLASSIFIED
         assert result.data_type == "raw_signal"
         assert result.platform == "ONT"
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_pod5_raw_signal(self):
-        result = engine.classify_extended(FileInfo(filename="sample_run.pod5"))
+        result = engine.classify_extended(FileInfo.from_filename("sample_run.pod5"))
         assert result.status_of("data_modality") == NOT_CLASSIFIED
         assert result.data_type == "raw_signal"
         assert result.platform == "ONT"
@@ -304,22 +305,22 @@ class TestRuleEngineE2E:
 
     def test_flnc_bam_is_transcriptomic(self):
         """IsoSeq flnc BAM should be transcriptomic, not genomic."""
-        result = engine.classify_extended(FileInfo(filename="HG00097.lymph.m84203_240914_042802_s4.flnc.bam"))
+        result = engine.classify_extended(FileInfo.from_filename("HG00097.lymph.m84203_240914_042802_s4.flnc.bam"))
         assert result.data_modality == "transcriptomic.bulk"
 
     def test_isoseq_bam_is_transcriptomic(self):
         """BAM with isoseq in filename should be transcriptomic."""
-        result = engine.classify_extended(FileInfo(filename="sample.isoseq.bam"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.isoseq.bam"))
         assert result.data_modality == "transcriptomic.bulk"
 
     def test_plain_bam_no_modality(self):
         """BAM without header or platform signals should not get genomic modality."""
-        result = engine.classify_extended(FileInfo(filename="sample.reads.bam"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.reads.bam"))
         assert result.status_of("data_modality") == NOT_CLASSIFIED
 
     def test_salmon_quant_sf_is_transcriptomic_quantification(self):
         """A Salmon quant.sf is a single-sample transcript abundance table (#157)."""
-        result = engine.classify_extended(FileInfo(filename="NUFIP1-BGRSLV04-28_quant.sf"))
+        result = engine.classify_extended(FileInfo.from_filename("NUFIP1-BGRSLV04-28_quant.sf"))
         assert result.data_modality == "transcriptomic.bulk"
         assert result.data_type == "quantification"
         assert result.assay_type == "RNA-seq"
@@ -332,73 +333,73 @@ class TestRuleEngineE2E:
         token boundary) both stay not_classified.
         """
         for name in ("something.sf", "frequant.sf"):
-            result = engine.classify_extended(FileInfo(filename=name))
+            result = engine.classify_extended(FileInfo.from_filename(name))
             assert result.status_of("data_type") == NOT_CLASSIFIED, name
 
     def test_plink_1000g(self):
         result = engine.classify_extended(
-            FileInfo(filename="IBS.3.pgen", dataset_title="ANVIL_1000G_PRIMED_data_model")
+            FileInfo.from_filename("IBS.3.pgen", dataset_title="ANVIL_1000G_PRIMED_data_model")
         )
         assert result.data_modality == "genomic"
         assert result.reference_assembly == "GRCh38"
 
     def test_bed_methylation(self):
-        result = engine.classify_extended(FileInfo(filename="sample.modbam2bed.cpg.bed"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.modbam2bed.cpg.bed"))
         assert result.data_modality == "epigenomic.methylation"
 
     def test_bed_assembly_qc(self):
-        result = engine.classify_extended(FileInfo(filename="HG01928.paternal.f1_assembly.hap1.bed"))
+        result = engine.classify_extended(FileInfo.from_filename("HG01928.paternal.f1_assembly.hap1.bed"))
         assert result.data_modality == "genomic"
 
     def test_fastq_rna_filename(self):
-        result = engine.classify_extended(FileInfo(filename="sample_RNA_001.fastq.gz"))
+        result = engine.classify_extended(FileInfo.from_filename("sample_RNA_001.fastq.gz"))
         assert result.data_modality == "transcriptomic.bulk"
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_checksum_not_applicable(self):
-        result = engine.classify_extended(FileInfo(filename="sample.md5"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.md5"))
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_chunked_upload_not_applicable(self):
-        result = engine.classify_extended(FileInfo(filename="c5ff4e67-1db9-4fd1.gs-chunked-io-part.000013"))
+        result = engine.classify_extended(FileInfo.from_filename("c5ff4e67-1db9-4fd1.gs-chunked-io-part.000013"))
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_timestamp_filename_not_applicable(self):
-        result = engine.classify_extended(FileInfo(filename="2020-11-20T212208.245537Z"))
+        result = engine.classify_extended(FileInfo.from_filename("2020-11-20T212208.245537Z"))
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_png_derived(self):
-        result = engine.classify_extended(FileInfo(filename="assembly_plot.png"))
+        result = engine.classify_extended(FileInfo.from_filename("assembly_plot.png"))
         assert result.status_of("data_modality") == NOT_APPLICABLE
         assert result.status_of("platform") == NOT_APPLICABLE
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_all_index_types_not_applicable(self):
         for ext in [".bai", ".crai", ".tbi", ".csi", ".pbi"]:
-            result = engine.classify_extended(FileInfo(filename=f"sample{ext}"))
+            result = engine.classify_extended(FileInfo.from_filename(f"sample{ext}"))
             assert result.status_of("data_modality") == NOT_APPLICABLE, f"{ext} should be not_applicable"
 
     def test_narrowpeak_is_chromatin(self):
-        result = engine.classify_extended(FileInfo(filename="sample.narrowPeak"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.narrowPeak"))
         assert result.data_modality == "epigenomic.chromatin_accessibility"
 
     def test_bigwig_with_chip_keyword(self):
-        result = engine.classify_extended(FileInfo(filename="H3K27ac_ChIP.bw"))
+        result = engine.classify_extended(FileInfo.from_filename("H3K27ac_ChIP.bw"))
         assert result.data_modality == "epigenomic.histone_modification"
 
     def test_bed_reference_from_filename(self):
         """BED file with hg38 in filename should detect GRCh38."""
-        result = engine.classify_extended(FileInfo(filename="sample.hg38.regions.bed"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.hg38.regions.bed"))
         assert result.reference_assembly == "GRCh38"
 
     def test_idat_methylation(self):
         """IDAT file should be epigenomic methylation."""
-        result = engine.classify_extended(FileInfo(filename="200123456789_R01C01.idat"))
+        result = engine.classify_extended(FileInfo.from_filename("200123456789_R01C01.idat"))
         assert result.data_modality == "epigenomic.methylation"
 
     def test_no_crash_on_unknown(self):
         for name in ["readme.xyz", "data.parquet", "model.h5", ""]:
-            result = engine.classify_extended(FileInfo(filename=name))
+            result = engine.classify_extended(FileInfo.from_filename(name))
             # Unknown files don't crash and resolve to a not_classified status
             # (the value stays None — the sentinel lives in status now).
             assert result.status_of("data_modality") == NOT_CLASSIFIED
@@ -406,28 +407,28 @@ class TestRuleEngineE2E:
     def test_fasta_base_rule(self):
         """FASTA files should get base rule classification."""
         for ext in [".fa", ".fasta", ".fa.gz", ".fasta.gz"]:
-            result = engine.classify_extended(FileInfo(filename=f"sample{ext}"))
+            result = engine.classify_extended(FileInfo.from_filename(f"sample{ext}"))
             assert result.data_type == "sequence", f"{ext} should be sequence"
             assert result.status_of("platform") == NOT_APPLICABLE
             assert result.status_of("assay_type") == NOT_APPLICABLE
 
     def test_fasta_assembly_filename(self):
         """FASTA with assembly keyword in filename."""
-        result = engine.classify_extended(FileInfo(filename="HG00673.paternal.f1_assembly_v1.fa.gz"))
+        result = engine.classify_extended(FileInfo.from_filename("HG00673.paternal.f1_assembly_v1.fa.gz"))
         assert result.data_modality == "genomic"
         assert result.data_type == "assembly"
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_fasta_haplotype_filename(self):
         """FASTA with haplotype keyword in filename."""
-        result = engine.classify_extended(FileInfo(filename="hapdup_contigs_2.fasta"))
+        result = engine.classify_extended(FileInfo.from_filename("hapdup_contigs_2.fasta"))
         assert result.data_modality == "genomic"
         assert result.data_type == "assembly"
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_fasta_verkko_filename(self):
         """FASTA with verkko assembler keyword."""
-        result = engine.classify_extended(FileInfo(filename="HG02300_verkko_gfase_diploid.fasta.gz"))
+        result = engine.classify_extended(FileInfo.from_filename("HG02300_verkko_gfase_diploid.fasta.gz"))
         assert result.data_modality == "genomic"
         assert result.data_type == "assembly"
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
@@ -444,7 +445,7 @@ class TestPangenomeGraphs:
 
     def test_gfa_assembly_graph_is_pangenome(self):
         """A single-sample assembly graph (.gfa) is still a sequence graph."""
-        result = engine.classify_extended(FileInfo(filename="HG002-full-0.14.1.hap1.p_ctg.gfa"))
+        result = engine.classify_extended(FileInfo.from_filename("HG002-full-0.14.1.hap1.p_ctg.gfa"))
         assert result.data_modality == "genomic"
         assert result.data_type == "pangenome"
         assert result.status_of("platform") == NOT_APPLICABLE
@@ -452,26 +453,26 @@ class TestPangenomeGraphs:
 
     def test_pggb_gfa_gz_is_pangenome(self):
         """PGGB pangenome graph (.gfa.gz compound extension) — not an mc reference."""
-        result = engine.classify_extended(FileInfo(filename="chr1.hprc-v1.0-pggb.gfa.gz"))
+        result = engine.classify_extended(FileInfo.from_filename("chr1.hprc-v1.0-pggb.gfa.gz"))
         assert result.data_modality == "genomic"
         assert result.data_type == "pangenome"
 
     def test_vg_and_xg_are_pangenome(self):
         for name in ("sample.vg", "graph.xg"):
-            result = engine.classify_extended(FileInfo(filename=name))
+            result = engine.classify_extended(FileInfo.from_filename(name))
             assert result.data_type == "pangenome", name
             assert result.data_modality == "genomic", name
 
     def test_mc_gbz_is_pangenome_reference(self):
         """HPRC minigraph-cactus GBZ — the published alignment reference graph."""
-        result = engine.classify_extended(FileInfo(filename="hprc-v1.0-mc-grch38.gbz"))
+        result = engine.classify_extended(FileInfo.from_filename("hprc-v1.0-mc-grch38.gbz"))
         assert result.data_modality == "genomic"
         assert result.data_type == "pangenome.reference"
         # reference_assembly comes from the shared filename_ref_* rules
         assert result.reference_assembly == "GRCh38"
 
     def test_mc_gbwt_chm13_is_pangenome_reference(self):
-        result = engine.classify_extended(FileInfo(filename="hprc-v1.0-mc-chm13.gbwt"))
+        result = engine.classify_extended(FileInfo.from_filename("hprc-v1.0-mc-chm13.gbwt"))
         assert result.data_type == "pangenome.reference"
         assert result.reference_assembly == "CHM13"
 
@@ -489,7 +490,7 @@ class TestRgfaContentClassification:
     def test_rank0_segments_are_pangenome_reference(self):
         """The real signal: minigraph rGFA, all leading segments SR:i:0 on chr1."""
         tags = [SegmentTag(sn="chr1", sr="0") for _ in range(5)]
-        record = classify_from_gfa_segment_tags(tags, file_name="hprc-v1.0-minigraph-grch38.gfa.gz")
+        record = classify_from_gfa_segment_tags(tags, name=FileName.parse("hprc-v1.0-minigraph-grch38.gfa.gz"))
         assert get_val(record, "data_type") == "pangenome.reference"
         # reference_assembly still comes from the filename rules, not content
         assert get_val(record, "reference_assembly") == "GRCh38"
@@ -505,7 +506,7 @@ class TestRgfaContentClassification:
         exact-match assertion would fail for a change unrelated to this behavior.
         """
         record = classify_from_gfa_segment_tags(
-            [SegmentTag(sn="chr1", sr="0")], file_name="hprc-v1.0-minigraph-grch38.gfa.gz"
+            [SegmentTag(sn="chr1", sr="0")], name=FileName.parse("hprc-v1.0-minigraph-grch38.gfa.gz")
         )
         rules = [e["rule_id"] for e in record["data_type"]["evidence"]]
         assert "pangenome_graph" in rules, "the tier-1 claim was clobbered"
@@ -519,7 +520,7 @@ class TestRgfaContentClassification:
         above the tier-1 `pangenome` claim it refines. Pin the tier so resolving
         from claims agrees with the value set here."""
         record = classify_from_gfa_segment_tags(
-            [SegmentTag(sn="chr1", sr="0")], file_name="hprc-v1.0-minigraph-grch38.gfa.gz"
+            [SegmentTag(sn="chr1", sr="0")], name=FileName.parse("hprc-v1.0-minigraph-grch38.gfa.gz")
         )
         claims = record["data_type"]["evidence"]
         content = next(c for c in claims if c["rule_id"] == "rgfa_stable_rank_reference")
@@ -530,12 +531,12 @@ class TestRgfaContentClassification:
     def test_nonzero_rank_only_stays_pangenome(self):
         """Non-reference haplotype segments (rank >= 1) do not make a reference graph."""
         tags = [SegmentTag(sn="HG002#1#chr1", sr="1")]
-        record = classify_from_gfa_segment_tags(tags, file_name="some-graph.gfa.gz")
+        record = classify_from_gfa_segment_tags(tags, name=FileName.parse("some-graph.gfa.gz"))
         assert get_val(record, "data_type") == "pangenome"
 
     def test_untagged_gfa_stays_pangenome(self):
         """A plain GFA (pggb) carries no rGFA tags, so parsing yields no segments."""
-        record = classify_from_gfa_segment_tags([], file_name="chr1.hprc-v1.0-pggb.gfa.gz")
+        record = classify_from_gfa_segment_tags([], name=FileName.parse("chr1.hprc-v1.0-pggb.gfa.gz"))
         assert get_val(record, "data_type") == "pangenome"
 
     def test_no_segments_falls_back_to_filename_rules(self):
@@ -544,26 +545,28 @@ class TestRgfaContentClassification:
         Minigraph-cactus GFA segments are untagged, so the `-mc-` filename rule
         is what keeps this a reference graph.
         """
-        record = classify_from_gfa_segment_tags([], file_name="hprc-v1.0-mc-grch38.gfa.gz")
+        record = classify_from_gfa_segment_tags([], name=FileName.parse("hprc-v1.0-mc-grch38.gfa.gz"))
         assert get_val(record, "data_type") == "pangenome.reference"
         assert get_val(record, "reference_assembly") == "GRCh38"
 
     def test_rank0_without_stable_name_is_not_a_reference_claim(self):
         """SR without SN is malformed rGFA — no contig to anchor the claim."""
-        record = classify_from_gfa_segment_tags([SegmentTag(sr="0")], file_name="some-graph.gfa")
+        record = classify_from_gfa_segment_tags([SegmentTag(sr="0")], name=FileName.parse("some-graph.gfa"))
         assert get_val(record, "data_type") == "pangenome"
 
     def test_empty_file_name_falls_back_to_file_format(self):
         """The pipeline selects records on file_format OR file_name, so file_name
         can be empty on a record with a real extension (pipeline._filter_records)."""
-        record = classify_from_gfa_segment_tags([], file_name="", file_format=".rgfa.gz")
+        record = classify_from_gfa_segment_tags([], name=FileName.parse(""), file_format=".rgfa.gz")
         assert get_val(record, "data_type") == "pangenome"
         rules = [e["rule_id"] for e in record["data_type"]["evidence"]]
         assert "pangenome_graph" in rules
 
     def test_file_name_wins_over_file_format(self):
         """A real filename carries the tokens the tier-2 rules need."""
-        record = classify_from_gfa_segment_tags([], file_name="hprc-v1.0-mc-grch38.gfa.gz", file_format=".gfa")
+        record = classify_from_gfa_segment_tags(
+            [], name=FileName.parse("hprc-v1.0-mc-grch38.gfa.gz"), file_format=".gfa"
+        )
         assert get_val(record, "data_type") == "pangenome.reference"
         assert get_val(record, "reference_assembly") == "GRCh38"
 
@@ -572,12 +575,12 @@ class TestRgfaContentClassification:
         file_format keeps the `-mc-`/`grch38` tokens the tier-2 rules match;
         using file_format alone would discard them, and using the bare name would
         make extract_extension return the junk suffix '.0-mc-grch38'."""
-        record = classify_from_gfa_segment_tags([], file_name="hprc-v1.0-mc-grch38", file_format=".gfa.gz")
+        record = classify_from_gfa_segment_tags([], name=FileName.parse("hprc-v1.0-mc-grch38"), file_format=".gfa.gz")
         assert get_val(record, "data_type") == "pangenome.reference"
         assert get_val(record, "reference_assembly") == "GRCh38"
 
     def test_extensionless_file_name_still_classifies_as_a_graph(self):
-        record = classify_from_gfa_segment_tags([], file_name="graph", file_format=".gfa")
+        record = classify_from_gfa_segment_tags([], name=FileName.parse("graph"), file_format=".gfa")
         assert get_val(record, "data_type") == "pangenome"
         assert get_val(record, "data_modality") == "genomic"
 
@@ -585,28 +588,40 @@ class TestRgfaContentClassification:
 class TestFilenameForRules:
     """The rule engine reads the extension from the filename, so a selected record
     whose file_name lacks one must have file_format grafted on — without corrupting
-    a name that already has a valid extension."""
+    a name that already has a valid extension.
+
+    ``file_name_for_rules`` takes a parsed :class:`FileName` (#242) and returns one;
+    ``_rule_name`` wraps the parse/unwrap so the assertions stay in raw-string terms.
+    A ``None`` file_name models a header-only call with no name at all."""
+
+    @staticmethod
+    def _rule_name(file_name, file_format, default, allowed_extensions=None):
+        # A None file_name models a header-only call with no name — FileName.EMPTY.
+        name = FileName.parse(file_name) if file_name is not None else FileName.EMPTY
+        return file_name_for_rules(
+            name, file_format, FileName.parse(default), allowed_extensions=allowed_extensions
+        ).raw
 
     def test_known_extension_is_kept_verbatim(self):
-        assert filename_for_rules("graph.gfa", ".gfa", "x") == "graph.gfa"
+        assert self._rule_name("graph.gfa", ".gfa", "x") == "graph.gfa"
 
     def test_mismatched_but_valid_extension_is_not_appended_to(self):
         """5,227 corpus records are named *.fastq.gz while declaring file_format
         '.fastq'. Appending would yield '*.fastq.gz.fastq'."""
-        assert filename_for_rules("IGVFFI0052MDWT.fastq.gz", ".fastq", "x") == "IGVFFI0052MDWT.fastq.gz"
+        assert self._rule_name("IGVFFI0052MDWT.fastq.gz", ".fastq", "x") == "IGVFFI0052MDWT.fastq.gz"
 
     def test_unknown_extension_gets_file_format_appended(self):
-        assert filename_for_rules("hprc-v1.0-mc-grch38", ".gfa.gz", "x") == "hprc-v1.0-mc-grch38.gfa.gz"
+        assert self._rule_name("hprc-v1.0-mc-grch38", ".gfa.gz", "x") == "hprc-v1.0-mc-grch38.gfa.gz"
 
     def test_extensionless_name_gets_file_format_appended(self):
-        assert filename_for_rules("graph", ".gfa", "x") == "graph.gfa"
+        assert self._rule_name("graph", ".gfa", "x") == "graph.gfa"
 
     def test_no_name_uses_file_format(self):
-        assert filename_for_rules("", ".rgfa.gz", "x") == "file.rgfa.gz"
+        assert self._rule_name("", ".rgfa.gz", "x") == "file.rgfa.gz"
 
     def test_no_name_and_no_format_uses_the_default(self):
-        assert filename_for_rules("", "", "graph.gfa") == "graph.gfa"
-        assert filename_for_rules(None, None, "graph.gfa") == "graph.gfa"
+        assert self._rule_name("", "", "graph.gfa") == "graph.gfa"
+        assert self._rule_name(None, None, "graph.gfa") == "graph.gfa"
 
     def test_non_dotted_file_format_is_not_grafted_on(self):
         """~108k corpus records carry file_format 'Other'; 'graphOther' matches nothing.
@@ -614,14 +629,14 @@ class TestFilenameForRules:
         The name is returned as-is rather than fabricated: nothing is knowable, and
         claiming a `.gfa` we were never told about would be worse than not_classified.
         """
-        assert filename_for_rules("graph", "Other", "graph.gfa") == "graph"
-        assert filename_for_rules("", "Other", "graph.gfa") == "graph.gfa"
+        assert self._rule_name("graph", "Other", "graph.gfa") == "graph"
+        assert self._rule_name("", "Other", "graph.gfa") == "graph.gfa"
 
     def test_known_but_disallowed_extension_is_not_trusted(self):
         """A graph record named *.tar.gz must not be classified off the tar rules
         just because .tar.gz is a known extension somewhere in the map."""
         assert (
-            filename_for_rules(
+            self._rule_name(
                 "hprc-graph.tar.gz",
                 ".gfa.gz",
                 "graph.gfa",
@@ -632,7 +647,7 @@ class TestFilenameForRules:
 
     def test_allowed_extension_is_trusted_verbatim(self):
         assert (
-            filename_for_rules(
+            self._rule_name(
                 "hprc-v1.0-mc-grch38.gfa.gz",
                 ".gfa",
                 "graph.gfa",
@@ -649,7 +664,7 @@ class TestGfaContentClaimCoherence:
         data_modality was not_classified."""
         record = classify_from_gfa_segment_tags(
             [SegmentTag(sn="chr1", sr="0")],
-            file_name="hprc-graph.tar.gz",
+            name=FileName.parse("hprc-graph.tar.gz"),
             file_format=".gfa.gz",
         )
         assert get_val(record, "data_type") == "pangenome.reference"
@@ -661,7 +676,7 @@ class TestGfaContentClaimCoherence:
         assert get_val(record, "data_type") == "pangenome"
 
     def test_evidence_reason_is_singular_for_one_segment(self):
-        record = classify_from_gfa_segment_tags([SegmentTag(sn="chr1", sr="0")], file_name="some-graph.gfa")
+        record = classify_from_gfa_segment_tags([SegmentTag(sn="chr1", sr="0")], name=FileName.parse("some-graph.gfa"))
         content = next(e for e in record["data_type"]["evidence"] if e["rule_id"] == "rgfa_stable_rank_reference")
         assert "1 rGFA segment carries" in content["reason"]
 
@@ -863,20 +878,20 @@ class TestDerivedFileTierPrecedence:
 
     def test_index_with_reference_in_filename(self):
         """Index file with GRCh38 in filename should get reference_assembly=GRCh38."""
-        result = engine.classify_extended(FileInfo(filename="sample.GRCh38.bam.bai"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.GRCh38.bam.bai"))
         assert result.status_of("data_modality") == NOT_APPLICABLE
         assert result.reference_assembly == "GRCh38"
         assert result.status_of("platform") == NOT_APPLICABLE
 
     def test_index_with_chm13_in_filename(self):
         """Index file with CHM13 in filename should get reference_assembly=CHM13."""
-        result = engine.classify_extended(FileInfo(filename="HG01879.CHM13v2.cram.crai"))
+        result = engine.classify_extended(FileInfo.from_filename("HG01879.CHM13v2.cram.crai"))
         assert result.reference_assembly == "CHM13"
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_index_without_reference_in_filename(self):
         """Index file without reference hint should get reference_assembly=not_classified."""
-        result = engine.classify_extended(FileInfo(filename="sample.bam.bai"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.bam.bai"))
         assert result.status_of("reference_assembly") == NOT_CLASSIFIED
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
@@ -884,7 +899,7 @@ class TestDerivedFileTierPrecedence:
 
     def test_checksum_ignores_filename_reference(self):
         """Checksum file should stay not_applicable even with GRCh38 in filename."""
-        result = engine.classify_extended(FileInfo(filename="sample.GRCh38.bam.md5"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.GRCh38.bam.md5"))
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
@@ -892,7 +907,7 @@ class TestDerivedFileTierPrecedence:
 
     def test_log_ignores_filename_reference(self):
         """Log file should stay not_applicable even with hg38 in filename."""
-        result = engine.classify_extended(FileInfo(filename="alignment.hg38.log"))
+        result = engine.classify_extended(FileInfo.from_filename("alignment.hg38.log"))
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
@@ -900,13 +915,13 @@ class TestDerivedFileTierPrecedence:
 
     def test_svs_ignores_filename_reference(self):
         """SVS histology image should stay not_applicable for reference_assembly."""
-        result = engine.classify_extended(FileInfo(filename="hg38.sample.svs"))
+        result = engine.classify_extended(FileInfo.from_filename("hg38.sample.svs"))
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
         assert result.data_modality == "imaging.histology"
 
     def test_png_ignores_filename_reference(self):
         """PNG plot with reference in filename should stay not_applicable."""
-        result = engine.classify_extended(FileInfo(filename="GRCh38_coverage_plot.png"))
+        result = engine.classify_extended(FileInfo.from_filename("GRCh38_coverage_plot.png"))
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
@@ -914,7 +929,7 @@ class TestDerivedFileTierPrecedence:
 
     def test_fast5_ignores_filename_reference(self):
         """FAST5 raw signal with reference in filename should stay not_applicable."""
-        result = engine.classify_extended(FileInfo(filename="GRCh38_run.fast5"))
+        result = engine.classify_extended(FileInfo.from_filename("GRCh38_run.fast5"))
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
         assert result.platform == "ONT"
 
@@ -922,14 +937,14 @@ class TestDerivedFileTierPrecedence:
 
     def test_stats_with_reference_in_filename(self):
         """Stats file with CHM13 in filename should get reference_assembly=CHM13."""
-        result = engine.classify_extended(FileInfo(filename="HG01879.CHM13v2.chrX.samtools.stats.txt"))
+        result = engine.classify_extended(FileInfo.from_filename("HG01879.CHM13v2.chrX.samtools.stats.txt"))
         assert result.reference_assembly == "CHM13"
         assert result.status_of("data_modality") == NOT_APPLICABLE
         assert result.status_of("platform") == NOT_APPLICABLE
 
     def test_stats_without_reference_in_filename(self):
         """Stats file without reference hint should get not_classified, not not_applicable."""
-        result = engine.classify_extended(FileInfo(filename="HG00345.mosdepth.region.dist.txt"))
+        result = engine.classify_extended(FileInfo.from_filename("HG00345.mosdepth.region.dist.txt"))
         assert result.status_of("reference_assembly") == NOT_CLASSIFIED
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
@@ -938,16 +953,16 @@ class TestDerivedFileTierPrecedence:
     def test_assembly_qc_beats_intervals_targets(self):
         """Assembly QC BED (tier 2) should override intervals_targets (tier 1)."""
         result = engine.classify_extended(
-            FileInfo(filename="HG01928.maternal.f1_assembly_v2_genbank.HSat2and3_Regions.bed")
+            FileInfo.from_filename("HG01928.maternal.f1_assembly_v2_genbank.HSat2and3_Regions.bed")
         )
         assert result.data_modality == "genomic"  # not not_applicable
 
     def test_chip_peaks_beat_generic_peaks(self):
         """ChIP-seq peaks (tier 2) should override generic peaks (tier 1)."""
-        result = engine.classify_extended(FileInfo(filename="H3K27ac_chip_peaks.bed"))
+        result = engine.classify_extended(FileInfo.from_filename("H3K27ac_chip_peaks.bed"))
         assert result.data_modality == "epigenomic.histone_modification"
 
     def test_capture_targets_not_applicable(self):
         """Capture target BED without competing rules should get not_applicable."""
-        result = engine.classify_extended(FileInfo(filename="exome_capture_targets.bed"))
+        result = engine.classify_extended(FileInfo.from_filename("exome_capture_targets.bed"))
         assert result.status_of("data_modality") == NOT_APPLICABLE

--- a/tests/test_header_classifier.py
+++ b/tests/test_header_classifier.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from meta_disco.file_name import FileName
 from meta_disco.models import CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED, field_status, field_value
 
 
@@ -489,7 +490,7 @@ class TestFastqClassification:
     def test_paired_end_from_filename(self):
         """Detect paired-end from filename."""
         reads = ["@A00297:44:HFKH3DSXX:2:1354:30508:28839"]
-        result = classify_from_fastq_header(reads, file_name="sample_R1_001.fastq.gz")
+        result = classify_from_fastq_header(reads, name=FileName.parse("sample_R1_001.fastq.gz"))
         assert result["is_paired_end"] is True
 
     def test_empty_input(self):
@@ -620,7 +621,7 @@ class TestVcfClassification:
         (#152). Before the fix the classifier synthesized `sample.vcf.gz`."""
         header = """##fileformat=VCFv4.2
 #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO"""
-        result = classify_from_vcf_header(header, file_name="1kgp.chr20.chm13.vcf.gz")
+        result = classify_from_vcf_header(header, name=FileName.parse("1kgp.chr20.chm13.vcf.gz"))
         assert val(result, "reference_assembly") == "CHM13"
 
 
@@ -777,7 +778,7 @@ class TestBamCramClassification:
         modality signal still classifies rnaseq from the name (#152). Before the
         fix the classifier synthesized `sample.bam` and dropped the name."""
         header = "@HD\tVN:1.6"
-        result = classify_from_header(header, file_name="sample.rnaseq.bam")
+        result = classify_from_header(header, name=FileName.parse("sample.rnaseq.bam"))
         assert val(result, "data_modality") == "transcriptomic.bulk"
         assert val(result, "data_type") == "alignments"
 
@@ -785,7 +786,7 @@ class TestBamCramClassification:
         """A hifi filename recovers platform even when the header names none —
         the ~110-file platform bucket in #152."""
         header = "@HD\tVN:1.6"
-        result = classify_from_header(header, file_name="HG02055.paternal.hifi.bam")
+        result = classify_from_header(header, name=FileName.parse("HG02055.paternal.hifi.bam"))
         assert val(result, "platform") == "PACBIO"
 
     def test_header_signal_not_clobbered_by_filename(self):
@@ -793,7 +794,7 @@ class TestBamCramClassification:
         the fix adds filename coverage, it does not displace header rules (#152)."""
         header = """@HD\tVN:1.6
 @PG\tID:STAR\tPN:STAR\tVN:2.7.9a"""
-        result = classify_from_header(header, file_name="sample.bam")
+        result = classify_from_header(header, name=FileName.parse("sample.bam"))
         assert val(result, "data_modality") == "transcriptomic.bulk"
 
 

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from meta_disco.file_name import Format
+from meta_disco.file_name import FileName, Format
 from meta_disco.models import (
     CLASSIFICATION_FIELDS,
     CLASSIFIED,
@@ -58,38 +58,38 @@ class TestRuleMatching:
 
     def test_alignment_rnaseq_filename(self, engine):
         """RNA-seq indicators in filename should set transcriptomic modality."""
-        result = engine.classify(FileInfo(filename="sample_RNA_aligned.bam"))
+        result = engine.classify(FileInfo.from_filename("sample_RNA_aligned.bam"))
         assert result.data_modality == "transcriptomic.bulk"
         assert "alignment_rnaseq_filename" in result.rules_matched
 
     def test_alignment_wgs_filename(self, engine):
         """WGS indicators should set genomic modality with WGS assay_type."""
-        result = engine.classify(FileInfo(filename="sample_WGS_aligned.bam"))
+        result = engine.classify(FileInfo.from_filename("sample_WGS_aligned.bam"))
         assert result.data_modality == "genomic"
 
     def test_alignment_ref_grch38(self, engine):
         """hg38/GRCh38 in filename should set reference assembly."""
-        result = engine.classify(FileInfo(filename="sample.hg38.cram"))
+        result = engine.classify(FileInfo.from_filename("sample.hg38.cram"))
         assert result.reference_assembly == "GRCh38"
 
     def test_alignment_ref_grch37(self, engine):
         """hg19/GRCh37 in filename should set reference assembly."""
-        result = engine.classify(FileInfo(filename="sample.hg19.bam"))
+        result = engine.classify(FileInfo.from_filename("sample.hg19.bam"))
         assert result.reference_assembly == "GRCh37"
 
     def test_alignment_ref_chm13(self, engine):
         """CHM13/T2T in filename should set reference assembly."""
-        result = engine.classify(FileInfo(filename="sample.chm13.cram"))
+        result = engine.classify(FileInfo.from_filename("sample.chm13.cram"))
         assert result.reference_assembly == "CHM13"
 
     def test_rna_filename_sets_modality_regardless_of_size(self, engine):
         """RNA filename indicator should set transcriptomic modality."""
-        result = engine.classify(FileInfo(filename="sample_RNA_aligned.bam", file_size=60_000_000_000))
+        result = engine.classify(FileInfo.from_filename("sample_RNA_aligned.bam", file_size=60_000_000_000))
         assert result.data_modality == "transcriptomic.bulk"
 
     def test_star_aligner_indicates_rnaseq(self, engine):
         """STAR aligner output pattern should indicate RNA-seq."""
-        result = engine.classify(FileInfo(filename="sample.Aligned.sortedByCoord.out.bam"))
+        result = engine.classify(FileInfo.from_filename("sample.Aligned.sortedByCoord.out.bam"))
         assert result.data_modality == "transcriptomic.bulk"
 
 
@@ -98,17 +98,17 @@ class TestVariantFiles:
 
     def test_vcf_default_genomic(self, engine):
         """VCF files should default to genomic."""
-        result = engine.classify(FileInfo(filename="sample.vcf"))
+        result = engine.classify(FileInfo.from_filename("sample.vcf"))
         assert result.data_modality == "genomic"
 
     def test_vcf_gz_default_genomic(self, engine):
         """Compressed VCF files should default to genomic."""
-        result = engine.classify(FileInfo(filename="sample.vcf.gz"))
+        result = engine.classify(FileInfo.from_filename("sample.vcf.gz"))
         assert result.data_modality == "genomic"
 
     def test_vcf_with_ref_grch38(self, engine):
         """VCF with reference in filename."""
-        result = engine.classify(FileInfo(filename="NA19189.chr2.hg38.vcf.gz"))
+        result = engine.classify(FileInfo.from_filename("NA19189.chr2.hg38.vcf.gz"))
         assert result.data_modality == "genomic"
         assert result.reference_assembly == "GRCh38"
 
@@ -119,7 +119,7 @@ class TestVariantFiles:
         tier-3 ``vcf_contig_grch38`` rule reading the parsed assembly subfield.
         """
         ext_info = ExtendedFileInfo(
-            filename="sample.vcf.gz",
+            name=FileName.parse("sample.vcf.gz"),
             vcf_header="##contig=<ID=chr1,length=248956422,assembly=GRCh38>",
         )
         result = engine.classify_extended(ext_info, include_tier3=True)
@@ -143,7 +143,7 @@ class TestVariantFiles:
     def test_vcf_contig_assembly_aliases_classify(self, engine, assembly, expected):
         """##contig assembly aliases classify to the same set as ##reference (#221)."""
         ext_info = ExtendedFileInfo(
-            filename="sample.vcf.gz",
+            name=FileName.parse("sample.vcf.gz"),
             vcf_header=f"##contig=<ID=chr1,length=248956422,assembly={assembly}>",
         )
         result = engine.classify_extended(ext_info, include_tier3=True)
@@ -168,7 +168,7 @@ class TestVariantFiles:
         ],
     )
     def test_vcf_gca_accession_version_maps_to_correct_assembly(self, engine, header_line, expected):
-        ext_info = ExtendedFileInfo(filename="sample.vcf.gz", vcf_header=header_line)
+        ext_info = ExtendedFileInfo(name=FileName.parse("sample.vcf.gz"), vcf_header=header_line)
         result = engine.classify_extended(ext_info, include_tier3=True)
         assert result.reference_assembly == expected
 
@@ -182,26 +182,26 @@ class TestFormatMatching:
     def test_format_keyed_rule_matches_every_spelling(self, engine, name):
         """One `format: FASTA` rule fires for every FASTA spelling/compression
         variant — the collapse the extension list used to enumerate by hand."""
-        result = engine.classify_extended(FileInfo(filename=name))
+        result = engine.classify_extended(FileInfo.from_filename(name))
         assert result.data_type == "sequence"
 
     def test_format_keyed_filename_rule_still_fires(self, engine):
         """A tier-2 rule that pairs `format: FASTA` with a filename_pattern still
         matches on both conditions (fasta_assembly_filename)."""
-        result = engine.classify_extended(FileInfo(filename="HG002.hifiasm.bp.p_ctg.fa"))
+        result = engine.classify_extended(FileInfo.from_filename("HG002.hifiasm.bp.p_ctg.fa"))
         assert result.data_modality == "genomic"
         assert result.data_type == "assembly"
 
     def test_format_keyed_rule_skipped_for_other_formats(self, engine):
         """A format-only rule is considered for every file but must not fire when
         the format differs — a BAM is not classified as FASTA sequence."""
-        result = engine.classify_extended(FileInfo(filename="sample.bam"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.bam"))
         assert result.data_type != "sequence"
 
     def test_engine_derives_format_from_settled_extension(self, engine):
         """classify_extended sets file_info.format from the extension it settles
         on, agreeing with file_format even on a header-only (name-less) call."""
-        ext_info = ExtendedFileInfo(filename="", file_format=".cram")
+        ext_info = ExtendedFileInfo(name=FileName.parse(""), file_format=".cram")
         engine.classify_extended(ext_info)
         assert ext_info.format is Format.CRAM
 
@@ -211,7 +211,7 @@ class TestFormatMatching:
         silently skipped — the guard keys on presence, not truthiness (#243)."""
         from meta_disco.rule_loader import UnifiedRule
 
-        fasta = ExtendedFileInfo(filename="genome.fa", format=Format.FASTA)
+        fasta = ExtendedFileInfo(name=FileName.parse("genome.fa"), format=Format.FASTA)
         result = ExtendedClassificationResult()
         empty_fmt = UnifiedRule(id="x", tier=1, scope="extension", when={"format": ""}, then={}, rationale="")
         assert engine._rule_matches(empty_fmt, fasta, result) is False
@@ -223,15 +223,15 @@ class TestFormatMatching:
         """A mixed-case header-only file_format is lower-cased once at the source,
         so the extensions / when.file_format / assay conditions all match case-
         insensitively — a `.CRAM` classifies identically to a `.cram` (#243)."""
-        upper = ExtendedFileInfo(filename="", file_format=".CRAM")
-        lower = ExtendedFileInfo(filename="", file_format=".cram")
+        upper = ExtendedFileInfo(name=FileName.parse(""), file_format=".CRAM")
+        lower = ExtendedFileInfo(name=FileName.parse(""), file_format=".cram")
         r_upper = engine.classify_extended(upper)
         r_lower = engine.classify_extended(lower)
         assert upper.file_format == ".cram"  # normalized in place
         assert upper.format is Format.CRAM
         assert r_upper.data_type == r_lower.data_type  # downstream matching is case-insensitive
         # A None file_format is left as-is (no crash) and derives no format.
-        none_info = ExtendedFileInfo(filename="", file_format=None)
+        none_info = ExtendedFileInfo(name=FileName.parse(""), file_format=None)
         engine.classify_extended(none_info)
         assert none_info.file_format is None
         assert none_info.format is None
@@ -249,15 +249,15 @@ class TestWrapperSplitMatching:
     def test_core_keyed_rule_matches_compressed_and_uncompressed(self, engine, name):
         """The extension rules list only the core (".vcf"), yet both sample.vcf and
         sample.vcf.gz route through it — the compression no longer needs listing."""
-        compressed = engine.classify_extended(FileInfo(filename=name))
-        bare = engine.classify_extended(FileInfo(filename=name.replace(".gz", "")))
+        compressed = engine.classify_extended(FileInfo.from_filename(name))
+        bare = engine.classify_extended(FileInfo.from_filename(name.replace(".gz", "")))
         assert compressed.data_type == bare.data_type
         assert compressed.data_type is not None
 
     def test_gvcf_core_keeps_its_distinct_signal(self, engine):
         """`.g.vcf.gz` splits to the `.g.vcf` core, which derives Format.GVCF and
         still matches the VCF rules that list `.g.vcf` (behavior-preserved)."""
-        ext_info = ExtendedFileInfo(filename="HG002.deepvariant.g.vcf.gz")
+        ext_info = ExtendedFileInfo(name=FileName.parse("HG002.deepvariant.g.vcf.gz"))
         result = engine.classify_extended(ext_info)
         assert ext_info.format is Format.GVCF
         assert result.data_type == "variants"
@@ -266,7 +266,7 @@ class TestWrapperSplitMatching:
         """A header-only call passing a compound file_format (".fastq.gz") with no
         filename settles to the core (".fastq") so the core-keyed rules still fire
         — the regression the #244 core-keying would otherwise introduce."""
-        ext_info = ExtendedFileInfo(filename="", file_format=".fastq.gz")
+        ext_info = ExtendedFileInfo(name=FileName.parse(""), file_format=".fastq.gz")
         result = engine.classify_extended(ext_info)
         assert ext_info.file_format == ".fastq"
         assert ext_info.format is Format.FASTQ
@@ -278,7 +278,7 @@ class TestWrapperSplitMatching:
         gate collapsed it, and #244 needed a known-core short-circuit to compensate;
         #249 made the parser recognize ".g.vcf" directly, so the plain normalization
         keeps it correctly and the short-circuit is gone."""
-        ext_info = ExtendedFileInfo(filename="", file_format=".g.vcf")
+        ext_info = ExtendedFileInfo(name=FileName.parse(""), file_format=".g.vcf")
         engine.classify_extended(ext_info)
         assert ext_info.file_format == ".g.vcf"
         assert ext_info.format is Format.GVCF
@@ -314,7 +314,7 @@ class TestThenStatus:
 
     def test_status_only_field_is_not_applicable(self, tmp_path):
         engine = self._engine_with_rule(tmp_path, {"status": {"reference_assembly": "not_applicable"}})
-        out = engine.classify_extended(FileInfo(filename="x.bam")).to_output_dict()
+        out = engine.classify_extended(FileInfo.from_filename("x.bam")).to_output_dict()
         assert out["reference_assembly"]["status"] == NOT_APPLICABLE
         assert out["reference_assembly"]["value"] is None
 
@@ -328,7 +328,7 @@ class TestThenStatus:
                 "status": {"reference_assembly": "not_applicable"},
             },
         )
-        out = engine.classify_extended(FileInfo(filename="x.bam")).to_output_dict()
+        out = engine.classify_extended(FileInfo.from_filename("x.bam")).to_output_dict()
         assert out["data_type"]["status"] == CLASSIFIED
         assert out["data_type"]["value"] == "raw_signal"
         assert out["reference_assembly"]["status"] == NOT_APPLICABLE
@@ -513,22 +513,22 @@ class TestDerivativeFiles:
 
     def test_index_bai(self, engine):
         """BAI index files should be not_applicable."""
-        result = engine.classify_extended(FileInfo(filename="sample.bam.bai"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.bam.bai"))
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_index_crai(self, engine):
         """CRAI index files should be not_applicable."""
-        result = engine.classify_extended(FileInfo(filename="sample.cram.crai"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.cram.crai"))
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_checksum_md5(self, engine):
         """MD5 checksum files should be not_applicable."""
-        result = engine.classify_extended(FileInfo(filename="HG02558.final.cram.md5"))
+        result = engine.classify_extended(FileInfo.from_filename("HG02558.final.cram.md5"))
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_log_files(self, engine):
         """Log files should be not_applicable."""
-        result = engine.classify_extended(FileInfo(filename="pipeline.log"))
+        result = engine.classify_extended(FileInfo.from_filename("pipeline.log"))
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
 
@@ -538,27 +538,27 @@ class TestSpecialFileTypes:
     def test_plink_genomic(self, engine):
         """PLINK files should be genomic."""
         for ext in [".pgen", ".pvar", ".psam"]:
-            result = engine.classify(FileInfo(filename=f"sample{ext}"))
+            result = engine.classify(FileInfo.from_filename(f"sample{ext}"))
             assert result.data_modality == "genomic"
 
     def test_single_cell_matrix(self, engine):
         """Single-cell matrix files should be transcriptomic.single_cell."""
-        result = engine.classify(FileInfo(filename="sample.h5ad"))
+        result = engine.classify(FileInfo.from_filename("sample.h5ad"))
         assert result.data_modality == "transcriptomic.single_cell"
 
     def test_single_cell_atac(self, engine):
         """Single-cell ATAC matrix should be epigenomic."""
-        result = engine.classify(FileInfo(filename="sample_atac_peaks.h5ad"))
+        result = engine.classify(FileInfo.from_filename("sample_atac_peaks.h5ad"))
         assert result.data_modality == "epigenomic.chromatin_accessibility"
 
     def test_methylation_idat(self, engine):
         """IDAT files should be epigenomic.methylation."""
-        result = engine.classify(FileInfo(filename="sample.idat"))
+        result = engine.classify(FileInfo.from_filename("sample.idat"))
         assert result.data_modality == "epigenomic.methylation"
 
     def test_histology_svs(self, engine):
         """SVS files should be imaging.histology."""
-        result = engine.classify(FileInfo(filename="GTEX-18A6Q-1126.svs"))
+        result = engine.classify(FileInfo.from_filename("GTEX-18A6Q-1126.svs"))
         assert result.data_modality == "imaging.histology"
 
 
@@ -567,12 +567,12 @@ class TestFastqFiles:
 
     def test_fastq_rna(self, engine):
         """FASTQ with RNA indicator."""
-        result = engine.classify(FileInfo(filename="sample_rnaseq_R1.fastq.gz"))
+        result = engine.classify(FileInfo.from_filename("sample_rnaseq_R1.fastq.gz"))
         assert result.data_modality == "transcriptomic.bulk"
 
     def test_fastq_ambiguous(self, engine):
         """FASTQ without indicators is not classified for modality."""
-        result = engine.classify_extended(FileInfo(filename="sample_R1.fastq.gz"))
+        result = engine.classify_extended(FileInfo.from_filename("sample_R1.fastq.gz"))
         assert result.status_of("data_modality") == NOT_CLASSIFIED
 
 
@@ -581,12 +581,12 @@ class TestSignalTracks:
 
     def test_bigwig_chip(self, engine):
         """ChIP-seq bigwig files."""
-        result = engine.classify(FileInfo(filename="sample_H3K27ac.bigwig"))
+        result = engine.classify(FileInfo.from_filename("sample_H3K27ac.bigwig"))
         assert result.data_modality == "epigenomic.histone_modification"
 
     def test_bigwig_atac(self, engine):
         """ATAC-seq bigwig files."""
-        result = engine.classify(FileInfo(filename="sample_atac.bw"))
+        result = engine.classify(FileInfo.from_filename("sample_atac.bw"))
         assert result.data_modality == "epigenomic.chromatin_accessibility"
 
 
@@ -595,27 +595,27 @@ class TestPeakFiles:
 
     def test_narrowpeak_chromatin_accessibility(self, engine):
         """narrowPeak files should be epigenomic.chromatin_accessibility."""
-        result = engine.classify(FileInfo(filename="sample.narrowPeak"))
+        result = engine.classify(FileInfo.from_filename("sample.narrowPeak"))
         assert result.data_modality == "epigenomic.chromatin_accessibility"
 
     def test_broadpeak_chromatin_accessibility(self, engine):
         """broadPeak files should be epigenomic.chromatin_accessibility."""
-        result = engine.classify(FileInfo(filename="sample.broadPeak"))
+        result = engine.classify(FileInfo.from_filename("sample.broadPeak"))
         assert result.data_modality == "epigenomic.chromatin_accessibility"
 
     def test_peaks_bed_chromatin_accessibility(self, engine):
         """BED files with 'peaks' should be epigenomic.chromatin_accessibility."""
-        result = engine.classify(FileInfo(filename="atac_peaks.bed"))
+        result = engine.classify(FileInfo.from_filename("atac_peaks.bed"))
         assert result.data_modality == "epigenomic.chromatin_accessibility"
 
     def test_chip_peaks_histone_modification(self, engine):
         """ChIP-seq peak files should be epigenomic.histone_modification."""
-        result = engine.classify(FileInfo(filename="H3K27ac_chip_peaks.bed"))
+        result = engine.classify(FileInfo.from_filename("H3K27ac_chip_peaks.bed"))
         assert result.data_modality == "epigenomic.histone_modification"
 
     def test_summit_bed_chromatin_accessibility(self, engine):
         """Summit files should be epigenomic.chromatin_accessibility."""
-        result = engine.classify(FileInfo(filename="sample_summits.bed"))
+        result = engine.classify(FileInfo.from_filename("sample_summits.bed"))
         assert result.data_modality == "epigenomic.chromatin_accessibility"
 
 
@@ -624,17 +624,17 @@ class TestTextFiles:
 
     def test_stats_file(self, engine):
         """QC stats files should be not_applicable."""
-        result = engine.classify_extended(FileInfo(filename="sample.stats.txt"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.stats.txt"))
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_count_matrix(self, engine):
         """Count matrix files should be transcriptomic."""
-        result = engine.classify(FileInfo(filename="gene_counts.txt"))
+        result = engine.classify(FileInfo.from_filename("gene_counts.txt"))
         assert result.data_modality == "transcriptomic.bulk"
 
     def test_ambiguous_txt(self, engine):
         """Ambiguous text files are not classified for modality."""
-        result = engine.classify_extended(FileInfo(filename="data.txt"))
+        result = engine.classify_extended(FileInfo.from_filename("data.txt"))
         assert result.status_of("data_modality") == NOT_CLASSIFIED
 
 
@@ -643,27 +643,27 @@ class TestIntegration:
 
     def test_hifi_bam(self, engine):
         """HiFi reads BAM file."""
-        result = engine.classify(FileInfo(filename="m64043_210211_005516.hifi_reads.bam"))
+        result = engine.classify(FileInfo.from_filename("m64043_210211_005516.hifi_reads.bam"))
         assert result.data_modality == "genomic"
 
     def test_vcf_with_chr(self, engine):
         """VCF with chromosome in filename."""
-        result = engine.classify(FileInfo(filename="NA19189.chr2.hc.vcf.gz"))
+        result = engine.classify(FileInfo.from_filename("NA19189.chr2.hc.vcf.gz"))
         assert result.data_modality == "genomic"
 
     def test_gtex_histology(self, engine):
         """GTEx histology image."""
-        result = engine.classify(FileInfo(filename="GTEX-18A6Q-1126.svs"))
+        result = engine.classify(FileInfo.from_filename("GTEX-18A6Q-1126.svs"))
         assert result.data_modality == "imaging.histology"
 
     def test_cram_md5(self, engine):
         """CRAM MD5 checksum should be not_applicable."""
-        result = engine.classify_extended(FileInfo(filename="HG02558.final.cram.md5"))
+        result = engine.classify_extended(FileInfo.from_filename("HG02558.final.cram.md5"))
         assert result.status_of("data_modality") == NOT_APPLICABLE
 
     def test_unknown_extension(self, engine):
         """Unknown extensions are not classified."""
-        result = engine.classify_extended(FileInfo(filename="sample.xyz"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.xyz"))
         assert result.status_of("data_modality") == NOT_CLASSIFIED
 
 
@@ -672,22 +672,22 @@ class TestConflictingReferenceRules:
 
     def test_ambiguous_filename_two_refs(self, engine):
         """Filename with both CHM13 and hg38 should be not_classified."""
-        result = engine.classify_extended(FileInfo(filename="CHM13.hg38.gff3.gz"))
+        result = engine.classify_extended(FileInfo.from_filename("CHM13.hg38.gff3.gz"))
         assert result.status_of("reference_assembly") == NOT_CLASSIFIED
 
     def test_liftover_chain_two_refs(self, engine):
         """Liftover chain with two references should be not_classified."""
-        result = engine.classify_extended(FileInfo(filename="liftover.hg19.to.hg38.chain"))
+        result = engine.classify_extended(FileInfo.from_filename("liftover.hg19.to.hg38.chain"))
         assert result.status_of("reference_assembly") == NOT_CLASSIFIED
 
     def test_single_ref_not_affected(self, engine):
         """Single reference in filename should still work."""
-        result = engine.classify_extended(FileInfo(filename="sample.GRCh38.bed"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.GRCh38.bed"))
         assert result.reference_assembly == "GRCh38"
 
     def test_conflict_evidence_recorded(self, engine):
         """Conflict should produce a conflict marker in reference_assembly evidence."""
-        result = engine.classify_extended(FileInfo(filename="CHM13.hg38.gff3.gz"))
+        result = engine.classify_extended(FileInfo.from_filename("CHM13.hg38.gff3.gz"))
         ref_evidence = result.field_evidence.get("reference_assembly", [])
         assert any(e.get("marker") == "conflict" for e in ref_evidence)
         # Prior evidence should also be preserved
@@ -699,14 +699,14 @@ class TestConflictingClassificationFields:
 
     def test_data_modality_conflict(self, engine):
         """Same-tier rules disagreeing on data_modality produce not_classified."""
-        result = engine.classify_extended(FileInfo(filename="sample_rnaseq_wgs_aligned.bam"))
+        result = engine.classify_extended(FileInfo.from_filename("sample_rnaseq_wgs_aligned.bam"))
         assert result.status_of("data_modality") == NOT_CLASSIFIED
         evidence = result.field_evidence.get("data_modality", [])
         assert any(e.get("marker") == "conflict" for e in evidence)
 
     def test_conflict_preserves_prior_evidence(self, engine):
         """Conflict marker is appended to existing evidence, not replaced."""
-        result = engine.classify_extended(FileInfo(filename="CHM13.hg38.gff3.gz"))
+        result = engine.classify_extended(FileInfo.from_filename("CHM13.hg38.gff3.gz"))
         evidence = result.field_evidence.get("reference_assembly", [])
         rule_ids = [e.get("rule_id") for e in evidence]
         # Both the original rule and the conflict marker should be present
@@ -716,7 +716,7 @@ class TestConflictingClassificationFields:
     def test_conflict_evidence_has_status_and_competing_values(self, engine):
         """Conflict evidence carries a not_classified status (in the status field,
         not the value slot) and the structured competing_values field."""
-        result = engine.classify_extended(FileInfo(filename="CHM13.hg38.gff3.gz"))
+        result = engine.classify_extended(FileInfo.from_filename("CHM13.hg38.gff3.gz"))
         evidence = result.field_evidence.get("reference_assembly", [])
         conflict = next(e for e in evidence if e.get("marker") == "conflict")
         assert conflict["status"] == NOT_CLASSIFIED
@@ -725,7 +725,7 @@ class TestConflictingClassificationFields:
 
     def test_normal_evidence_has_value_field(self, engine):
         """Every evidence entry should include the value that was set."""
-        result = engine.classify_extended(FileInfo(filename="sample.GRCh38.bed"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.GRCh38.bed"))
         evidence = result.field_evidence.get("reference_assembly", [])
         ref_entry = next(e for e in evidence if e["rule_id"] == "filename_ref_grch38")
         assert ref_entry["value"] == "GRCh38"
@@ -886,7 +886,7 @@ class TestEvaluateClaims:
 
     def test_rule_authored_not_classified_in_evidence(self, engine):
         """fastq_modality_unknown rationale should appear in evidence, not generic placeholder."""
-        result = engine.classify_extended(FileInfo(filename="sample_R1.fastq.gz"), include_tier3=True)
+        result = engine.classify_extended(FileInfo.from_filename("sample_R1.fastq.gz"), include_tier3=True)
         dm_evidence = result.field_evidence.get("data_modality", [])
         rule_ids = [e["rule_id"] for e in dm_evidence]
         # Should have the rule's ID, not the generic "not_classified" placeholder
@@ -952,11 +952,11 @@ class TestAssayTypeInference:
     def test_inferred_assay_type_has_evidence(self, engine):
         """Inferred assay_type should have evidence from the infer_assay_type rule."""
         file_info = ExtendedFileInfo(
-            filename="sample.bam",
+            name=FileName.parse("sample.bam"),
             file_size=60_000_000_000,
             file_format=".bam",
         )
-        result = engine.classify_extended(FileInfo(filename="sample.bam", file_size=60_000_000_000))
+        result = engine.classify_extended(FileInfo.from_filename("sample.bam", file_size=60_000_000_000))
         # Set conditions that trigger WGS inference (via set_field to stay coherent)
         result.set_field("data_modality", "genomic")
         result.set_field("platform", "ILLUMINA")
@@ -971,11 +971,11 @@ class TestAssayTypeInference:
     def test_inferred_assay_type_removes_not_classified_placeholder(self, engine):
         """Inference should remove stale not_classified placeholder evidence."""
         file_info = ExtendedFileInfo(
-            filename="sample.bam",
+            name=FileName.parse("sample.bam"),
             file_size=60_000_000_000,
             file_format=".bam",
         )
-        result = engine.classify_extended(FileInfo(filename="sample.bam", file_size=60_000_000_000))
+        result = engine.classify_extended(FileInfo.from_filename("sample.bam", file_size=60_000_000_000))
         result.set_field("data_modality", "genomic")
         result.set_field("platform", "ILLUMINA")
         result.set_field("assay_type", status=NOT_CLASSIFIED)
@@ -999,13 +999,13 @@ class TestReasonChain:
 
     def test_multiple_reasons(self, engine):
         """Multiple matching rules should accumulate reasons."""
-        result = engine.classify(FileInfo(filename="sample_RNA.hg38.bam"))
+        result = engine.classify(FileInfo.from_filename("sample_RNA.hg38.bam"))
         assert len(result.reasons) >= 2
         assert len(result.rules_matched) >= 2
 
     def test_reason_explains_decision(self, engine):
         """Reasons should explain why classification was made."""
-        result = engine.classify(FileInfo(filename="sample.svs"))
+        result = engine.classify(FileInfo.from_filename("sample.svs"))
         assert any("histology" in r.lower() or "svs" in r.lower() for r in result.reasons)
 
 
@@ -1015,7 +1015,7 @@ class TestSentinelValues:
     def test_derivative_files_get_not_applicable(self, engine):
         """Index files get not_applicable for modality/platform/assay but not reference_assembly
         (reference IS applicable to indexes — it's determined by the parent file's alignment)."""
-        result = engine.classify_extended(FileInfo(filename="sample.bam.bai"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.bam.bai"))
         assert result.status_of("data_modality") == NOT_APPLICABLE
         assert result.status_of("reference_assembly") == NOT_CLASSIFIED  # applicable but unknown without filename hint
         assert result.status_of("platform") == NOT_APPLICABLE
@@ -1023,13 +1023,13 @@ class TestSentinelValues:
 
     def test_unclassified_fields_get_not_classified(self, engine):
         """Files with unset fields should get not_classified."""
-        result = engine.classify_extended(FileInfo(filename="sample.xyz"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.xyz"))
         assert result.status_of("data_modality") == NOT_CLASSIFIED
         assert result.status_of("reference_assembly") == NOT_CLASSIFIED
 
     def test_not_classified_evidence_includes_field_name(self, engine):
         """Evidence reason for not_classified should name the specific field."""
-        result = engine.classify_extended(FileInfo(filename="sample.xyz"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.xyz"))
         checked = 0
         for fld in ["data_modality", "data_type", "platform", "reference_assembly", "assay_type"]:
             evidence = result.field_evidence[fld]
@@ -1041,31 +1041,31 @@ class TestSentinelValues:
 
     def test_images_get_not_applicable_for_genomic_fields(self, engine):
         """Image files should get not_applicable for platform and reference."""
-        result = engine.classify_extended(FileInfo(filename="sample.svs"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.svs"))
         assert result.data_modality == "imaging.histology"
         assert result.status_of("platform") == NOT_APPLICABLE
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_fastq_gets_not_applicable_reference(self, engine):
         """FASTQ files should get not_applicable for reference (unaligned reads)."""
-        result = engine.classify_extended(FileInfo(filename="sample.fastq.gz"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.fastq.gz"))
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
 
     def test_fast5_gets_not_applicable_reference(self, engine):
         """FAST5 files should get not_applicable for reference (raw signal)."""
-        result = engine.classify_extended(FileInfo(filename="sample.fast5"))
+        result = engine.classify_extended(FileInfo.from_filename("sample.fast5"))
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
         assert result.platform == "ONT"
 
     def test_bam_without_header_not_classified(self, engine):
         """BAM without header should leave modality as not_classified."""
-        result = engine.classify_extended(ExtendedFileInfo(filename="sample.bam", file_size=60_000_000_000))
+        result = engine.classify_extended(ExtendedFileInfo(name=FileName.parse("sample.bam"), file_size=60_000_000_000))
         # No header = no modality evidence, even for large files
         assert result.status_of("data_modality") == NOT_CLASSIFIED
 
     def test_png_all_fields_not_applicable(self, engine):
         """PNG files should get not_applicable for all non-applicable fields."""
-        result = engine.classify_extended(FileInfo(filename="plot.png"))
+        result = engine.classify_extended(FileInfo.from_filename("plot.png"))
         assert result.status_of("data_modality") == NOT_APPLICABLE
         assert result.status_of("platform") == NOT_APPLICABLE
         assert result.status_of("reference_assembly") == NOT_APPLICABLE
@@ -1080,22 +1080,22 @@ class TestOutputDictStatus:
         # Every dimension entry carries `status` alongside the existing keys,
         # across a spread of file types.
         for filename in ("sample_WGS_aligned.bam", "sample.fastq.gz", "plot.png"):
-            out = engine.classify_extended(FileInfo(filename=filename)).to_output_dict()
+            out = engine.classify_extended(FileInfo.from_filename(filename)).to_output_dict()
             for fld in CLASSIFICATION_FIELDS:
                 assert set(out[fld]) == {"value", "status", "evidence"}
 
     def test_status_pins_each_sentinel_state(self, engine):
         # Stage 3 shape: a real value classifies (value kept); each sentinel lives
         # in `status` with `value` nulled out — no sentinels in `value`.
-        classified = engine.classify_extended(FileInfo(filename="sample_WGS_aligned.bam")).to_output_dict()[
+        classified = engine.classify_extended(FileInfo.from_filename("sample_WGS_aligned.bam")).to_output_dict()[
             "data_modality"
         ]
         assert (classified["value"], classified["status"]) == ("genomic", CLASSIFIED)
 
-        n_a = engine.classify_extended(FileInfo(filename="plot.png")).to_output_dict()["reference_assembly"]
+        n_a = engine.classify_extended(FileInfo.from_filename("plot.png")).to_output_dict()["reference_assembly"]
         assert (n_a["value"], n_a["status"]) == (None, NOT_APPLICABLE)
 
         n_c = engine.classify_extended(
-            ExtendedFileInfo(filename="sample.bam", file_size=60_000_000_000)
+            ExtendedFileInfo(name=FileName.parse("sample.bam"), file_size=60_000_000_000)
         ).to_output_dict()["data_modality"]
         assert (n_c["value"], n_c["status"]) == (None, NOT_CLASSIFIED)


### PR DESCRIPTION
Closes #246. Part of the FileName epic #242.

## What changed

Parse the raw `file_name` into a `FileName` value object **once**, at the load boundary, and thread that object through the pipeline → classifiers → `ExtendedFileInfo` instead of a raw string.

- **Load boundary parse-once.** `ClassifierRecord.from_record` (pipeline path) and `FileInfo.from_filename` (script / single-file path) are the sole parse sites. `ExtendedFileInfo.from_file_info` copies the parsed `FileName` across without re-parsing.
- **Engine reads the fact.** `classify_extended` reads `ext_info.name.extension` instead of calling `parse_file_name` on every classification; the filename-pattern matcher reads `name.raw`.
- **`FileInfo` / `ExtendedFileInfo` carry `name: FileName`** (composition, replacing the raw `filename: str`), defaulting to a shared `FileName.EMPTY` sentinel.
- **The six classifier signatures take `name: FileName`** (`classify_from_header`/`vcf`/`fastq`/`fasta`/`bed`/`gfa`).
- **`filename_for_rules` → `file_name_for_rules`**, retyped `FileName`-in/`FileName`-out: it reuses the threaded fact when the extension is usable (no re-parse) and only builds a fresh grafted `FileName` in the `allowed_extensions` override case.

## Why

The filename is a fact about the *record*, not about a classification pass. #241 moved the parse into the engine's single derivation site but re-parsed per `classify` call. This issue realizes the "parse once" invariant of #242 by parsing at the true load boundary and threading the value.

## Assumptions I made

- **Decision A** (with the issue author): the raw `file_name` is parsed at the load boundary and `file_format` stays a *separate* fallback that the engine reconciles (name extension wins, else `file_format`). The header-only classifiers keep hardcoding their known `file_format` (`.bam`/`.vcf.gz`/…) for the no-name case; their `file_format` param is accepted for call uniformity but not consulted.
- **Decision Replace**: classifier params were replaced (not added alongside), so ~150 mechanical test-call rewrites (`FileInfo(filename=…)` → `FileInfo.from_filename(…)`, `file_name="x"` → `name=FileName.parse("x")`).
- **`file_name_for_rules` stays until #245.** Its `allowed_extensions` override (e.g. forcing `graph.tar.gz` onto the `.gfa` rules) is behavior the engine's reconciliation lacks, so it can't simply be dropped this PR; #245 pushes that override into the engine and deletes the helper. It tests "usable" against the *compound* spelling (`name.extension + wrappers`), the same value the old `extract_extension` returned — that invariant is pinned by `test_file_name.py::TestBehaviorPreservation`.
- **`FileName.EMPTY`** models "no name" (a header-only call): it reads identically to any name with no known extension (`extension is None`, empty `raw`), so downstream code threads one value instead of a `FileName | None` with `is not None` guards at every reader.
- Deferred (not this PR): #245 (retire `file_name_for_rules`), the `extensions.py` category-catalog seam and dead `get_file_type` (noted on #246), and per-type `FileInfo` / content-union (#154).

## How to verify

Definition of done (from #246):

- [x] **Parse at the true load boundary.** `ClassifierRecord.from_record` parses `file_name` into a `FileName` once — see `src/meta_disco/records.py`.
- [x] **Threaded through pipeline → classifiers → `ExtendedFileInfo`.** `pipeline._fetch_and_classify` passes `name=item.name`; classifiers build `ExtendedFileInfo(name=…)`.
- [x] **`ExtendedFileInfo` carries the `FileName` fact**, filename-pattern rules read `.raw`.
- [x] **Six classifier signatures take a parsed `FileName`.**

Steps:
1. `make test` — 798 pass.
2. `make lint && make format-check && uv run pyright` — all clean.
3. Behavior preservation: run an extension/filename-only A/B of `engine.classify_extended(FileInfo.from_filename(name)).to_output_dict()` over the AnVIL corpus on this branch vs `main` and diff — **0 differences across 100,670 unique filenames** (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)