### PR TITLE
Model containers as containers; retire filename_for_rules (#245)

### DIFF
--- a/scripts/generate_coverage_report.py
+++ b/scripts/generate_coverage_report.py
@@ -16,11 +16,9 @@ from collections import Counter, defaultdict
 from datetime import datetime
 from pathlib import Path
 
+from meta_disco.file_name import FileName
 from meta_disco.models import field_label
 from meta_disco.output_utils import CLASSIFICATION_FILES, find_latest_run
-from meta_disco.rule_loader import UnifiedRules
-
-COMPOUND_EXTENSIONS = UnifiedRules.COMPOUND_EXTENSIONS
 
 DIMENSIONS = [
     ("data_modality", "Data Modality", ""),
@@ -51,13 +49,9 @@ def escape_md_cell(text: str) -> str:
 
 
 def get_extension(filename: str) -> str:
-    name = filename.lower()
-    for ext in COMPOUND_EXTENSIONS:
-        if name.endswith(ext):
-            return ext
-    if "." in filename:
-        return "." + filename.rsplit(".", 1)[-1].lower()
-    return "(none)"
+    # Group by the parsed clean core extension (#245); an archive/compression-only
+    # or extensionless name has no core and groups under "(none)".
+    return FileName.parse(filename).extension or "(none)"
 
 
 def load_records(run_dir: Path) -> list[dict]:

--- a/src/meta_disco/file_name.py
+++ b/src/meta_disco/file_name.py
@@ -8,9 +8,8 @@ string (epic #242).
 
 ``FileName`` is a pure data type and its parse is a **pure function**:
 ``FileName.parse(name)`` needs no loaded ``UnifiedRules`` — the whole extension
-vocabulary (``COMPOUND_EXTENSIONS`` / ``WRAPPER_SUFFIXES`` / ``EXTENSION_TO_FORMAT``
-/ ``EXTENSION_MAP`` and the derived ``CORE_EXTENSIONS``) lives here in-code as a
-self-contained leaf (#252). ``extension`` is syntactic — the exact core suffix,
+vocabulary (``WRAPPER_SUFFIXES`` / ``EXTENSION_TO_FORMAT`` / ``EXTENSION_MAP`` and
+the derived ``CORE_EXTENSIONS``) lives here in-code as a self-contained leaf (#252). ``extension`` is syntactic — the exact core suffix,
 ``.cram`` distinct from ``.bam`` — with any compression/archive kept apart in
 ``wrappers`` (#244: ``sample.vcf.gz`` → extension ``.vcf`` + wrappers ``(".gz",)``).
 ``format`` is *derived*: what the file actually is, collapsing spelling and
@@ -83,32 +82,15 @@ class FormatSource(str, Enum):
 # rules instance. UnifiedRules re-exposes these as thin delegators.
 # ---------------------------------------------------------------------------
 
-# Compound extensions in priority order (longest first).
-COMPOUND_EXTENSIONS: tuple[str, ...] = (
-    ".g.vcf.gz",  # Must come before .vcf.gz
-    ".gvcf.gz",
-    ".vcf.gz",
-    ".fastq.gz",
-    ".fq.gz",
-    ".fasta.gz",
-    ".fa.gz",
-    ".bed.gz",
-    ".sam.gz",
-    ".rgfa.gz",
-    ".gfa.gz",
-    ".fast5.tar.gz",  # Must come before .tar.gz
-    ".fast5.tar",  # Must come before .tar
-    ".tar.gz",
-    ".mtx.gz",
-)
-
-# Compression and archive suffixes — "wrappers" around the format, not the
-# format itself. Since #244 these do the real work of the extension/format
-# split: the parse splits a recognized extension token into its clean core
-# suffix and these trailing wrappers (".vcf.gz" -> ".vcf" + (".gz",)). Ordered
-# longest-first: the split/peel loop takes the first `endswith` match, so `.bgz`
-# must precede `.gz` or a `.bgz` token would mis-peel as `.gz` and leave a
-# dangling `b` on the core.
+# Compression and archive suffixes — "wrappers" (containers) around the format,
+# not the format itself. The parse peels *every* trailing wrapper off the name
+# first, then recognizes the core the remainder ends with (#245): a container is
+# always stripped, so ``.fast5.tar.gz`` -> core ``.fast5`` + (``.tar``, ``.gz``)
+# falls out with no per-combination allowlist, and an archive with no inner format
+# (``graph.tar.gz``) leaves ``extension=None``. Ordered longest-first: the peel loop
+# takes the first `endswith` match, so `.bgz` must precede `.gz` or a `.bgz` token
+# would mis-peel as `.gz` and leave a dangling `b`. `.tar`/`.zip` are containers
+# here, never content extensions (#245).
 WRAPPER_SUFFIXES: tuple[str, ...] = (".bgz", ".bz2", ".zip", ".tar", ".gz", ".xz")
 
 # Known core extension -> canonical file Format (#243). Keyed on the clean core
@@ -138,27 +120,23 @@ EXTENSION_TO_FORMAT: dict[str, Format] = {
 }
 
 # Extension -> file-type category. Hoisted in-code from unified_rules.yaml (#252)
-# — the last YAML-loaded parse vocabulary. Still carries the compound spellings
-# (.vcf.gz, ...) that #249 deferred pruning to #245 (they back file_name_for_rules'
-# fallback). The parse consumes only its *keys* (via CORE_EXTENSIONS); the
-# category values feed get_file_type and the when.file_format validation (#114).
+# — the last YAML-loaded parse vocabulary. Keyed only on *clean cores* (#245): the
+# compression/archive spellings (.vcf.gz, .fast5.tar.gz, ...) were pruned once the
+# parse peels every wrapper before recognizing the core, so the compound keys were
+# unreferenced. Archive containers (.tar, .tar.gz, .zip) are not cores — they carry
+# no content format of their own (#245). The parse consumes only these *keys* (via
+# CORE_EXTENSIONS); the category values feed get_file_type and the when.file_format
+# validation (#114).
 EXTENSION_MAP: dict[str, str] = {
     ".bam": "alignment",
     ".cram": "alignment",
     ".sam": "alignment",
-    ".sam.gz": "alignment",
     ".vcf": "variant",
-    ".vcf.gz": "variant",
     ".bcf": "variant",
     ".gvcf": "variant",
-    ".gvcf.gz": "variant",
-    ".g.vcf.gz": "variant",
     ".fastq": "reads",
     ".fq": "reads",
-    ".fastq.gz": "reads",
-    ".fq.gz": "reads",
     ".bed": "intervals",
-    ".bed.gz": "intervals",
     ".narrowpeak": "intervals",
     ".broadpeak": "intervals",
     ".bigwig": "signal",
@@ -178,12 +156,9 @@ EXTENSION_MAP: dict[str, str] = {
     ".h5ad": "single_cell_matrix",
     ".loom": "single_cell_matrix",
     ".mtx": "single_cell_matrix",
-    ".mtx.gz": "single_cell_matrix",
     ".idat": "methylation_array",
     ".fast5": "nanopore",
     ".pod5": "nanopore",
-    ".fast5.tar": "nanopore",
-    ".fast5.tar.gz": "nanopore",
     ".svs": "histology_image",
     ".tiff": "image",
     ".tif": "image",
@@ -191,19 +166,12 @@ EXTENSION_MAP: dict[str, str] = {
     ".jpg": "image",
     ".fasta": "sequence",
     ".fa": "sequence",
-    ".fasta.gz": "sequence",
-    ".fa.gz": "sequence",
     ".gfa": "pangenome",
-    ".gfa.gz": "pangenome",
     ".rgfa": "pangenome",
-    ".rgfa.gz": "pangenome",
     ".gbz": "pangenome",
     ".vg": "pangenome",
     ".gbwt": "pangenome",
     ".xg": "pangenome",
-    ".tar": "archive",
-    ".tar.gz": "archive",
-    ".zip": "archive",
     ".sf": "quantification",
     ".txt": "text_ambiguous",
     ".tsv": "text_ambiguous",
@@ -212,26 +180,20 @@ EXTENSION_MAP: dict[str, str] = {
 }
 
 
-def _peel_wrappers(token: str, *, keep_last: bool) -> tuple[str, tuple[str, ...]]:
-    """Peel trailing compression/archive ``WRAPPER_SUFFIXES`` off ``token``.
+def _peel_wrappers(token: str) -> tuple[str, tuple[str, ...]]:
+    """Peel *every* trailing container/compression ``WRAPPER_SUFFIXES`` off ``token``.
 
-    Peels longest-first and returns ``(remainder, wrappers)`` with the wrappers
-    in name order. ``keep_last`` chooses between the two uses:
-
-    - ``keep_last=True`` splits a *recognized* extension token into its core and
-      wrappers, stopping before the last remaining token so an archive extension
-      keeps its own suffix: ``.vcf.gz`` -> (``.vcf``, ``(".gz",)``);
-      ``.fast5.tar.gz`` -> (``.fast5``, ``(".tar", ".gz")``); ``.tar.gz`` ->
-      (``.tar``, ``(".gz",)``); ``.tar`` -> (``.tar``, ``()``).
-    - ``keep_last=False`` peels *every* trailing wrapper off an unrecognized
-      name, where no core is claimed and the remainder is only used to trim the
-      stem: ``notes.txt.gz`` -> (``notes.txt``, ``(".gz",)``).
+    Peels longest-first and returns ``(remainder, wrappers)`` with the wrappers in
+    name order: ``notes.txt.gz`` -> (``notes.txt``, ``(".gz",)``); ``run.fast5.tar.gz``
+    -> (``run.fast5``, ``(".tar", ".gz")``); ``graph.tar.gz`` -> (``graph``, ``(".tar",
+    ".gz")``). Containers are always stripped — the caller then recognizes whatever
+    core the remainder ends with (#245).
     """
     rest = token
     wrappers: list[str] = []
     while True:
         for suffix in WRAPPER_SUFFIXES:
-            if rest.endswith(suffix) and not (keep_last and rest == suffix):
+            if rest.endswith(suffix):
                 wrappers.append(suffix)
                 rest = rest[: -len(suffix)]
                 break
@@ -242,16 +204,13 @@ def _peel_wrappers(token: str, *, keep_last: bool) -> tuple[str, tuple[str, ...]
 
 
 # The explicit set of producible core extensions (#249). The single source of
-# truth for which clean core suffixes the parse can yield. Derived from every
-# in-code source of core truth, so it cannot drift: every compound extension
-# wrapper-stripped (which is where the multi-dot core ``.g.vcf`` comes from —
-# ``_peel_wrappers(".g.vcf.gz")``), the single-dot ``EXTENSION_MAP`` keys, and the
-# ``EXTENSION_TO_FORMAT`` keys (a format-mapped extension is a producible core by
-# definition). Lower-cased, since recognition matches a lower-cased name.
+# truth for which clean core suffixes the parse can yield, once every container
+# wrapper is peeled (#245). Derived from the single-dot ``EXTENSION_MAP`` keys and
+# the ``EXTENSION_TO_FORMAT`` keys (a format-mapped extension is a producible core
+# by definition — and the only multi-dot core, ``.g.vcf``, lives there). Lower-cased,
+# since recognition matches a lower-cased name.
 CORE_EXTENSIONS: frozenset[str] = frozenset(
-    {_peel_wrappers(c, keep_last=True)[0] for c in COMPOUND_EXTENSIONS}
-    | {k.lower() for k in EXTENSION_MAP if k.count(".") == 1}
-    | {k.lower() for k in EXTENSION_TO_FORMAT}
+    {k.lower() for k in EXTENSION_MAP if k.count(".") == 1} | {k.lower() for k in EXTENSION_TO_FORMAT}
 )
 
 # The cores with more than one dot (e.g. ``.g.vcf``), longest-first — the only
@@ -261,29 +220,6 @@ CORE_EXTENSIONS: frozenset[str] = frozenset(
 _MULTI_DOT_CORES: tuple[str, ...] = tuple(
     sorted((c for c in CORE_EXTENSIONS if c.count(".") > 1), key=len, reverse=True)
 )
-
-
-def extract_extension(filename: str) -> str:
-    """Extract the file extension, handling compound extensions.
-
-    The legacy compound-or-junk extractor (returns the whole compound ``.vcf.gz``,
-    or the junk last-dot suffix for an unknown name). No longer on the classify
-    path — ``file_name_for_rules`` reconstructs the compound from the parsed
-    ``FileName`` (core + wrappers) since #246, and rule matching uses
-    :meth:`FileName.parse` directly. Retained as the leaf raw-name extractor and
-    the behavior reference its tests pin; retired with #245.
-    """
-    filename_lower = filename.lower()
-
-    # Check compound extensions first (in priority order)
-    for ext in COMPOUND_EXTENSIONS:
-        if filename_lower.endswith(ext):
-            return ext
-
-    # Fall back to simple extension
-    if "." in filename:
-        return "." + filename.rsplit(".", 1)[-1].lower()
-    return ""
 
 
 def extension_to_format(extension: str | None) -> Format | None:
@@ -307,9 +243,9 @@ class FileName:
     contract (``^.+$``) diverts a nameless record to ``validation_failed`` before
     it is parsed — though ``FileName`` itself does not re-validate. ``extension``
     is the clean core suffix the rules key on (``.vcf``, not ``.vcf.gz``), or
-    ``None`` when the name carries no known extension — never the junk last-dot
-    suffix ``extract_extension`` returns (``"hprc-v1.0-mc-grch38"`` →
-    ``".0-mc-grch38"``). ``wrappers`` are the trailing compression/archive
+    ``None`` when the name carries no known extension — never a junk last-dot
+    suffix (``"hprc-v1.0-mc-grch38"`` has no extension, not ``".0-mc-grch38"``).
+    ``wrappers`` are the trailing compression/archive
     suffixes split off that core, in name order (#244: ``sample.vcf.gz`` →
     extension ``.vcf``, wrappers ``(".gz",)``). ``stem`` is the token-carrying
     part: the name with its whole recognized extension (core + wrappers) removed,
@@ -347,57 +283,38 @@ class FileName:
     def parse(cls, filename: str) -> "FileName":
         """Parse ``filename`` into a :class:`FileName` against the in-code vocabulary.
 
-        Pure — no ``UnifiedRules`` instance (#252). Recognition is a wrapper-bearing
-        ``COMPOUND_EXTENSIONS`` match, else the known core the name ends with — the
-        multi-dot cores scanned longest-first, then an O(1) lookup of the single-dot
-        last token (#249); an unknown suffix yields ``None`` here, where
-        ``extract_extension`` returns the junk last-dot suffix (which matched no rule
-        anyway). #244 made the *representation* a clean core ``extension`` (``.vcf``)
-        plus the ``wrappers`` it bundled (``(".gz",)``), not the whole compound
-        (``.vcf.gz``); #249 made the core set explicit, which also lets a multi-dot
-        core be recognized in its uncompressed spelling (``sample.g.vcf`` →
-        ``.g.vcf``, matching the compressed ``.g.vcf.gz`` form). ``format`` is the
-        stage-1 derivation from the core extension (``extension_to_format``), with
-        ``format_source`` recording the provenance — set together or both ``None``.
+        Pure — no ``UnifiedRules`` instance (#252). Recognition is "peel every
+        container, then recognize the core underneath" (#245): strip all trailing
+        ``WRAPPER_SUFFIXES`` (compression/archive), then match the remainder against
+        the known cores — multi-dot cores (``.g.vcf``) scanned longest-first so one
+        wins over its shorter tail (``.vcf``), then an O(1) lookup of the last
+        dot-token against ``CORE_EXTENSIONS``. An archive with no inner format
+        (``graph.tar.gz`` → the remainder ``graph`` has no known core) yields
+        ``extension=None`` with ``.tar``/``.gz`` recorded as wrappers, because a
+        container carries no content format of its own. ``format`` is the stage-1
+        derivation from the core (``extension_to_format``), with ``format_source``
+        recording the provenance — set together or both ``None``.
         """
-        lower = filename.lower()
+        # Peel every trailing container/compression wrapper first, then recognize
+        # the core the wrapper-stripped remainder ends with. Lengths are preserved
+        # by lowercasing, so `base`'s length indexes back into the original-case name.
+        base, wrappers = _peel_wrappers(filename.lower())
 
-        recognized = None
-        for ext in COMPOUND_EXTENSIONS:
-            if lower.endswith(ext):
-                recognized = ext
+        extension = None
+        for core in _MULTI_DOT_CORES:
+            if base.endswith(core):
+                extension = core
                 break
-        if recognized is None:
-            # No wrapper-bearing compound matched — recognize the known core the
-            # name ends with (#249). Multi-dot cores (".g.vcf") are scanned first,
-            # longest-first, so one wins over its shorter tail (".vcf"); the common
-            # single-dot case is then an O(1) lookup of the last dot-token. Every
-            # core's leading dot makes both a genuine extension-boundary match, so
-            # the single-dot path is equivalent to the old extension_map gate and
-            # only the multi-dot scan is new (an uncompressed ".g.vcf").
-            for core in _MULTI_DOT_CORES:
-                if lower.endswith(core):
-                    recognized = core
-                    break
-            else:
-                if "." in filename:
-                    simple = "." + filename.rsplit(".", 1)[-1].lower()
-                    if simple in CORE_EXTENSIONS:
-                        recognized = simple
-
-        if recognized is not None:
-            # Split the recognized token into its clean core and wrappers (#244).
-            # The stem drops the whole recognized token (core + wrappers), so it
-            # carries only the name's tokens — unchanged from before the split.
-            extension, wrappers = _peel_wrappers(recognized, keep_last=True)
-            stem = filename[: -len(recognized)]
         else:
-            # No known extension: peel every trailing wrapper as informational
-            # advice and strip them from the stem, but claim no core extension.
-            extension = None
-            _, wrappers = _peel_wrappers(lower, keep_last=False)
-            wrapper_len = sum(len(w) for w in wrappers)
-            stem = filename[:-wrapper_len] if wrapper_len else filename
+            if "." in base:
+                simple = "." + base.rsplit(".", 1)[-1]
+                if simple in CORE_EXTENSIONS:
+                    extension = simple
+
+        # The stem is the original-case name minus its wrappers (base) and minus the
+        # recognized core (``extension`` is always a suffix of ``base``), so it carries
+        # only the name's tokens.
+        stem = filename[: len(base) - len(extension or "")]
 
         fmt = extension_to_format(extension)
         format_source = FormatSource.EXTENSION if fmt is not None else None

--- a/src/meta_disco/file_name.py
+++ b/src/meta_disco/file_name.py
@@ -296,8 +296,9 @@ class FileName:
         recording the provenance — set together or both ``None``.
         """
         # Peel every trailing container/compression wrapper first, then recognize
-        # the core the wrapper-stripped remainder ends with. Lengths are preserved
-        # by lowercasing, so `base`'s length indexes back into the original-case name.
+        # the core the wrapper-stripped remainder ends with. Recognition runs against
+        # the lowercased name; the stem is sliced by ASCII suffix length below, so it
+        # does not rely on lowercasing preserving length (see the stem computation).
         base, wrappers = _peel_wrappers(filename.lower())
 
         extension = None

--- a/src/meta_disco/file_name.py
+++ b/src/meta_disco/file_name.py
@@ -311,10 +311,14 @@ class FileName:
                 if simple in CORE_EXTENSIONS:
                     extension = simple
 
-        # The stem is the original-case name minus its wrappers (base) and minus the
-        # recognized core (``extension`` is always a suffix of ``base``), so it carries
-        # only the name's tokens.
-        stem = filename[: len(base) - len(extension or "")]
+        # The stem is the original-case name minus its recognized suffix (wrappers +
+        # core), so it carries only the name's tokens. Slice by the ASCII suffix
+        # lengths off the *original* name rather than by ``len(base)``: ``str.lower()``
+        # is not guaranteed to preserve length for every Unicode char (e.g. ``"İ"``),
+        # but the wrappers and core are ASCII, so their lengths index the original
+        # name correctly regardless.
+        suffix_len = sum(len(w) for w in wrappers) + len(extension or "")
+        stem = filename[: len(filename) - suffix_len]
 
         fmt = extension_to_format(extension)
         format_source = FormatSource.EXTENSION if fmt is not None else None

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -401,7 +401,10 @@ def classify_without_content(
     ``name`` and the declared ``file_format`` are handed to the engine, which
     reconciles them (name-extension wins, else ``file_format``); an archive name
     with no inner format (``x.tar.gz`` → ``extension=None``) falls through to
-    ``file_format`` or, failing that, stays unclassified — we do not classify a
+    ``file_format``. With neither, no *extension-scoped* rule fires, so the
+    container yields no content type of its own — though a filename/dataset rule
+    that carries no ``extensions:`` filter (e.g. a reference token in the name)
+    may still classify a field. We do not fabricate a content type for a
     container we could not read (#245).
 
     ``content_fields`` names the dimensions *this file type's content* can

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -30,15 +30,8 @@ if TYPE_CHECKING:
 
 # Text GFA formats this module can parse. The other graph extensions the
 # `pangenome` rules cover (.gbz, .vg, .gbwt, .xg) are binary vg/GBWT formats.
-# GFA_CONFIG.extensions is this same tuple — defined here so the classifier and
-# the config cannot disagree about which names it may trust.
+# GFA_CONFIG.extensions is this same tuple — the file-type routing filter.
 GRAPH_TEXT_EXTENSIONS = (".gfa", ".gfa.gz", ".rgfa", ".rgfa.gz")
-
-# Parsed-once graph fallback name for ``file_name_for_rules`` — a module constant so
-# the literal is not re-parsed on every graph classification call (a last resort when
-# the name is empty and no file_format is grafted). The empty-name fallback uses the
-# shared :data:`FileName.EMPTY`.
-_DEFAULT_GRAPH_NAME = FileName.parse("graph.gfa")
 
 
 @dataclass(frozen=True)
@@ -389,63 +382,12 @@ _ASSEMBLER_PATTERN = re.compile(
 _TRANSCRIPT_PATTERN = re.compile(r"^(ENST\d|NM_\d|NR_\d|XM_\d|rna-)", re.IGNORECASE)
 
 
-def file_name_for_rules(
-    name: FileName,
-    file_format: str | None,
-    default: FileName,
-    allowed_extensions: tuple[str, ...] | None = None,
-) -> FileName:
-    """The :class:`FileName` to hand the rule engine, which reads its extension.
-
-    ``ClassifyPipeline._filter_records`` selects a record when *either* its
-    ``file_name`` or its ``file_format`` carries a matching extension, so a
-    selected record's parsed ``name`` may carry no known extension.
-
-    So: keep the parsed ``name`` when it already carries a *usable* extension,
-    otherwise graft ``file_format`` onto its raw string and re-parse — preserving
-    the filename tokens the tier-2 rules match (``-mc-``, ``grch38``). "Usable" is
-    tested against the *compound* spelling (core + wrappers, e.g. ``.gfa.gz``), the
-    same value the old ``extract_extension`` returned, rather than "ends with
-    file_format": 5,227 corpus records are named ``*.fastq.gz`` while declaring
-    ``file_format: ".fastq"``, and grafting there would produce ``*.fastq.gz.fastq``.
-
-    ``allowed_extensions`` narrows "usable" to the extensions the caller can
-    actually handle. Without it, a graph record named ``graph.tar.gz`` would be
-    trusted verbatim: the tar rules run, ``pangenome_graph`` never fires, and a
-    content-derived ``data_type`` claim then lands on a record whose
-    ``data_modality`` is not_classified. Pass the calling config's extensions.
-
-    ``file_format`` is only grafted on when it looks like an extension. The
-    corpus carries ``file_format: "Other"`` on ~108k records; grafting that
-    would yield ``graphOther``, which matches nothing.
-
-    The threaded ``name`` is *reused* on the usable path — no re-parse — so the raw
-    file_name is parsed exactly once (at the load boundary, #242); only the graft
-    path parses a *different* string (the file_format-extended name). This helper is
-    the sole remaining reader of the compound ``extension_map`` keys and is retired
-    in #245, which pushes the allowed-extension override into the engine.
-    """
-    rules = _get_engine().rules
-    if name.extension is not None:
-        # Reconstruct the compound extension (core + wrappers) the old
-        # ``extract_extension`` returned, and test it exactly as before — against the
-        # caller's allowed set, or the (still compound-keyed) extension_map.
-        compound = name.extension + "".join(name.wrappers)
-        usable = compound in allowed_extensions if allowed_extensions else compound in rules.extension_map
-        if usable:
-            return name
-    if file_format and file_format.startswith("."):
-        return FileName.parse(f"{name.raw or 'file'}{file_format}")
-    return name if name.raw else default
-
-
 def classify_without_content(
     reason: str,
     *,
     name: FileName = FileName.EMPTY,
     file_size: int | None = None,
     file_format: str | None = None,
-    allowed_extensions: tuple[str, ...] | None = None,
     content_fields: tuple[str, ...] = (),
 ) -> dict:
     """Classify a file whose content could not be read, from its name alone.
@@ -455,7 +397,12 @@ def classify_without_content(
 
     Runs the tier-1/2 (extension and filename) rules only, so everything knowable
     without reading bytes is still classified: a `.gfa` is still `pangenome`,
-    still `genomic`, still `not_applicable` for platform and assay.
+    still `genomic`, still `not_applicable` for platform and assay. The parsed
+    ``name`` and the declared ``file_format`` are handed to the engine, which
+    reconciles them (name-extension wins, else ``file_format``); an archive name
+    with no inner format (``x.tar.gz`` → ``extension=None``) falls through to
+    ``file_format`` or, failing that, stays unclassified — we do not classify a
+    container we could not read (#245).
 
     ``content_fields`` names the dimensions *this file type's content* can
     determine (``FileTypeConfig.content_fields``). Only those carry the
@@ -474,9 +421,9 @@ def classify_without_content(
     """
     from .rule_engine import ExtendedFileInfo
 
-    rule_name = file_name_for_rules(name, file_format, default=FileName.EMPTY, allowed_extensions=allowed_extensions)
     file_info = ExtendedFileInfo(
-        name=rule_name,
+        name=name,
+        file_format=file_format,
         file_size=file_size,
     )
     result = _get_engine().classify_extended(file_info, include_tier3=False)
@@ -520,9 +467,10 @@ def classify_from_gfa_segment_tags(
     Args:
         segment_tags: Per-segment :class:`SegmentTag`s from fetchers.parse_gfa_segment_tags
         name: Optional parsed :class:`FileName` for extension/filename rules
-        file_format: Optional extension (e.g. ".rgfa.gz"), used to drive the
-            extension rules when the name carries no known extension
-            (see file_name_for_rules)
+        file_format: Optional declared extension (e.g. ".rgfa.gz"); the engine uses it
+            as the fallback when the name carries no known extension. A non-extension
+            value ("Other") or absent one falls back to ".gfa" — this is the graph
+            classifier, so an unrecognizable graph is still a plain ``pangenome``.
         file_size: Unused. Accepted because ``pipeline._fetch_and_classify`` calls
             every classifier with the same keyword arguments; no graph rule keys
             on file size. ``classify_from_fasta_header`` accepts it unused too.
@@ -532,16 +480,19 @@ def classify_from_gfa_segment_tags(
     """
     from .rule_engine import CONTENT_TIER, ExtendedFileInfo
 
-    rule_name = file_name_for_rules(
-        name,
-        file_format,
-        default=_DEFAULT_GRAPH_NAME,
-        allowed_extensions=GRAPH_TEXT_EXTENSIONS,
-    )
+    # Hand the engine the parsed name plus a graph file_format fallback: it trusts a
+    # known name-extension (``.gfa``/``.rgfa``), else this ``file_format``. A tar-named
+    # graph (``graph.tar.gz`` → extension=None, #245) falls through to ``.gfa.gz``. A
+    # file_format that is not a recognized extension — ``"Other"`` or a bare container
+    # like ``".tar"`` — defaults to ``.gfa`` so a graph we were routed to is still
+    # classified as one. "Recognized" is tested through the shared vocabulary
+    # (``FileName.parse``), not a bare ``startswith(".")``. No allowed-extension
+    # override is needed now that ``.tar`` is a container, not a content extension.
+    format_fallback = file_format if (file_format and FileName.parse(file_format).extension is not None) else ".gfa"
 
     # Tier 1/2 rules give the `pangenome` base, the `-mc-` reference refinement,
     # and reference_assembly from the filename.
-    file_info = ExtendedFileInfo(name=rule_name)
+    file_info = ExtendedFileInfo(name=name, file_format=format_fallback)
     engine = _get_engine()
     result = engine.classify_extended(file_info, include_tier3=False)
 

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -485,7 +485,8 @@ def classify_from_gfa_segment_tags(
 
     # Hand the engine the parsed name plus a graph file_format fallback: it trusts a
     # known name-extension (``.gfa``/``.rgfa``), else this ``file_format``. A tar-named
-    # graph (``graph.tar.gz`` → extension=None, #245) falls through to ``.gfa.gz``. A
+    # graph (``graph.tar.gz`` → extension=None, #245) falls through to ``.gfa.gz``,
+    # which the engine normalizes to its clean ``.gfa`` core. A
     # file_format that is not a recognized extension — ``"Other"`` or a bare container
     # like ``".tar"`` — defaults to ``.gfa`` so a graph we were routed to is still
     # classified as one. "Recognized" is tested through the shared vocabulary

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -141,7 +141,6 @@ def _fetch_and_classify(
             name=name,
             file_size=file_size,
             file_format=file_format,
-            allowed_extensions=config.extensions,
             content_fields=config.content_fields,
         ), True
 

--- a/src/meta_disco/rule_loader.py
+++ b/src/meta_disco/rule_loader.py
@@ -98,9 +98,7 @@ class UnifiedRules:
 
     # The extension vocabulary and the parse now live in file_name.py as a pure,
     # instance-free leaf (#252). These are thin delegators so existing callers
-    # (rule_engine, header_classifier, scripts, tests) are unchanged; they retire
-    # as #246/#245 migrate their sites to the file_name API.
-    COMPOUND_EXTENSIONS: ClassVar[tuple[str, ...]] = file_name.COMPOUND_EXTENSIONS
+    # (rule_engine, header_classifier, scripts, tests) are unchanged.
     WRAPPER_SUFFIXES: ClassVar[tuple[str, ...]] = file_name.WRAPPER_SUFFIXES
     EXTENSION_TO_FORMAT: ClassVar[dict[str, Format]] = file_name.EXTENSION_TO_FORMAT
 
@@ -140,15 +138,6 @@ class UnifiedRules:
     def extension_to_format(self, extension: str | None) -> Format | None:
         """Delegate to the pure ``file_name.extension_to_format`` (#252)."""
         return file_name.extension_to_format(extension)
-
-    def extract_extension(self, filename: str) -> str:
-        """Delegate to the pure ``file_name.extract_extension`` (#252)."""
-        return file_name.extract_extension(filename)
-
-    @staticmethod
-    def _peel_wrappers(token: str, *, keep_last: bool) -> tuple[str, tuple[str, ...]]:
-        """Delegate to the pure ``file_name._peel_wrappers`` (#252)."""
-        return file_name._peel_wrappers(token, keep_last=keep_last)
 
     def parse_file_name(self, filename: str) -> "FileName":
         """Delegate to the pure ``FileName.parse`` (#252)."""

--- a/src/meta_disco/rules/unified_rules.yaml
+++ b/src/meta_disco/rules/unified_rules.yaml
@@ -79,14 +79,14 @@
 # ---------------------------
 # Extension/filename conditions:
 # - extensions: list of clean core file extensions to match (e.g., [".bam",
-#     ".cram"]). Compression/archive is split off into wrappers at parse time
-#     (#244), so a core matches every compressed spelling the parser recognizes
-#     — those enumerated in COMPOUND_EXTENSIONS (meta_disco.file_name): ".vcf" matches
-#     both sample.vcf and sample.vcf.gz (never list ".vcf.gz" here), but an
-#     unlisted spelling like sample.bam.gz is not recognized and matches nothing.
-#     gVCF keeps its
-#     own core (".g.vcf"): both classify as data_type variants, but ".g.vcf"
-#     derives Format.GVCF (vs Format.VCF), so the distinction is not lost.
+#     ".cram"]). The parser peels every compression/archive container (.gz, .tar,
+#     .zip, ...) off the name first, then recognizes the core underneath (#245), so
+#     a core matches every compressed spelling: ".vcf" matches sample.vcf,
+#     sample.vcf.gz, and sample.vcf.bgz alike (never list ".vcf.gz" here). An
+#     archive container with no inner format (graph.tar.gz) has no core and matches
+#     nothing — a container is not a content type. gVCF keeps its own core
+#     (".g.vcf"): both classify as data_type variants, but ".g.vcf" derives
+#     Format.GVCF (vs Format.VCF), so the distinction is not lost.
 # - format: canonical file format to match (e.g., FASTA) — collapses the
 #     spelling/compression variants of one format (.fa/.fasta/.fa.gz/.fasta.gz)
 #     to a single identity, so key on this instead of re-listing extensions
@@ -886,21 +886,6 @@ rules:
       data_type: quantification
       assay_type: RNA-seq
     rationale: "Salmon/Sailfish transcript-level quantification (quant.sf)"
-
-  # ---------------------------------------------------------------------------
-  # Archive files - T2T specific
-  # ---------------------------------------------------------------------------
-  - id: archive_t2t_genomic
-    tier: 2
-    scope: filename
-    when:
-      extensions: [".tar"]
-      filename_pattern: "^chr[0-9XY]+\\.[0-9]+_[0-9]+\\.tar$"
-      dataset_pattern: "(?i)t2t"
-    then:
-      data_modality: genomic
-      data_type: archive
-    rationale: "T2T project genomic region archive"
 
   # ===========================================================================
   # TIER 2.5: FILE SIZE HEURISTICS

--- a/src/meta_disco/schema/classification.yaml
+++ b/src/meta_disco/schema/classification.yaml
@@ -302,7 +302,6 @@ enums:
       statistics:
       log:
       interval_set:
-      archive:
 
   reference_assembly_enum:
     permissible_values:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -25,7 +25,7 @@ from classify_vcf_files import classify_single_vcf as classify_vcf
 from meta_disco.evidence import SegmentTag
 from meta_disco.fetchers import parse_gfa_segment_tags
 from meta_disco.file_name import FileName
-from meta_disco.header_classifier import classify_from_gfa_segment_tags, file_name_for_rules
+from meta_disco.header_classifier import classify_from_gfa_segment_tags
 from meta_disco.models import (
     NOT_APPLICABLE,
     NOT_CLASSIFIED,
@@ -571,10 +571,10 @@ class TestRgfaContentClassification:
         assert get_val(record, "reference_assembly") == "GRCh38"
 
     def test_extensionless_file_name_keeps_its_tokens_and_gains_the_extension(self):
-        """A selected record's file_name may carry no extension. Appending
-        file_format keeps the `-mc-`/`grch38` tokens the tier-2 rules match;
-        using file_format alone would discard them, and using the bare name would
-        make extract_extension return the junk suffix '.0-mc-grch38'."""
+        """A selected record's file_name may carry no extension. The name's raw
+        tokens (`-mc-`/`grch38`) still reach the tier-2 filename rules, while the
+        engine falls back to the declared `file_format` (.gfa.gz) for the extension —
+        so the graph is classified and the reference is read from the name."""
         record = classify_from_gfa_segment_tags([], name=FileName.parse("hprc-v1.0-mc-grch38"), file_format=".gfa.gz")
         assert get_val(record, "data_type") == "pangenome.reference"
         assert get_val(record, "reference_assembly") == "GRCh38"
@@ -585,83 +585,15 @@ class TestRgfaContentClassification:
         assert get_val(record, "data_modality") == "genomic"
 
 
-class TestFilenameForRules:
-    """The rule engine reads the extension from the filename, so a selected record
-    whose file_name lacks one must have file_format grafted on — without corrupting
-    a name that already has a valid extension.
-
-    ``file_name_for_rules`` takes a parsed :class:`FileName` (#242) and returns one;
-    ``_rule_name`` wraps the parse/unwrap so the assertions stay in raw-string terms.
-    A ``None`` file_name models a header-only call with no name at all."""
-
-    @staticmethod
-    def _rule_name(file_name, file_format, default, allowed_extensions=None):
-        # A None file_name models a header-only call with no name — FileName.EMPTY.
-        name = FileName.parse(file_name) if file_name is not None else FileName.EMPTY
-        return file_name_for_rules(
-            name, file_format, FileName.parse(default), allowed_extensions=allowed_extensions
-        ).raw
-
-    def test_known_extension_is_kept_verbatim(self):
-        assert self._rule_name("graph.gfa", ".gfa", "x") == "graph.gfa"
-
-    def test_mismatched_but_valid_extension_is_not_appended_to(self):
-        """5,227 corpus records are named *.fastq.gz while declaring file_format
-        '.fastq'. Appending would yield '*.fastq.gz.fastq'."""
-        assert self._rule_name("IGVFFI0052MDWT.fastq.gz", ".fastq", "x") == "IGVFFI0052MDWT.fastq.gz"
-
-    def test_unknown_extension_gets_file_format_appended(self):
-        assert self._rule_name("hprc-v1.0-mc-grch38", ".gfa.gz", "x") == "hprc-v1.0-mc-grch38.gfa.gz"
-
-    def test_extensionless_name_gets_file_format_appended(self):
-        assert self._rule_name("graph", ".gfa", "x") == "graph.gfa"
-
-    def test_no_name_uses_file_format(self):
-        assert self._rule_name("", ".rgfa.gz", "x") == "file.rgfa.gz"
-
-    def test_no_name_and_no_format_uses_the_default(self):
-        assert self._rule_name("", "", "graph.gfa") == "graph.gfa"
-        assert self._rule_name(None, None, "graph.gfa") == "graph.gfa"
-
-    def test_non_dotted_file_format_is_not_grafted_on(self):
-        """~108k corpus records carry file_format 'Other'; 'graphOther' matches nothing.
-
-        The name is returned as-is rather than fabricated: nothing is knowable, and
-        claiming a `.gfa` we were never told about would be worse than not_classified.
-        """
-        assert self._rule_name("graph", "Other", "graph.gfa") == "graph"
-        assert self._rule_name("", "Other", "graph.gfa") == "graph.gfa"
-
-    def test_known_but_disallowed_extension_is_not_trusted(self):
-        """A graph record named *.tar.gz must not be classified off the tar rules
-        just because .tar.gz is a known extension somewhere in the map."""
-        assert (
-            self._rule_name(
-                "hprc-graph.tar.gz",
-                ".gfa.gz",
-                "graph.gfa",
-                allowed_extensions=(".gfa", ".gfa.gz", ".rgfa", ".rgfa.gz"),
-            )
-            == "hprc-graph.tar.gz.gfa.gz"
-        )
-
-    def test_allowed_extension_is_trusted_verbatim(self):
-        assert (
-            self._rule_name(
-                "hprc-v1.0-mc-grch38.gfa.gz",
-                ".gfa",
-                "graph.gfa",
-                allowed_extensions=(".gfa", ".gfa.gz"),
-            )
-            == "hprc-v1.0-mc-grch38.gfa.gz"
-        )
-
-
 class TestGfaContentClaimCoherence:
     def test_tar_named_graph_record_is_coherent(self):
-        """Previously: the .tar.gz name was trusted, pangenome_graph never fired, and
-        the rGFA claim forced data_type=pangenome.reference on a record whose
-        data_modality was not_classified."""
+        """A ``.tar.gz``-named graph must still classify as a graph, not as an archive.
+
+        Since #245 ``graph.tar.gz`` parses to ``extension=None`` (``.tar``/``.gz`` are
+        containers), so the engine falls back to the declared ``.gfa.gz`` file_format
+        — ``pangenome_graph`` fires and the rGFA rank-0 claim coherently refines it to
+        ``pangenome.reference`` on a ``genomic`` record. (Previously ``.tar`` was a
+        core extension a bespoke filename override had to reject.)"""
         record = classify_from_gfa_segment_tags(
             [SegmentTag(sn="chr1", sr="0")],
             name=FileName.parse("hprc-graph.tar.gz"),

--- a/tests/test_file_name.py
+++ b/tests/test_file_name.py
@@ -51,12 +51,13 @@ class TestExtension:
         assert fn.wrappers == (".gz",)
         assert fn.stem == "sample"
 
-    def test_archive_extension_keeps_tar_as_core(self):
-        """A gzipped tarball: ``.tar`` is the core extension (an archive is a real
-        file type), ``.gz`` the wrapper — the last token is never peeled away."""
+    def test_archive_container_has_no_core(self):
+        """#245: an archive with no inner format is a container, not a content
+        extension — ``.tar`` and ``.gz`` both peel as wrappers and the extension is
+        honestly None (a tar of unknown files is not classifiable from its name)."""
         fn = parse("hprc-graph.tar.gz")
-        assert fn.extension == ".tar"
-        assert fn.wrappers == (".gz",)
+        assert fn.extension is None
+        assert fn.wrappers == (".tar", ".gz")
         assert fn.stem == "hprc-graph"
 
     def test_gvcf_keeps_its_own_core(self):
@@ -78,23 +79,22 @@ class TestExtension:
         assert fn.wrappers == ()
         assert fn.stem == "HG002.deepvariant"
 
-    def test_double_wrapper_peels_both(self):
-        """``.fast5.tar.gz`` is tar-archived and gzip-compressed around a
-        ``.fast5`` core — both wrappers peel, in name order."""
+    def test_double_wrapper_peels_both_to_inner_core(self):
+        """``run.fast5.tar.gz`` is tar-archived and gzip-compressed around a
+        ``.fast5`` core — both containers peel and the inner ``.fast5`` is
+        recognized underneath (#245), with no per-combination allowlist entry."""
         fn = parse("run.fast5.tar.gz")
         assert fn.extension == ".fast5"
         assert fn.wrappers == (".tar", ".gz")
         assert fn.stem == "run"
 
     def test_extensionless_name_is_none_not_junk(self):
-        """The bug this fixes: extract_extension returns a junk last-dot suffix
-        ('.0-mc-grch38'); the parsed extension is honestly None."""
+        """A name whose last dot-token is not a known core yields extension None,
+        not a junk last-dot suffix (``.0-mc-grch38``)."""
         fn = parse("hprc-v1.0-mc-grch38")
         assert fn.extension is None
         assert fn.wrappers == ()
         assert fn.stem == "hprc-v1.0-mc-grch38"
-        # And the old parser did return the junk suffix — this is the contrast.
-        assert RULES.extract_extension("hprc-v1.0-mc-grch38") == ".0-mc-grch38"
 
     def test_unknown_simple_extension_is_none(self):
         fn = parse("readme.xyz")
@@ -102,36 +102,32 @@ class TestExtension:
         assert fn.stem == "readme.xyz"
 
 
-class TestBehaviorPreservation:
-    """For every name with a *known* extension, the core extension plus its
-    wrappers reconstruct exactly what the engine derived before (the compound
-    ``extract_extension``) — so #244 changes the *representation*, not *which*
-    names carry an extension. Rule routing is preserved: the core now stands in
-    for the old compound (the rule ``extensions:`` lists were migrated in step)."""
+class TestContainersArePeeled:
+    """#245: every compression/archive container is peeled off the name before the
+    core is recognized, so a core matches under any container spelling (``.vcf`` for
+    ``sample.vcf.gz``) and an archive with no inner format has no core."""
 
     @pytest.mark.parametrize(
-        "name",
+        ("name", "extension", "wrappers"),
         [
-            "sample.bam",
-            "HG00741.final.cram",
-            "cohort.vcf.gz",
-            "cohort.g.vcf.gz",
-            "reads.fastq.gz",
-            "reads.fq.gz",
-            "genome.fasta",
-            "genome.fa.gz",
-            "regions.bed.gz",
-            "graph.gfa.gz",
-            "graph.rgfa",
-            "NUFIP1_quant.sf",
-            "archive.tar.gz",
-            "run.fast5.tar.gz",
+            ("sample.bam", ".bam", ()),
+            ("cohort.vcf.gz", ".vcf", (".gz",)),
+            ("cohort.g.vcf.gz", ".g.vcf", (".gz",)),
+            ("reads.fastq.gz", ".fastq", (".gz",)),
+            ("genome.fa.gz", ".fa", (".gz",)),
+            ("regions.bed.gz", ".bed", (".gz",)),
+            ("graph.gfa.gz", ".gfa", (".gz",)),
+            ("run.fast5.tar.gz", ".fast5", (".tar", ".gz")),
+            # Containers with no inner format → no core, containers as wrappers.
+            ("archive.tar.gz", None, (".tar", ".gz")),
+            ("bundle.zip", None, (".zip",)),
+            ("chr1.0_248956422.tar", None, (".tar",)),
         ],
     )
-    def test_core_plus_wrappers_reconstructs_old_compound(self, name):
+    def test_container_peeled_then_core_recognized(self, name, extension, wrappers):
         fn = parse(name)
-        assert fn.extension is not None
-        assert fn.extension + "".join(fn.wrappers) == RULES.extract_extension(name)
+        assert fn.extension == extension
+        assert fn.wrappers == wrappers
 
 
 class TestFormat:
@@ -175,16 +171,24 @@ class TestWrappers:
         assert parse("sample.bam").wrappers == ()
 
     def test_bare_compression_without_format(self):
-        """No known core extension (.txt isn't in the vocabulary), so extension is
+        """No known core extension (.xyz isn't in the vocabulary), so extension is
         None; the .gz is captured as a wrapper and stripped from the stem."""
-        fn = parse("notes.txt.gz")
+        fn = parse("blob.xyz.gz")
         assert fn.extension is None
         assert fn.wrappers == (".gz",)
-        assert fn.stem == "notes.txt"
+        assert fn.stem == "blob.xyz"
 
     def test_bgz_is_not_mis_peeled_as_gz(self):
         """`.bgz` ends with `.gz`; the wrapper list is ordered longest-first so
         `.bgz` is captured whole, not mis-peeled as `.gz` leaving a dangling `b`."""
-        fn = parse("notes.txt.bgz")
+        fn = parse("blob.xyz.bgz")
         assert fn.wrappers == (".bgz",)
-        assert fn.stem == "notes.txt"
+        assert fn.stem == "blob.xyz"
+
+    def test_compressed_core_is_recognized_under_the_wrapper(self):
+        """#245: peel-first recognizes a known core beneath any container spelling —
+        a gzipped ``.tsv`` is a ``.tsv``, not an unrecognized blob."""
+        fn = parse("expression.tsv.gz")
+        assert fn.extension == ".tsv"
+        assert fn.wrappers == (".gz",)
+        assert fn.stem == "expression"

--- a/tests/test_file_name.py
+++ b/tests/test_file_name.py
@@ -101,6 +101,14 @@ class TestExtension:
         assert fn.extension is None
         assert fn.stem == "readme.xyz"
 
+    def test_length_changing_lowercase_char_does_not_skew_the_stem(self):
+        """`"İ".lower()` is two chars, so slicing the stem by the lowercased length
+        would over-keep. The suffix (wrappers + core) is ASCII, so the stem is sliced
+        off the original name by suffix length and stays correct."""
+        fn = parse("İ.bam")
+        assert fn.extension == ".bam"
+        assert fn.stem == "İ"
+
 
 class TestContainersArePeeled:
     """#245: every compression/archive container is peeled off the name before the

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -27,32 +27,6 @@ def engine():
     return RuleEngine()
 
 
-class TestExtensionExtraction:
-    """Test extension extraction logic."""
-
-    def test_simple_bam(self, engine):
-        assert engine.rules.extract_extension("sample.bam") == ".bam"
-
-    def test_compound_vcf_gz(self, engine):
-        assert engine.rules.extract_extension("file.vcf.gz") == ".vcf.gz"
-
-    def test_compound_fastq_gz(self, engine):
-        assert engine.rules.extract_extension("sample.fastq.gz") == ".fastq.gz"
-
-    def test_cram_with_dots(self, engine):
-        assert engine.rules.extract_extension("sample.hg38.cram") == ".cram"
-
-    def test_case_insensitive(self, engine):
-        assert engine.rules.extract_extension("SAMPLE.BAM") == ".bam"
-        assert engine.rules.extract_extension("File.VCF.GZ") == ".vcf.gz"
-
-    def test_no_extension(self, engine):
-        assert engine.rules.extract_extension("filename") == ""
-
-    def test_gvcf_gz(self, engine):
-        assert engine.rules.extract_extension("sample.g.vcf.gz") == ".g.vcf.gz"
-
-
 class TestRuleMatching:
     """Test rule matching logic."""
 
@@ -238,12 +212,11 @@ class TestFormatMatching:
 
 
 class TestWrapperSplitMatching:
-    """#244: rule `extensions:` are the clean core suffix; compression/archive is
-    split into wrappers at parse time. A core matches the uncompressed spelling
-    and every compressed spelling the parser recognizes (those in
-    COMPOUND_EXTENSIONS), so classification is unchanged by whether such a file is
-    gzipped — an unlisted spelling like ".bam.gz" is not recognized and matches
-    nothing."""
+    """#244/#245: rule `extensions:` are the clean core suffix; the parser peels
+    every compression/archive container off the name first, then recognizes the
+    core underneath. A core therefore matches the uncompressed spelling and every
+    compressed spelling alike (``.vcf`` matches ``sample.vcf`` and ``sample.vcf.gz``),
+    so classification is unchanged by whether such a file is gzipped."""
 
     @pytest.mark.parametrize("name", ["cohort.vcf.gz", "reads.fastq.gz", "reads.fq.gz"])
     def test_core_keyed_rule_matches_compressed_and_uncompressed(self, engine, name):

--- a/tests/test_rule_vocabulary.py
+++ b/tests/test_rule_vocabulary.py
@@ -137,24 +137,22 @@ def test_rule_when_format_values_valid():
 def test_core_extensions_derivation():
     """`core_extensions` is the explicit set of producible core extensions (#249).
 
-    Pins the derivation: every compound extension with its wrappers stripped (where
-    the multi-dot core `.g.vcf` comes from), unioned with the single-dot
-    `extension_map` keys and the `EXTENSION_TO_FORMAT` keys, all lower-cased, with
-    no compound left in.
+    Pins the derivation (#245: the parse peels every container first, so there is no
+    compound-extension allowlist): the single-dot `extension_map` keys unioned with
+    the `EXTENSION_TO_FORMAT` keys (where the one multi-dot core `.g.vcf` lives), all
+    lower-cased.
     """
     rules = get_unified_rules()
     core = rules.core_extensions
-    expected = {rules._peel_wrappers(c, keep_last=True)[0] for c in rules.COMPOUND_EXTENSIONS}
-    expected |= {k.lower() for k in rules.extension_map if k.count(".") == 1}
+    expected = {k.lower() for k in rules.extension_map if k.count(".") == 1}
     expected |= {k.lower() for k in rules.EXTENSION_TO_FORMAT}
     assert core == expected
     assert ".g.vcf" in core  # the multi-dot core
-    # No core may carry a compression/archive wrapper: a member that *ends with* a
-    # wrapper but is more than that wrapper (".vcf.gz", ".foo.bz2") is a compound
-    # that leaked in — e.g. from an unfiltered EXTENSION_TO_FORMAT key. ".tar"/".zip"
-    # are themselves archive cores (member == wrapper), so they are exempt.
-    leaked = sorted(c for c in core for w in rules.WRAPPER_SUFFIXES if c.endswith(w) and c != w)
-    assert not leaked, f"compound/wrapper-bearing extensions leaked into the core set: {leaked}"
+    # No core may carry — or be — a compression/archive container: nothing in the core
+    # set may end with a wrapper suffix. A compound (".vcf.gz") or a bare container
+    # (".tar"/".zip", removed as cores in #245) that appears here is a leak.
+    leaked = sorted(c for c in core for w in rules.WRAPPER_SUFFIXES if c.endswith(w))
+    assert not leaked, f"container/wrapper-bearing extensions leaked into the core set: {leaked}"
 
 
 def test_every_format_mapped_extension_is_producible():


### PR DESCRIPTION
Closes #245. Completes the FileName epic #242.

## What changed

An archive (`.tar`/`.tar.gz`/`.zip`) is a **container of files that each have their own format**, not a content format itself. The parser now models that directly, and that root fix retires the last piece of the old machinery.

- **Peel-first parse** (`file_name.py`): `FileName.parse` strips every compression/archive `WRAPPER_SUFFIXES` off the name first, then recognizes the core underneath. Deleted the `COMPOUND_EXTENSIONS` allowlist (peel-first makes per-combination entries unnecessary — `.fast5.tar.gz` → `.fast5` falls out), simplified `_peel_wrappers` (dropped `keep_last`), re-derived `CORE_EXTENSIONS` from the single-dot `EXTENSION_MAP` keys + `EXTENSION_TO_FORMAT`.
- **`.tar`/`.tar.gz`/`.zip` are containers, not cores** — removed from `EXTENSION_MAP`, so an archive with no inner format (`graph.tar.gz`) parses to `extension=None`. Pruned the 14 dead compound `EXTENSION_MAP` keys.
- **Retired `file_name_for_rules`** + its `allowed_extensions` guard + fabricated synthetic filename (its only real job was rejecting a `.tar`-named graph — moot now that `.tar` is a container). The two fallback classifiers (`classify_without_content`, `classify_from_gfa_segment_tags`) hand the engine the parsed name + declared `file_format` and let #246's reconciliation resolve the extension. Also deleted the now-dead `extract_extension` and the `rule_loader` delegators.
- **Dropped `archive_t2t_genomic`** (and the `archive` `data_type`): it inferred `genomic`/`archive` from the name of an unopened tar.

## Why

The FileName epic's remaining wart was a bespoke helper that fabricated names and carried an `allowed_extensions` override to reconcile a misleading `.tar` extension against the declared `file_format`. The override only existed because `.tar` was miscategorized as a *content* extension. Modeling `.tar`/`.zip` as containers (which they are) makes the override unnecessary — the helper, the allowlist, and the legacy extractor all evaporate, and the parse gets a cleaner, more general model in the bargain.

## Assumptions I made

- **`.tar`/`.tar.gz`/`.zip` carry no content format from the name alone**, so an archive with no inner extension is `not_classified` from the filename. This is deliberate: *we classify what we can read, not the container.*
- **The 124,335 `ANVIL_T2T*` `chrN.<start>_<end>.tar` records → `not_classified`** (they were `genomic`/`archive`). The name proves a genomic *region*, not that the tar's *contents* are genomic DNA — and the source metadata already declares `data_modality: null`. A **tar-content-peek classifier** (range-read the member headers, classify from the inner formats) is filed as **#255** as the accuracy-principle way to type these.
- **Peel-first is intentionally more permissive than the old allowlist**: it recognizes *any* compressed format spelling, not just the curated sequencing set. That's more correct (a bgzipped VCF is a VCF), and the A/B below quantifies exactly which files change.
- `file_format` stays as the engine's extensionless fallback for the two fallback classifiers; fully dropping it (a graph classifier asserting `pangenome` from segment-tag content) is the deferred #154 direction, not this PR.

## How to verify

Definition of done (from #245):

- [x] **`file_name_for_rules` deleted**, plus its `allowed_extensions`/fabricated-name machinery and `TestFilenameForRules`.
- [x] **The two live callers converted** to the engine reconciliation.
- [x] **Dead compound `extension_map` keys pruned.**
- [x] **The two pinned behaviors hold**: `.cram` still trusted distinctly from `.bam` (native to `FileName.extension`); a `.tar.gz`-named graph is still a graph, not an archive (`TestGfaContentClaimCoherence::test_tar_named_graph_record_is_coherent` — now via `extension=None` → `.gfa` fallback).

Steps:
1. `make test` (780) and `cd schema && make test` (10) — all pass.
2. `make lint && make format-check && uv run pyright` — all clean.
3. Behavior A/B over the AnVIL corpus (run this branch vs `main`):
   - **Filename-only** (`engine.classify_extended(FileInfo.from_filename(name))`): **29 changed names, all `not_classified` → `classified` improvements** — 23 × `*.vcf.bgz` → VCF/variants, 6 × gzipped expression matrices → transcriptomic.
   - **Classifier-path** (`classify_without_content` + `classify_from_gfa_segment_tags` over 157,888 corpus `(name, file_format, config)` rows): **0 drift**.
   - **Intended, separately verified**: 124,335 T2T `.tar` records move to `not_classified` (the `archive_t2t_genomic` deletion — invisible to the filename A/B because it needed `dataset_title`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)