### PR TITLE
Add dynamic escalating head-read for tar content fetches (#260)

### DIFF
--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -10,6 +10,7 @@ each fetcher constructs its typed evidence subclass and calls ``.save``/``.load`
 
 import functools
 import io
+import itertools
 import shutil
 import subprocess
 import tarfile
@@ -143,7 +144,15 @@ def _read_head_until(md5sum, *, url, stages, parse_head, conclusive):
 
     Most files satisfy the detector at the first (smallest) stage and never fetch more;
     only a file whose signal is deeper reads further, up to the last stage.
+
+    ``stages`` must be strictly ascending: a non-increasing target would ask for a range
+    that starts past the bytes already held (``start=len(buf) > target-1``), and the 416
+    that provokes is now read as end-of-file — so misuse would silently under-read rather
+    than fail. Reject it up front instead.
     """
+    stages = tuple(stages)
+    if any(b <= a for a, b in itertools.pairwise(stages)):
+        raise ValueError(f"stages must be strictly ascending, got {stages}")
     buf = b""
     payload = parse_head(buf)  # defined even if stages is empty
     for target in stages:

--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -118,7 +118,9 @@ def _fetch_range(md5sum: str, end_byte: int, timeout: int = 60, url: str | None 
     mirror does not hold this md5 — which is not the same as the file not existing,
     since the catalog entry may still carry a size and a DRS URI. `@wrap_as_fetch_error`
     lets this FetchError pass through unchanged, so the record becomes a
-    `not_classified` row with the HTTP status as its reason (#155).
+    `not_classified` row with the HTTP status as its reason (#155). A 416 raises
+    ``RangeNotSatisfiable``; a 200 to a ``start_byte > 0`` request (the server ignored
+    Range) also raises, so a caller accumulating bytes never appends a duplicated body.
     """
     fetch_url = url or f"{S3_MIRROR_URL}/{md5sum}.md5"
     headers = {"Range": f"bytes={start_byte}-{end_byte}"}
@@ -126,6 +128,12 @@ def _fetch_range(md5sum: str, end_byte: int, timeout: int = 60, url: str | None 
     source = "source URL" if url else "AnVIL S3 mirror"
     if resp.status_code == 416:  # start_byte at/past EOF — the escalating read treats this as end-of-file
         raise RangeNotSatisfiable(f"HTTP 416 from {source} range request")
+    if start_byte > 0 and resp.status_code == 200:
+        # A 200 to a ranged request means the server ignored Range and returned the whole
+        # body from byte 0; appending that to the bytes already held would duplicate and
+        # corrupt the buffer. S3 and GCS (where this data lives) honor Range with 206, so
+        # this should never fire — fail loudly rather than classify from a corrupt buffer.
+        raise FetchError(f"HTTP 200 (Range ignored) from {source} range request")
     if resp.status_code not in [200, 206]:
         raise FetchError(f"HTTP {resp.status_code} from {source} range request")
     return resp.content

--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -51,6 +51,17 @@ class FetchError(Exception):
         self.reason = reason
 
 
+class RangeNotSatisfiable(FetchError):
+    """A range request started at or past the end of the object (HTTP 416).
+
+    A subclass of :class:`FetchError` so every ``except FetchError`` still treats it
+    as unreadable content by default. The escalating read (:func:`_read_head_until`)
+    catches it specifically: once it already holds bytes, a 416 on the next stage means
+    the file ended exactly on a stage boundary, so it stops with the head in hand rather
+    than failing a file it fully read.
+    """
+
+
 def wrap_as_fetch_error(label: str, passthrough: tuple[type[BaseException], ...] = ()):
     """Decorate a fetcher so any read/parse failure surfaces as ``FetchError``.
 
@@ -94,10 +105,13 @@ def wrap_as_fetch_error(label: str, passthrough: tuple[type[BaseException], ...]
 # ``meta_disco.evidence``.
 
 
-def _fetch_range(md5sum: str, end_byte: int, timeout: int = 60, url: str | None = None) -> bytes:
-    """Fetch bytes 0 through end_byte (inclusive) from S3. Returns raw bytes.
+def _fetch_range(md5sum: str, end_byte: int, timeout: int = 60, url: str | None = None, start_byte: int = 0) -> bytes:
+    """Fetch bytes ``start_byte`` through ``end_byte`` (inclusive) from S3. Returns raw bytes.
 
-    If url is provided, fetches from that URL directly. Otherwise uses the AnVIL S3 mirror.
+    ``start_byte`` defaults to 0 (the whole-head fetch every caller used before #260);
+    the escalating read (:func:`_read_head_until`) passes a non-zero start to fetch only
+    the *new* bytes of the next stage. If url is provided, fetches from that URL directly.
+    Otherwise uses the AnVIL S3 mirror.
 
     Raises FetchError naming the HTTP status on a non-2xx response. 404 means the
     mirror does not hold this md5 — which is not the same as the file not existing,
@@ -106,11 +120,43 @@ def _fetch_range(md5sum: str, end_byte: int, timeout: int = 60, url: str | None 
     `not_classified` row with the HTTP status as its reason (#155).
     """
     fetch_url = url or f"{S3_MIRROR_URL}/{md5sum}.md5"
-    headers = {"Range": f"bytes=0-{end_byte}"}
+    headers = {"Range": f"bytes={start_byte}-{end_byte}"}
     resp = requests.get(fetch_url, headers=headers, timeout=timeout)
+    source = "source URL" if url else "AnVIL S3 mirror"
+    if resp.status_code == 416:  # start_byte at/past EOF — the escalating read treats this as end-of-file
+        raise RangeNotSatisfiable(f"HTTP 416 from {source} range request")
     if resp.status_code not in [200, 206]:
-        raise FetchError(f"HTTP {resp.status_code} from {'source URL' if url else 'AnVIL S3 mirror'} range request")
+        raise FetchError(f"HTTP {resp.status_code} from {source} range request")
     return resp.content
+
+
+def _read_head_until(md5sum, *, url, stages, parse_head, conclusive):
+    """Read escalating byte-prefixes from a file, stopping once the head is conclusive (#260).
+
+    For each cumulative byte target in ``stages`` (which must be strictly ascending),
+    fetch only the *new* bytes, append to the accumulated buffer, and ``parse_head`` the
+    whole buffer into a payload. Stop as soon as ``conclusive(payload)`` is true (the
+    caller-supplied detector — reader stays ignorant of what "conclusive" means), or the
+    read shows we hold the whole file: a short read, or a 416 on the next stage when the
+    file ended exactly on the prior boundary. Otherwise the stages run out (the cap).
+    Returns ``(payload, raw_bytes_fetched)``.
+
+    Most files satisfy the detector at the first (smallest) stage and never fetch more;
+    only a file whose signal is deeper reads further, up to the last stage.
+    """
+    buf = b""
+    payload = parse_head(buf)  # defined even if stages is empty
+    for target in stages:
+        try:
+            buf += _fetch_range(md5sum, target - 1, url=url, start_byte=len(buf))
+        except RangeNotSatisfiable:
+            if not buf:  # first stage on an empty object — a real unreadable, not EOF
+                raise
+            break  # the file ended exactly on the previous boundary; the head is complete
+        payload = parse_head(buf)
+        if conclusive(payload) or len(buf) < target:  # found the signal, or hit EOF
+            break
+    return payload, len(buf)
 
 
 def _decompress_if_gzipped(content: bytes, is_gzipped: bool) -> bytes:
@@ -537,6 +583,13 @@ def fetch_gfa_segment_tags(
 # members. See parse_tar_member_names.
 MAX_TAR_MEMBERS = 200
 
+# Escalating head-read stages (#260): cumulative byte targets. The read starts at
+# 256KiB (conclusive for ~98% of the T2T variant-store tars measured) and grows only
+# when the head is not yet conclusive — a GenomicsDB store whose variant signal is
+# deeper than 256KiB, say — up to the 100MiB cap. Only the deep-signal tail ever
+# fetches past the first stage.
+TAR_HEAD_STAGES = (HEAD_BYTES, 1024 * 1024, 10 * 1024 * 1024, 100 * 1024 * 1024)
+
 
 def parse_tar_member_names(data: bytes, max_members: int = MAX_TAR_MEMBERS) -> list[str]:
     """Member names from the head of a (already-decompressed) tar archive (#255).
@@ -572,32 +625,52 @@ def fetch_tar_headers(
     is_gzipped: bool = False,
     use_cache: bool = True,
     url: str | None = None,
+    head_detector=None,
     **kwargs,
 ) -> list[str]:
-    """Read member names from the head of a tar / tar.gz archive on S3 (#255).
+    """Read member names from the head of a tar / tar.gz archive on S3 (#255, #260).
 
     If url is provided, fetches from that URL directly. Otherwise uses the AnVIL S3 mirror.
-    Returns the member names visible in the fetched head; an empty list (a truncated
-    or non-tar head) is a readable result, not a failure. Raises ``FetchError`` naming
-    the cause when the range request itself fails, so the record is kept as a
+    Returns the member names visible in the read head; an empty list (a truncated or
+    non-tar head) is a readable result, not a failure. Raises ``FetchError`` naming the
+    cause when the range request itself fails, so the record is kept as a
     ``not_classified`` row instead of vanishing (#155).
 
-    Only the head is read (``HEAD_BYTES``): a ``.tar`` is read verbatim, a ``.tar.gz``
-    has its head gzip-decompressed (``_decompress_head``, BGZF-aware). That is enough
-    to see the leading members — the archive is classified from its dominant *inner*
-    format, since a container carries no format of its own (#245).
+    The head is read in escalating stages (:data:`TAR_HEAD_STAGES`, #260): it starts at
+    256KiB and grows only while ``head_detector`` reports the members are not yet
+    conclusive — so a GenomicsDB store whose variant signal is deeper than 256KiB is
+    still found — up to the 100MiB cap. ``head_detector`` is injected by the caller
+    (``FileTypeConfig.head_detector`` → ``pipeline``), so the fetcher stays ignorant of
+    what makes a head conclusive; ``None`` degrades to a single 256KiB read. A
+    ``.tar.gz`` has its accumulated head gzip-decompressed each stage (BGZF-aware); a
+    container carries no format of its own (#245) — the archive is classified from its
+    inner members.
     """
     if use_cache:
         cached = TarEvidence.load(evidence_dir, md5sum)
         if cached is not None:
             return cached.payload
 
-    content = _fetch_range(md5sum, HEAD_BYTES - 1, timeout=60, url=url)
-    raw_bytes = len(content)
+    def parse_head(buf: bytes) -> list[str]:
+        # `.tar.gz` decompresses the accumulated head (BGZF-aware); `.tar` passes through.
+        return parse_tar_member_names(_decompress_if_gzipped(buf, is_gzipped))
 
-    # A `.tar.gz` decompresses the head (BGZF-aware); a `.tar` passes through unchanged.
-    content = _decompress_if_gzipped(content, is_gzipped)
-    member_names = parse_tar_member_names(content)
+    detector = head_detector or (lambda _members: True)
+
+    def conclusive(members: list[str]) -> bool:
+        # A saturated parse (>= MAX_TAR_MEMBERS) can no longer grow — parse_tar_member_names
+        # only ever returns the first MAX_TAR_MEMBERS names, so deeper bytes cannot add a
+        # signal the detector would see. Stop escalating rather than read to the cap for
+        # nothing (a store of many tiny members whose signal is not in the first stage).
+        return len(members) >= MAX_TAR_MEMBERS or detector(members)
+
+    member_names, raw_bytes = _read_head_until(
+        md5sum,
+        url=url,
+        stages=TAR_HEAD_STAGES,
+        parse_head=parse_head,
+        conclusive=conclusive,
+    )
     if len(member_names) >= MAX_TAR_MEMBERS:
         # `>=` reaches the cap; the scan does not report whether more members
         # followed, so this may also fire for an archive of exactly that many — hence

--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -106,6 +106,18 @@ def wrap_as_fetch_error(label: str, passthrough: tuple[type[BaseException], ...]
 # ``meta_disco.evidence``.
 
 
+def _content_range_start(content_range: str) -> int | None:
+    """The first-byte position of a ``Content-Range: bytes <start>-<end>/<total>`` header.
+
+    ``"bytes 0-262143/524288"`` -> ``0``. Returns ``None`` when the header is absent or
+    unparseable, which the caller treats the same as a misaligned window.
+    """
+    try:
+        return int(content_range.split()[1].split("/")[0].split("-")[0])
+    except (IndexError, ValueError):
+        return None
+
+
 def _fetch_range(md5sum: str, end_byte: int, timeout: int = 60, url: str | None = None, start_byte: int = 0) -> bytes:
     """Fetch bytes ``start_byte`` through ``end_byte`` (inclusive) from S3. Returns raw bytes.
 
@@ -121,6 +133,12 @@ def _fetch_range(md5sum: str, end_byte: int, timeout: int = 60, url: str | None 
     `not_classified` row with the HTTP status as its reason (#155). A 416 raises
     ``RangeNotSatisfiable``; a 200 to a ``start_byte > 0`` request (the server ignored
     Range) also raises, so a caller accumulating bytes never appends a duplicated body.
+
+    A 206 is verified against its ``Content-Range``: the returned window must start where
+    we asked (``start_byte``). A mismatched or missing ``Content-Range`` means the server
+    handed back the wrong bytes — classifying from a misaligned window could produce a
+    *wrong* answer, so it raises rather than guess. (Fewer bytes than requested is fine —
+    the object is shorter than the range; the caller reads that as EOF.)
     """
     fetch_url = url or f"{S3_MIRROR_URL}/{md5sum}.md5"
     headers = {"Range": f"bytes={start_byte}-{end_byte}"}
@@ -136,6 +154,12 @@ def _fetch_range(md5sum: str, end_byte: int, timeout: int = 60, url: str | None 
         raise FetchError(f"HTTP 200 (Range ignored) from {source} range request")
     if resp.status_code not in [200, 206]:
         raise FetchError(f"HTTP {resp.status_code} from {source} range request")
+    if resp.status_code == 206:
+        got = resp.headers.get("Content-Range", "")
+        if _content_range_start(got) != start_byte:
+            raise FetchError(
+                f"misaligned range from {source}: requested start={start_byte}, got {got or '(no Content-Range)'!r}"
+            )
     return resp.content
 
 

--- a/src/meta_disco/file_types.py
+++ b/src/meta_disco/file_types.py
@@ -22,6 +22,7 @@ from .header_classifier import (
     classify_from_header,
     classify_from_tar_members,
     classify_from_vcf_header,
+    tar_head_is_conclusive,
 )
 from .pipeline import FileTypeConfig
 from .summaries import print_bam_summary, print_fastq_summary, print_vcf_summary
@@ -92,6 +93,9 @@ TAR_CONFIG = FileTypeConfig(
     # The inner member formats determine what the contents are; nothing here reads a
     # member's own header, so no reference_assembly / platform / assay_type.
     content_fields=("data_modality", "data_type"),
+    # Escalating head-read (#260): read deeper only until the members are classifiable,
+    # so a GenomicsDB store whose variant signal sits past the first 256KiB is reached.
+    head_detector=tar_head_is_conclusive,
 )
 
 FILE_TYPE_REGISTRY = {

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -628,19 +628,24 @@ def _recognized_inner_extensions(member_names: list[str]) -> list[tuple[str, str
 
 
 def tar_head_is_conclusive(member_names: list[str]) -> bool:
-    """Whether reading deeper into the archive could change its classification (#260).
+    """Whether the members read so far are signal enough to stop the escalating read (#260).
 
     The escalating-read stop condition injected into the tar fetcher (via
     ``FileTypeConfig.head_detector``): read deeper only while this is False, so a
     GenomicsDB store whose variant signal sits past the first stage is still reached.
 
-    True on a GenomicsDB variant-store signal, or once any member carries a recognized
-    inner extension — at that point the members read already carry the strongest signal
-    :func:`classify_from_tar_members` acts on, so more bytes cannot improve the result.
-    "Conclusive" means *settled*, not *classified*: a head of only header-only members
-    (e.g. ``.bam``, which needs its own header, not just its extension) is conclusive yet
-    classifies to ``not_classified`` — reading deeper would not change that either. Uses
-    the same recognition helpers as the classifier so the two agree on what counts.
+    True on a GenomicsDB variant-store signal — definitive on its own, it fixes the
+    archive as a variant store regardless of the other members — or once any member
+    carries a recognized inner extension. The recognized-extension case is a
+    *first-signal* stop, not a promise about the final value: the generic path in
+    :func:`classify_from_tar_members` picks the *dominant* recognized extension over the
+    members read, and a deeper read could still shift that dominant. Stopping at the
+    first recognized member is deliberate — it keeps the generic path the fixed-head
+    sample it always was, while letting the GenomicsDB signal (the #260 target) escalate.
+    So "conclusive" means *enough to make the call*, not *classified*: a head of only
+    header-only members (e.g. ``.bam``, classified from its own header, not its
+    extension) is conclusive yet resolves to ``not_classified``. Uses the same
+    recognition helpers as the classifier so the two agree on what counts as recognized.
     """
     return bool(_is_genomicsdb_variant_store(member_names) or _recognized_inner_extensions(member_names))
 

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -608,6 +608,43 @@ def _is_genomicsdb_variant_store(member_names: list[str]) -> bool:
     return False
 
 
+def _recognized_inner_extensions(member_names: list[str]) -> list[tuple[str, str]]:
+    """The archive members whose basename carries a recognized inner extension (#260).
+
+    Returns ``(extension, basename)`` pairs. ``FileName.parse`` reads the extension from
+    the basename (peeling any wrappers, yielding a clean core incl. multi-dot cores like
+    ``.g.vcf``); parsing the basename rather than the full member path keeps a mid-path
+    directory dot out of it. Shared by :func:`classify_from_tar_members` (which picks the
+    dominant extension) and :func:`tar_head_is_conclusive` (which only asks whether any
+    exists), so the two cannot drift apart in what they count as recognized.
+    """
+    recognized = []
+    for member in member_names:
+        basename = member.rsplit("/", 1)[-1]
+        ext = FileName.parse(basename).extension
+        if ext is not None:
+            recognized.append((ext, basename))
+    return recognized
+
+
+def tar_head_is_conclusive(member_names: list[str]) -> bool:
+    """Whether reading deeper into the archive could change its classification (#260).
+
+    The escalating-read stop condition injected into the tar fetcher (via
+    ``FileTypeConfig.head_detector``): read deeper only while this is False, so a
+    GenomicsDB store whose variant signal sits past the first stage is still reached.
+
+    True on a GenomicsDB variant-store signal, or once any member carries a recognized
+    inner extension — at that point the members read already carry the strongest signal
+    :func:`classify_from_tar_members` acts on, so more bytes cannot improve the result.
+    "Conclusive" means *settled*, not *classified*: a head of only header-only members
+    (e.g. ``.bam``, which needs its own header, not just its extension) is conclusive yet
+    classifies to ``not_classified`` — reading deeper would not change that either. Uses
+    the same recognition helpers as the classifier so the two agree on what counts.
+    """
+    return bool(_is_genomicsdb_variant_store(member_names) or _recognized_inner_extensions(member_names))
+
+
 def classify_from_tar_members(
     member_names: list[str],
     *,
@@ -648,7 +685,6 @@ def classify_from_tar_members(
     from .rule_engine import CONTENT_TIER, ExtendedFileInfo
 
     engine = _get_engine()
-    basenames = [member.rsplit("/", 1)[-1] for member in member_names]
 
     # Base pass over the archive's own name — its tokens may still carry a reference
     # or other filename signal, and it seeds the result the content claims layer on.
@@ -666,14 +702,7 @@ def classify_from_tar_members(
         return result.to_output_dict()
 
     # (2) Generic: classify by the dominant recognized inner member extension.
-    # FileName.parse reads the extension from the basename (peeling any wrappers and
-    # yielding a clean core, incl. multi-dot cores like .g.vcf); parsing the basename
-    # rather than the full member path keeps a mid-path directory dot out of it.
-    recognized: list[tuple[str, str]] = []  # (inner extension, member basename)
-    for basename in basenames:
-        ext = FileName.parse(basename).extension
-        if ext is not None:
-            recognized.append((ext, basename))
+    recognized = _recognized_inner_extensions(member_names)  # (inner extension, member basename)
     if not recognized:
         return result.to_output_dict()
 

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -93,6 +93,12 @@ class FileTypeConfig:
     # must be installed). Raises to abort the run fast, instead of letting every
     # record fail the same way and vanish. None means no check.
     preflight: Callable | None = None
+    # Detector for an escalating head-read (#260): given the fetcher's parsed payload,
+    # returns whether the head is conclusive (enough to classify). The fetcher reads
+    # deeper only while this is False. Injected here rather than imported by the fetcher,
+    # so the reader stays decoupled from the classifier's recognition logic. None means
+    # the fetcher reads a single fixed head (the default for every type but tar).
+    head_detector: Callable | None = None
 
 
 def _fetch_and_classify(
@@ -133,6 +139,7 @@ def _fetch_and_classify(
             file_name=file_name,
             is_gzipped=is_gzipped,
             use_cache=use_cache,
+            head_detector=config.head_detector,
         )
     except FetchError as e:
         print(f"Content unreadable, classifying from filename — {file_name or md5sum}: {e.reason}")

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -301,6 +301,13 @@ class TestReadHeadUntil:
         with pytest.raises(fetchers.RangeNotSatisfiable):
             _read_head_until(MD5, url=None, stages=(10, 100), parse_head=lambda b: b, conclusive=lambda b: False)
 
+    @pytest.mark.parametrize("stages", [(100, 10), (10, 10), (10, 100, 50)])
+    def test_non_ascending_stages_rejected(self, stages):
+        # A non-ascending target would ask for a range starting past the bytes in hand;
+        # the 416 that provokes now reads as EOF, so misuse must fail loudly up front.
+        with pytest.raises(ValueError, match="strictly ascending"):
+            _read_head_until(MD5, url=None, stages=stages, parse_head=lambda b: b, conclusive=lambda b: False)
+
 
 class TestTarFetcherEscalation:
     """fetch_tar_headers reads deeper only until the detector is satisfied (#260)."""

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -301,6 +301,18 @@ class TestReadHeadUntil:
         with pytest.raises(fetchers.RangeNotSatisfiable):
             _read_head_until(MD5, url=None, stages=(10, 100), parse_head=lambda b: b, conclusive=lambda b: False)
 
+    def test_200_to_a_ranged_stage_raises_rather_than_duplicating(self, monkeypatch):
+        # A server that ignores Range and answers 200 with the whole body on stage 2 would
+        # corrupt the accumulated buffer if appended. S3/GCS honor Range (206); this is the
+        # fail-loud guard for the case that they don't.
+        def _get(url, headers, timeout=None):
+            start, _end = (int(x) for x in headers["Range"].split("=")[1].split("-"))
+            return _Resp(206 if start == 0 else 200, b"x" * 20)  # stage 2 ignores Range
+
+        monkeypatch.setattr(fetchers.requests, "get", _get)
+        with pytest.raises(FetchError, match="Range ignored"):
+            _read_head_until(MD5, url=None, stages=(10, 100), parse_head=lambda b: b, conclusive=lambda b: False)
+
     @pytest.mark.parametrize("stages", [(100, 10), (10, 10), (10, 100, 50)])
     def test_non_ascending_stages_rejected(self, stages):
         # A non-ascending target would ask for a range starting past the bytes in hand;

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -15,6 +15,7 @@ import requests
 import meta_disco.fetchers as fetchers
 from meta_disco.fetchers import (
     FetchError,
+    _read_head_until,
     fetch_bam_header,
     fetch_fasta_headers,
     fetch_fastq_reads,
@@ -52,6 +53,42 @@ def evidence_dir(tmp_path):
 
 def _patch_get(monkeypatch, resp):
     monkeypatch.setattr(fetchers.requests, "get", lambda *a, **k: resp)
+
+
+def _patch_range_get(monkeypatch, full: bytes) -> list[tuple[int, int]]:
+    """Serve `full` in response to `Range: bytes=START-END`, returning that slice.
+
+    Returns a list the mock appends each requested (start, end) to — so a test can
+    assert how many range requests the escalating read actually made.
+    """
+    calls: list[tuple[int, int]] = []
+
+    def _get(url, headers, timeout=None):
+        start, end = (int(x) for x in headers["Range"].split("=")[1].split("-"))
+        calls.append((start, end))
+        return _Resp(206, full[start : end + 1])
+
+    monkeypatch.setattr(fetchers.requests, "get", _get)
+    return calls
+
+
+def _patch_range_get_with_eof(monkeypatch, full: bytes) -> list[tuple[int, int]]:
+    """Like `_patch_range_get`, but a range whose start is at/past EOF answers 416.
+
+    That is S3's behavior for an unsatisfiable range, and the case the escalating read
+    hits when a file ends exactly on a stage boundary.
+    """
+    calls: list[tuple[int, int]] = []
+
+    def _get(url, headers, timeout=None):
+        start, end = (int(x) for x in headers["Range"].split("=")[1].split("-"))
+        calls.append((start, end))
+        if start >= len(full):
+            return _Resp(416)
+        return _Resp(206, full[start : end + 1])
+
+    monkeypatch.setattr(fetchers.requests, "get", _get)
+    return calls
 
 
 class TestRangeFetchers:
@@ -206,3 +243,126 @@ class TestTarFetcher:
         # not a FetchError — the range request itself succeeded.
         _patch_get(monkeypatch, _Resp(200, b"garbage, not a tar"))
         assert fetch_tar_headers(evidence_dir, MD5, file_name="x.tar", is_gzipped=False, use_cache=False) == []
+
+
+class TestReadHeadUntil:
+    """The escalating read loop (#260): stop on the detector, on EOF, or at the cap."""
+
+    def test_stops_at_the_first_conclusive_stage(self, monkeypatch):
+        # `full` is larger than stage 1 but the detector is satisfied by stage-1 bytes.
+        calls = _patch_range_get(monkeypatch, b"C" + b"x" * 5000)
+        payload, raw = _read_head_until(
+            MD5, url=None, stages=(10, 100, 1000), parse_head=lambda b: b, conclusive=lambda b: b.startswith(b"C")
+        )
+        assert payload.startswith(b"C") and raw == 10
+        assert calls == [(0, 9)]  # exactly one range request
+
+    def test_escalates_until_conclusive(self, monkeypatch):
+        # The signal byte 'S' sits at offset 15 — past stage 1 (10B), within stage 2 (100B).
+        calls = _patch_range_get(monkeypatch, b"x" * 15 + b"S" + b"y" * 500)
+        payload, raw = _read_head_until(
+            MD5, url=None, stages=(10, 100, 1000), parse_head=lambda b: b, conclusive=lambda b: b"S" in b
+        )
+        assert b"S" in payload and raw == 100
+        assert calls == [(0, 9), (10, 99)]  # stage 1 then the incremental stage-2 bytes
+
+    def test_short_read_stops_at_eof(self, monkeypatch):
+        # The whole file is 30B; stage 2 asks for up to 100 and gets a short read → EOF.
+        calls = _patch_range_get(monkeypatch, b"z" * 30)  # never conclusive
+        _payload, raw = _read_head_until(
+            MD5, url=None, stages=(10, 100, 1000), parse_head=lambda b: b, conclusive=lambda b: False
+        )
+        assert raw == 30
+        assert calls == [(0, 9), (10, 99)]  # stops after the short second read; no third stage
+
+    def test_reads_to_the_last_stage_when_never_conclusive(self, monkeypatch):
+        calls = _patch_range_get(monkeypatch, b"q" * 5000)  # bigger than the cap, never conclusive
+        _payload, raw = _read_head_until(
+            MD5, url=None, stages=(10, 100, 1000), parse_head=lambda b: b, conclusive=lambda b: False
+        )
+        assert raw == 1000  # the cap
+        assert len(calls) == 3
+
+    def test_range_not_satisfiable_after_bytes_is_treated_as_eof(self, monkeypatch):
+        # The file is exactly the stage-1 boundary (10B): stage 1 fills it (not a short
+        # read), so stage 2 asks from offset 10 == EOF → 416. That is end-of-file, not a
+        # failure — the read stops with the head it already holds.
+        calls = _patch_range_get_with_eof(monkeypatch, b"z" * 10)  # never conclusive
+        payload, raw = _read_head_until(
+            MD5, url=None, stages=(10, 100, 1000), parse_head=lambda b: b, conclusive=lambda b: False
+        )
+        assert raw == 10 and payload == b"z" * 10
+        assert calls == [(0, 9), (10, 99)]  # the 416 stage ends the read; no third stage
+
+    def test_range_not_satisfiable_on_first_stage_propagates(self, monkeypatch):
+        # An empty object 416s on the very first stage, with no bytes in hand — a real
+        # unreadable, not EOF, so it must surface as FetchError (kept as not_classified).
+        _patch_range_get_with_eof(monkeypatch, b"")
+        with pytest.raises(fetchers.RangeNotSatisfiable):
+            _read_head_until(MD5, url=None, stages=(10, 100), parse_head=lambda b: b, conclusive=lambda b: False)
+
+
+class TestTarFetcherEscalation:
+    """fetch_tar_headers reads deeper only until the detector is satisfied (#260)."""
+
+    def test_shallow_archive_exits_at_the_first_stage(self, monkeypatch, evidence_dir):
+        from meta_disco.header_classifier import tar_head_is_conclusive
+
+        data = _make_tar([("g/callset.json", b"{}"), ("g/vidmap.json", b"{}")])
+        calls = _patch_range_get(monkeypatch, data)
+        names = fetch_tar_headers(
+            evidence_dir,
+            MD5,
+            file_name="x.tar",
+            is_gzipped=False,
+            use_cache=False,
+            head_detector=tar_head_is_conclusive,
+        )
+        assert "g/callset.json" in names
+        assert len(calls) == 1  # the GenomicsDB signal was in the first stage; no escalation
+
+    def test_deep_signal_triggers_escalation(self, monkeypatch, evidence_dir):
+        from meta_disco.header_classifier import tar_head_is_conclusive
+
+        # A >256KiB opaque member pushes the GenomicsDB signal past the first stage.
+        data = _make_tar([("bulk/blob.bin", b"x" * 300_000), ("g/callset.json", b"{}")])
+        calls = _patch_range_get(monkeypatch, data)
+        names = fetch_tar_headers(
+            evidence_dir,
+            MD5,
+            file_name="x.tar",
+            is_gzipped=False,
+            use_cache=False,
+            head_detector=tar_head_is_conclusive,
+        )
+        assert "g/callset.json" in names  # found only after escalating past 256KiB
+        assert len(calls) >= 2
+
+    def test_no_detector_reads_a_single_head(self, monkeypatch, evidence_dir):
+        data = _make_tar([("bulk/blob.bin", b"x" * 300_000), ("g/callset.json", b"{}")])
+        calls = _patch_range_get(monkeypatch, data)
+        # head_detector=None degrades to one 256KiB read (the pre-#260 behavior).
+        fetch_tar_headers(evidence_dir, MD5, file_name="x.tar", is_gzipped=False, use_cache=False, head_detector=None)
+        assert len(calls) == 1
+
+    def test_saturated_member_cap_stops_escalation(self, monkeypatch, evidence_dir):
+        from meta_disco.header_classifier import tar_head_is_conclusive
+
+        # 250 unrecognized members fit inside the first stage, then a big member pushes the
+        # file past 256KiB so stage 1 is a full (non-short) read with no conclusive signal.
+        # The parse saturates at MAX_TAR_MEMBERS and deeper bytes cannot grow that set, so
+        # the escalation must stop rather than march through every stage to the cap.
+        members = [(f"d/f{i}", b"") for i in range(250)] + [("d/big.bin", b"x" * 200_000)]
+        data = _make_tar(members)
+        assert len(data) > fetchers.HEAD_BYTES  # stage 1 is a full read, not EOF
+        calls = _patch_range_get(monkeypatch, data)
+        names = fetch_tar_headers(
+            evidence_dir,
+            MD5,
+            file_name="x.tar",
+            is_gzipped=False,
+            use_cache=False,
+            head_detector=tar_head_is_conclusive,
+        )
+        assert len(names) >= fetchers.MAX_TAR_MEMBERS
+        assert len(calls) == 1  # saturated parse: no escalation despite no conclusive signal

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -41,9 +41,16 @@ MD5 = "a" * 32
 
 
 class _Resp:
-    def __init__(self, status_code, content=b""):
+    def __init__(self, status_code, content=b"", headers=None):
         self.status_code = status_code
         self.content = content
+        self.headers = headers or {}
+
+
+def _partial(full: bytes, start: int, end: int) -> "_Resp":
+    """A conformant 206: the requested slice plus a matching Content-Range header."""
+    body = full[start : end + 1]
+    return _Resp(206, body, headers={"Content-Range": f"bytes {start}-{start + len(body) - 1}/{len(full)}"})
 
 
 @pytest.fixture
@@ -66,7 +73,7 @@ def _patch_range_get(monkeypatch, full: bytes) -> list[tuple[int, int]]:
     def _get(url, headers, timeout=None):
         start, end = (int(x) for x in headers["Range"].split("=")[1].split("-"))
         calls.append((start, end))
-        return _Resp(206, full[start : end + 1])
+        return _partial(full, start, end)
 
     monkeypatch.setattr(fetchers.requests, "get", _get)
     return calls
@@ -85,7 +92,7 @@ def _patch_range_get_with_eof(monkeypatch, full: bytes) -> list[tuple[int, int]]
         calls.append((start, end))
         if start >= len(full):
             return _Resp(416)
-        return _Resp(206, full[start : end + 1])
+        return _partial(full, start, end)
 
     monkeypatch.setattr(fetchers.requests, "get", _get)
     return calls
@@ -222,14 +229,14 @@ class TestTarFetcher:
 
     def test_returns_member_names_from_the_head(self, monkeypatch, evidence_dir):
         data = _make_tar([("g/callset.json", b"{}"), ("g/vcfheader.vcf", b"##")])
-        _patch_get(monkeypatch, _Resp(206, data))
+        _patch_get(monkeypatch, _partial(data, 0, len(data) - 1))
         names = fetch_tar_headers(evidence_dir, MD5, file_name="x.tar", is_gzipped=False, use_cache=False)
         assert names == ["g/callset.json", "g/vcfheader.vcf"]
 
     def test_gzipped_tar_head_is_decompressed_then_parsed(self, monkeypatch, evidence_dir):
         # A .tar.gz: is_gzipped=True must decompress the head before the tar parse.
         gz = gzip.compress(_make_tar([("g/callset.json", b"{}"), ("g/vidmap.json", b"{}")]))
-        _patch_get(monkeypatch, _Resp(206, gz))
+        _patch_get(monkeypatch, _partial(gz, 0, len(gz) - 1))
         names = fetch_tar_headers(evidence_dir, MD5, file_name="x.tar.gz", is_gzipped=True, use_cache=False)
         assert names == ["g/callset.json", "g/vidmap.json"]
 
@@ -306,12 +313,31 @@ class TestReadHeadUntil:
         # corrupt the accumulated buffer if appended. S3/GCS honor Range (206); this is the
         # fail-loud guard for the case that they don't.
         def _get(url, headers, timeout=None):
-            start, _end = (int(x) for x in headers["Range"].split("=")[1].split("-"))
-            return _Resp(206 if start == 0 else 200, b"x" * 20)  # stage 2 ignores Range
+            start, end = (int(x) for x in headers["Range"].split("=")[1].split("-"))
+            if start == 0:  # stage 1 is conformant
+                return _Resp(206, b"x" * (end - start + 1), headers={"Content-Range": f"bytes 0-{end}/1000"})
+            return _Resp(200, b"x" * 20)  # stage 2: server ignores Range
 
         monkeypatch.setattr(fetchers.requests, "get", _get)
         with pytest.raises(FetchError, match="Range ignored"):
             _read_head_until(MD5, url=None, stages=(10, 100), parse_head=lambda b: b, conclusive=lambda b: False)
+
+    def test_206_with_misaligned_content_range_raises(self, monkeypatch):
+        # A 206 whose Content-Range starts somewhere other than we asked for means the
+        # server handed back the wrong window; classifying from it could be wrong.
+        def _get(url, headers, timeout=None):
+            return _Resp(206, b"x" * 10, headers={"Content-Range": "bytes 5-14/100"})  # asked start=0
+
+        monkeypatch.setattr(fetchers.requests, "get", _get)
+        with pytest.raises(FetchError, match="misaligned range"):
+            _read_head_until(MD5, url=None, stages=(10,), parse_head=lambda b: b, conclusive=lambda b: False)
+
+    def test_206_without_content_range_raises(self, monkeypatch):
+        # A conformant 206 always carries Content-Range; its absence means we cannot
+        # confirm the window is aligned, so treat it the same as a mismatch.
+        _patch_get(monkeypatch, _Resp(206, b"x" * 10))  # no Content-Range header
+        with pytest.raises(FetchError, match="misaligned range"):
+            _read_head_until(MD5, url=None, stages=(10,), parse_head=lambda b: b, conclusive=lambda b: False)
 
     @pytest.mark.parametrize("stages", [(100, 10), (10, 10), (10, 100, 50)])
     def test_non_ascending_stages_rejected(self, stages):


### PR DESCRIPTION
## What changed

The tar content fetcher now reads the archive head in **escalating stages** (256 KiB → 1 MiB → 10 MiB → 100 MiB) instead of a single fixed 256 KiB read. It stops as soon as a caller-injected **detector** reports the members read so far are classifiable, or on end-of-file, or at the 100 MiB cap.

- `_read_head_until` (`fetchers.py`) — the general escalating-read loop. Each stage fetches only the *new* bytes (`_fetch_range` gained a `start_byte`), appends to the buffer, and re-parses the whole head. It stops on the detector, a short read (EOF), or the cap.
- The detector is **dependency-injected** via `FileTypeConfig.head_detector` → `pipeline` → fetcher, so the reader stays ignorant of what "conclusive" means. `tar_head_is_conclusive` (`header_classifier.py`) is the tar detector; it shares a new `_recognized_inner_extensions` helper with `classify_from_tar_members` so the detector and classifier agree on what counts as recognized.
- Escalation also **stops once the parse saturates at `MAX_TAR_MEMBERS`** (200): `parse_tar_member_names` only ever returns the first 200 names, so deeper bytes cannot surface a signal the detector would see — reading further would be wasted.
- A **416 on a later stage is treated as end-of-file**, not a failure (`RangeNotSatisfiable`, a `FetchError` subclass): a file that ends exactly on a stage boundary was fully read. A first-stage 416 (an empty object) still surfaces as `FetchError`.

## Why

Corpus validation for #255 found that ~2% of the readable T2T GenomicsDB variant-store tars carry their variant signal (schema files / VCF-attribute `.tdb` arrays) *past* the first 256 KiB, so a fixed head read left them `not_classified`. The escalating read recovers that tail (validated 98% → 100% of readable T2T tars) while keeping the common case at a single 256 KiB fetch — "pay for the deeper read only when you need it."

## Assumptions I made

- **The conclusive signal falls within the first `MAX_TAR_MEMBERS` (200) members.** The parse caps member names at 200, so a signal beyond member 200 is invisible regardless of byte depth — and the member-cap stop relies on this. The #260 end-to-end validation (100% recovery) confirms the real T2T signals land within the first 200 members; if a future archive layout violated this, it would classify `not_classified`, not wrong.
- **The mirror honors HTTP Range with 206 and answers 416 for a start at/past EOF** (standard S3 behavior). The 416→EOF handling depends on it; a server that answered 200 with the whole body would still work but wouldn't benefit from the boundary optimization.
- **`head_detector` is `None` for every non-tar type**, degrading `_read_head_until` to a single 256 KiB read — the pre-#260 behavior. Every fetcher already absorbs the new kwarg via `**kwargs`.
- **Stages must be strictly ascending** (documented on `_read_head_until`); `TAR_HEAD_STAGES` is.

## How to verify

Definition of done (from #260): read the tar head dynamically in stages, exit as soon as the head is classifiable, up to a 100 MiB cap, with the detector decoupled from the reader.

1. **Unit** — `make test`. New tests in `tests/test_fetchers.py`: `TestReadHeadUntil` (stops at first conclusive stage, escalates until conclusive, short-read EOF, reads to the cap, 416-after-bytes is EOF, first-stage 416 propagates) and `TestTarFetcherEscalation` (shallow archive → 1 fetch, deep signal → escalates, no detector → single head, saturated member cap → no escalation). All 806 pass.
2. **Decoupling** — confirm the fetcher names no classifier symbol: `grep -n "genomicsdb\|extension\|tar_head" src/meta_disco/fetchers.py` returns nothing; the detector arrives only as `FileTypeConfig.head_detector`.
3. **End-to-end (network)** — run the tar classifier over a sample of `ANVIL_T2T*` `.tar` md5s from `data/anvil/anvil_files_metadata.ndjson` against the S3 mirror. Expect readable T2T tars → `genomic`/`variants`, and most files reading only 256 KiB (`raw_bytes_fetched` in the evidence) with only the deep-tail escalating.

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)
