### PR TITLE
Add streaming read path + differential harness alongside fetchers (#264)

### DIFF
--- a/scripts/compare_streaming.py
+++ b/scripts/compare_streaming.py
@@ -45,10 +45,13 @@ STREAMING_FETCHERS = {
 def _route(rec: dict) -> str | None:
     """The in-scope config name whose extensions match this record, or None.
 
-    Mirrors production routing (``ClassifyPipeline._filter_records``): case-sensitive, matching
-    on either ``file_format`` or ``file_name`` — so a record whose extension lives only in
-    ``file_format`` is still sampled, and a mixed-case name is not spuriously matched. Longest
-    matching extension wins so ``.vcf.gz`` routes to vcf, not a bare ``.gz``.
+    Uses production's match rule (``ClassifyPipeline._filter_records``): case-sensitive, on
+    either ``file_format`` or ``file_name`` — so a record whose extension lives only in
+    ``file_format`` is still sampled, and a mixed-case name is not spuriously matched.
+    Production runs that rule per config and may match one file to several; the harness needs a
+    single bucket per file, so it additionally picks the config with the longest matching
+    extension (``.vcf.gz`` -> vcf, not a bare ``.gz``). That extra disambiguation is the
+    harness's, not production's.
     """
     fmt = str(rec.get("file_format") or "")
     name = str(rec.get("file_name") or "")

--- a/scripts/compare_streaming.py
+++ b/scripts/compare_streaming.py
@@ -1,0 +1,203 @@
+"""Differential harness: old fixed-window fetchers vs the new streaming path (#264).
+
+Runs both read paths against live S3 on a per-type sample of real files and reports where
+they diverge — at the fetcher-output level (header text / read names / contig names /
+segment tags / member names) and at the final classification level (the acceptance gate
+for the #263 cutover). Read-depth differences that flip no classification are expected and
+fine; anything that changes a classification is listed for investigation.
+
+This is a manual tool (it needs the network); it is not imported by the pipeline or run in
+CI. BAM/CRAM is out of scope (#263) — it stays on samtools — so it is skipped here.
+
+    uv run python scripts/compare_streaming.py --per-type 40
+"""
+
+import argparse
+import json
+import tempfile
+from collections import Counter
+from dataclasses import replace
+from pathlib import Path
+
+from meta_disco.fetchers import FetchError
+from meta_disco.file_types import FILE_TYPE_REGISTRY
+from meta_disco.pipeline import ClassifyPipeline
+from meta_disco.streaming import (
+    fetch_fasta_headers_streaming,
+    fetch_fastq_reads_streaming,
+    fetch_gfa_segment_tags_streaming,
+    fetch_tar_headers_streaming,
+    fetch_vcf_header_streaming,
+)
+
+DEFAULT_METADATA = Path("data/anvil/anvil_files_metadata.ndjson")
+
+# The streaming counterpart of each in-scope config's fetcher, keyed by config name.
+STREAMING_FETCHERS = {
+    "vcf": fetch_vcf_header_streaming,
+    "fastq": fetch_fastq_reads_streaming,
+    "fasta": fetch_fasta_headers_streaming,
+    "gfa": fetch_gfa_segment_tags_streaming,
+    "tar": fetch_tar_headers_streaming,
+}
+
+
+def _route(rec: dict) -> str | None:
+    """The in-scope config name whose extensions match this record, or None.
+
+    Mirrors production routing (``ClassifyPipeline._filter_records``): case-sensitive, matching
+    on either ``file_format`` or ``file_name`` — so a record whose extension lives only in
+    ``file_format`` is still sampled, and a mixed-case name is not spuriously matched. Longest
+    matching extension wins so ``.vcf.gz`` routes to vcf, not a bare ``.gz``.
+    """
+    fmt = str(rec.get("file_format") or "")
+    name = str(rec.get("file_name") or "")
+    best, best_len = None, 0
+    for cfg_name in STREAMING_FETCHERS:
+        for ext in FILE_TYPE_REGISTRY[cfg_name].extensions:
+            if (fmt.endswith(ext) or name.endswith(ext)) and len(ext) > best_len:
+                best, best_len = cfg_name, len(ext)
+    return best
+
+
+def _sample(metadata: Path, per_type: int) -> dict[str, list[dict]]:
+    """First ``per_type`` records of each in-scope file type, by extension routing."""
+    buckets: dict[str, list[dict]] = {name: [] for name in STREAMING_FETCHERS}
+    remaining = len(buckets)
+    with metadata.open() as fh:
+        for line in fh:
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            cfg_name = _route(rec)
+            if cfg_name is None or len(buckets[cfg_name]) >= per_type:
+                continue
+            buckets[cfg_name].append(rec)
+            if len(buckets[cfg_name]) == per_type:
+                remaining -= 1
+                if remaining == 0:
+                    break
+    return buckets
+
+
+def _is_gzipped(config, file_name: str, file_format: str | None) -> bool:
+    """Mirror the pipeline's gzip determination so the diff reflects production, not a guess.
+
+    Same rule as ``ClassifyPipeline._process_single_record`` (pipeline.py): if the config has
+    no ``.gz`` extension at all, treat the file as gzipped; otherwise it is gzipped only when
+    its name or ``file_format`` ends in ``.gz``.
+    """
+    has_gz_ext = any(ext.endswith(".gz") for ext in config.extensions)
+    if not has_gz_ext:
+        return True
+    return file_name.endswith(".gz") or (file_format or "").endswith(".gz")
+
+
+def _norm_payload(payload):
+    """Normalize a fetcher payload for equality (SegmentTags -> their on-disk dicts)."""
+    if isinstance(payload, list):
+        return [item.to_json() if hasattr(item, "to_json") else item for item in payload]
+    return payload
+
+
+def _fetch_payload(fetcher, config, rec: dict, is_gzipped: bool, evidence_dir: Path):
+    """Run one fetcher; return its normalized payload, or an ``("error", reason)`` marker."""
+    try:
+        out = fetcher(
+            evidence_dir,
+            rec["file_md5sum"],
+            file_name=rec.get("file_name", ""),
+            is_gzipped=is_gzipped,
+            use_cache=False,
+            head_detector=config.head_detector,
+        )
+        return _norm_payload(out)
+    except FetchError as e:
+        return ("error", e.reason)
+
+
+def _classifications(config, rec: dict, is_gzipped: bool, evidence_base: Path) -> dict:
+    """The five-dimension classification block for one file under ``config``."""
+    record = ClassifyPipeline.classify_single(
+        config,
+        rec["file_md5sum"],
+        file_name=rec.get("file_name", ""),
+        file_size=rec.get("file_size"),
+        file_format=rec.get("file_format"),
+        is_gzipped=is_gzipped,
+        use_cache=False,
+        evidence_base=evidence_base,
+    )
+    return record["classifications"]
+
+
+def _class_key(classifications: dict) -> dict:
+    """Reduce a classification block to per-dimension ``(value, status)``, dropping evidence.
+
+    The cutover gate is whether the verdict matches, not whether the audit prose is identical:
+    when both paths agree a file is unreadable, their fetch-failure reason wording differs (and
+    lands in the evidence), which must NOT read as a regression. Comparing only value+status
+    measures what the cutover actually cares about.
+    """
+    return {
+        dim: ((entry.get("value"), entry.get("status")) if isinstance(entry, dict) else entry)
+        for dim, entry in classifications.items()
+    }
+
+
+def compare(buckets: dict[str, list[dict]], workdir: Path) -> None:
+    for cfg_name, records in buckets.items():
+        config = FILE_TYPE_REGISTRY[cfg_name]
+        streaming_config = replace(config, fetcher=STREAMING_FETCHERS[cfg_name])
+        tally: Counter = Counter()
+        print(f"\n=== {cfg_name}: {len(records)} files ===")
+
+        for rec in records:
+            md5 = rec.get("file_md5sum")
+            if not md5:
+                tally["skipped_no_md5"] += 1
+                continue
+            file_name = rec.get("file_name", "")
+            try:
+                is_gzipped = _is_gzipped(config, file_name, rec.get("file_format"))
+                ev = workdir / cfg_name / md5
+                old_payload = _fetch_payload(config.fetcher, config, rec, is_gzipped, ev / "old_fetch")
+                new_payload = _fetch_payload(STREAMING_FETCHERS[cfg_name], config, rec, is_gzipped, ev / "new_fetch")
+                old_class = _class_key(_classifications(config, rec, is_gzipped, ev / "old_cls"))
+                new_class = _class_key(_classifications(streaming_config, rec, is_gzipped, ev / "new_cls"))
+            except Exception as e:  # one pathological file must not abort the whole live-S3 run
+                tally["error"] += 1
+                print(f"  ERROR {md5} {file_name}: {type(e).__name__}: {e}")
+                continue
+
+            tally["payload_match" if old_payload == new_payload else "payload_diff"] += 1
+            if old_class == new_class:
+                tally["class_match"] += 1
+            else:
+                tally["class_diff"] += 1
+                print(f"  CLASS DIFF {md5} {file_name}")
+                print(f"    old: {old_class}")
+                print(f"    new: {new_class}")
+
+        print(f"  payload: {tally['payload_match']} match / {tally['payload_diff']} diff")
+        print(f"  class:   {tally['class_match']} match / {tally['class_diff']} diff")
+        if tally["skipped_no_md5"]:
+            print(f"  skipped (no md5): {tally['skipped_no_md5']}")
+        if tally["error"]:
+            print(f"  errors (logged, skipped): {tally['error']}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metadata", type=Path, default=DEFAULT_METADATA, help="AnVIL metadata NDJSON")
+    parser.add_argument("--per-type", type=int, default=40, help="files to sample per file type")
+    args = parser.parse_args()
+
+    buckets = _sample(args.metadata, args.per_type)
+    with tempfile.TemporaryDirectory(prefix="compare-streaming-") as tmp:
+        compare(buckets, Path(tmp))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare_streaming.py
+++ b/scripts/compare_streaming.py
@@ -45,14 +45,16 @@ STREAMING_FETCHERS = {
 def _route(rec: dict) -> str | None:
     """The in-scope config name whose extensions match this record, or None.
 
-    Uses production's match rule (``ClassifyPipeline._filter_records``): case-sensitive, on
-    either ``file_format`` or ``file_name`` — so a record whose extension lives only in
-    ``file_format`` is still sampled, and a mixed-case name is not spuriously matched.
-    Production runs that rule per config and may match one file to several; the harness needs a
-    single bucket per file, so it additionally picks the config with the longest matching
-    extension (``.vcf.gz`` -> vcf, not a bare ``.gz``). That extra disambiguation is the
-    harness's, not production's.
+    Uses production's match rule (``ClassifyPipeline._filter_records``): a ``skip``-flagged
+    record is excluded, and matching is case-sensitive on either ``file_format`` or
+    ``file_name`` — so a record whose extension lives only in ``file_format`` is still sampled,
+    and a mixed-case name is not spuriously matched. Production runs that rule per config and
+    may match one file to several; the harness needs a single bucket per file, so it additionally
+    picks the config with the longest matching extension (``.vcf.gz`` -> vcf, not a bare
+    ``.gz``). That extra disambiguation is the harness's, not production's.
     """
+    if rec.get("skip"):
+        return None
     fmt = str(rec.get("file_format") or "")
     name = str(rec.get("file_name") or "")
     best, best_len = None, 0

--- a/src/meta_disco/streaming.py
+++ b/src/meta_disco/streaming.py
@@ -175,8 +175,12 @@ class _CappedRead:
     stream ended AND the raw reader reached genuine object EOF (``raw.whole_file``). It stays
     False when the read stopped at the decompressed ``cap``, at the compressed cap (which
     makes the raw reader return 0 bytes indistinguishably from EOF, so ``raw.whole_file`` is
-    the tie-breaker), or on a cut-short/corrupt gzip stream. This is the one place the caps
-    and the truncated-gzip handling live; the line drivers below share it.
+    the tie-breaker), or on a cut-short/corrupt gzip stream. Note this is conservative at the
+    cap: if the decoded stream happens to end exactly as ``cap`` is reached, the loop exits on
+    the cap without observing EOF, so ``complete`` is False — a technically-whole head is
+    reported truncated rather than claiming a completion the code cannot prove without reading
+    past the cap. This is the one place the caps and the truncated-gzip handling live; the
+    line drivers below share it.
 
     Only gzip *decode* failures are caught here — ``EOFError`` / ``zlib.error`` /
     ``gzip.BadGzipFile`` from a truncated or corrupt stream. A failed range fetch mid-read is

--- a/src/meta_disco/streaming.py
+++ b/src/meta_disco/streaming.py
@@ -19,11 +19,11 @@ The shape:
   (:class:`_VcfMatcher`, :class:`_FastqMatcher`, :class:`_FastaMatcher`) for the text
   types, and :func:`_walk_tar_members` for tar.
 
-Decompression-bomb defense falls out of the design: every reader stops at
-``MAX_DECOMPRESSED`` bytes (``_iter_lines`` discards each line as it scans; ``_read_head_text``
-holds at most that capped head), and the tar walk streams member bodies past without
-materializing them — so a pathological ``.gz`` yields a truncated head bounded by the cap,
-never an unbounded buffer.
+Decompression-bomb defense falls out of the design: the line readers stop at
+``MAX_DECOMPRESSED`` decompressed bytes (``_iter_lines`` discards each line as it scans;
+``_read_head_text`` holds at most that capped head), while the tar walk streams member bodies
+past without materializing them, bounded on the network side by ``TAR_COMPRESSED_CAP``
+compressed bytes — so a pathological ``.gz`` yields a truncated head, never an unbounded buffer.
 """
 
 import gzip

--- a/src/meta_disco/streaming.py
+++ b/src/meta_disco/streaming.py
@@ -362,6 +362,22 @@ def _load_cached(evidence_cls, evidence_dir, md5sum: str, use_cache: bool):
     return cached.payload if cached is not None else None
 
 
+def _save_head_evidence(evidence_cls, evidence_dir, *, md5sum, file_name, raw, url, **payload) -> None:
+    """Persist a fetched head as its typed evidence, filling the fields every fetcher shares.
+
+    ``payload`` carries the type-specific field(s) — e.g. ``read_names=...``, plus VCF's extra
+    ``max_positions``; ``md5sum`` / ``file_name`` / ``raw_bytes_fetched`` (from ``raw``) /
+    ``source_url`` are the common provenance all five fetchers record identically.
+    """
+    evidence_cls(
+        md5sum=md5sum,
+        file_name=file_name,
+        raw_bytes_fetched=raw.bytes_fetched,
+        source_url=url,
+        **payload,
+    ).save(evidence_dir)
+
+
 @wrap_as_fetch_error("VCF header")
 def fetch_vcf_header_streaming(
     evidence_dir,
@@ -383,14 +399,16 @@ def fetch_vcf_header_streaming(
     if matcher.header_lines:
         header_text = "\n".join(matcher.header_lines)
         max_positions = extract_max_positions(matcher.variant_lines) if matcher.variant_lines else None
-        VcfEvidence(
+        _save_head_evidence(
+            VcfEvidence,
+            evidence_dir,
             md5sum=md5sum,
             file_name=file_name,
+            raw=raw,
+            url=url,
             header_text=header_text,
             max_positions=max_positions,
-            raw_bytes_fetched=raw.bytes_fetched,
-            source_url=url,
-        ).save(evidence_dir)
+        )
         return header_text
 
     raise FetchError("no VCF header lines (no '#' lines) in the read head")
@@ -416,13 +434,15 @@ def fetch_fastq_reads_streaming(
     matcher = _scan_lines(stream, raw, cap=MAX_DECOMPRESSED, matcher=_FastqMatcher(num_reads=num_reads))
 
     if matcher.read_names:
-        FastqEvidence(
+        _save_head_evidence(
+            FastqEvidence,
+            evidence_dir,
             md5sum=md5sum,
             file_name=file_name,
+            raw=raw,
+            url=url,
             read_names=matcher.read_names,
-            raw_bytes_fetched=raw.bytes_fetched,
-            source_url=url,
-        ).save(evidence_dir)
+        )
         return matcher.read_names
 
     raise FetchError("no FASTQ read names (no '@' lines) in the read head")
@@ -446,13 +466,15 @@ def fetch_fasta_headers_streaming(
     stream, raw = _open_stream(md5sum, url=url, is_gzipped=is_gzipped, compressed_cap=HEAD_COMPRESSED_CAP)
     matcher = _scan_lines(stream, raw, cap=MAX_DECOMPRESSED, matcher=_FastaMatcher())
 
-    FastaEvidence(
+    _save_head_evidence(
+        FastaEvidence,
+        evidence_dir,
         md5sum=md5sum,
         file_name=file_name,
+        raw=raw,
+        url=url,
         contig_names=matcher.contig_names,
-        raw_bytes_fetched=raw.bytes_fetched,
-        source_url=url,
-    ).save(evidence_dir)
+    )
     return matcher.contig_names
 
 
@@ -475,13 +497,9 @@ def fetch_gfa_segment_tags_streaming(
     text, truncated = _read_head_text(stream, raw, cap=MAX_DECOMPRESSED)
     segment_tags = parse_gfa_segment_tags(text, truncated=truncated)
 
-    GfaEvidence(
-        md5sum=md5sum,
-        file_name=file_name,
-        gfa_segment_tags=segment_tags,
-        raw_bytes_fetched=raw.bytes_fetched,
-        source_url=url,
-    ).save(evidence_dir)
+    _save_head_evidence(
+        GfaEvidence, evidence_dir, md5sum=md5sum, file_name=file_name, raw=raw, url=url, gfa_segment_tags=segment_tags
+    )
     return segment_tags
 
 
@@ -512,11 +530,7 @@ def fetch_tar_headers_streaming(
         stream, raw, detector=detector, max_members=MAX_TAR_MEMBERS, stages=TAR_HEAD_STAGES
     )
 
-    TarEvidence(
-        md5sum=md5sum,
-        file_name=file_name,
-        member_names=member_names,
-        raw_bytes_fetched=raw.bytes_fetched,
-        source_url=url,
-    ).save(evidence_dir)
+    _save_head_evidence(
+        TarEvidence, evidence_dir, md5sum=md5sum, file_name=file_name, raw=raw, url=url, member_names=member_names
+    )
     return member_names

--- a/src/meta_disco/streaming.py
+++ b/src/meta_disco/streaming.py
@@ -165,10 +165,12 @@ class _CappedRead:
     and the truncated-gzip handling live; the line drivers below share it.
 
     Only gzip *decode* failures are caught here — ``EOFError`` / ``zlib.error`` /
-    ``gzip.BadGzipFile`` from a truncated or corrupt stream. A ``FetchError`` (incl. a
-    transport error, since ``requests`` exceptions subclass ``OSError``) is NOT caught, so a
-    failed range fetch mid-read propagates as a read failure instead of masquerading as a
-    clean truncation.
+    ``gzip.BadGzipFile`` from a truncated or corrupt stream. A failed range fetch mid-read is
+    deliberately NOT caught: an HTTP-status ``FetchError`` and a transport error alike
+    propagate out to be surfaced as ``FetchError`` by ``@wrap_as_fetch_error``, rather than
+    masquerading as a clean truncation. This is exactly why the catch excludes ``OSError`` —
+    ``requests`` transport exceptions (``ConnectionError`` / ``Timeout``) are ``OSError``
+    subclasses (``RequestException`` derives from ``OSError``), so catching it would swallow them.
     """
 
     def __init__(self, stream, raw: "_RawRangeReader", cap: int):

--- a/src/meta_disco/streaming.py
+++ b/src/meta_disco/streaming.py
@@ -45,8 +45,9 @@ from .fetchers import (
     wrap_as_fetch_error,
 )
 
-# Range-fetch sizing. The first range matches the fixed-window fetchers' 256KiB head;
-# each subsequent range grows so a deep read (tar) costs few round-trips, not many.
+# Range-fetch sizing. The first range is 256KiB — the common head size (FASTQ/FASTA/GFA and
+# tar's first stage); subsequent ranges grow geometrically, so the fetchers that read further
+# (VCF up to its 1MiB cap, a deep tar) reach their data in a few round-trips, not many.
 FIRST_CHUNK = HEAD_BYTES
 CHUNK_GROWTH = 4
 MAX_CHUNK = 10 * 1024 * 1024

--- a/src/meta_disco/streaming.py
+++ b/src/meta_disco/streaming.py
@@ -1,0 +1,492 @@
+"""One streaming read path for the range-based head-fetchers (#263, #264).
+
+Every range-based fetcher reads the same way: pull a file's head from S3 in bytes,
+decompress it on the fly when gzipped, and feed the decompressed stream to a small
+matcher that stops as soon as it has what it needs. This module builds that single
+path **alongside** the fixed-window fetchers in ``fetchers.py`` — nothing here is wired
+into the pipeline yet; ``scripts/compare_streaming.py`` diffs the two before any cutover
+(#264 is stage 1 of #263).
+
+The shape:
+
+* :class:`_RawRangeReader` — a forward-only ``io.RawIOBase`` that lazily fetches
+  escalating byte ranges (reusing ``fetchers._fetch_range``'s ``start_byte`` /
+  ``RangeNotSatisfiable`` / ``Content-Range`` alignment from #260), capped at a
+  compressed-byte ceiling.
+* :func:`_open_stream` — wraps it in ``gzip.GzipFile`` when gzipped (which decodes
+  concatenated members transparently, so BGZF reads past its first block).
+* line drivers (:func:`_iter_lines`, :func:`_read_head_text`) + matchers
+  (:class:`_VcfMatcher`, :class:`_FastqMatcher`, :class:`_FastaMatcher`) for the text
+  types, and :func:`_walk_tar_members` for tar.
+
+Decompression-bomb defense falls out of the design: every reader stops at
+``MAX_DECOMPRESSED`` bytes (``_iter_lines`` discards each line as it scans; ``_read_head_text``
+holds at most that capped head), and the tar walk streams member bodies past without
+materializing them — so a pathological ``.gz`` yields a truncated head bounded by the cap,
+never an unbounded buffer.
+"""
+
+import gzip
+import io
+import tarfile
+import zlib
+
+from .evidence import FastaEvidence, FastqEvidence, GfaEvidence, TarEvidence, VcfEvidence
+from .fetchers import (
+    HEAD_BYTES,
+    MAX_TAR_MEMBERS,
+    TAR_HEAD_STAGES,
+    FetchError,
+    RangeNotSatisfiable,
+    _decode_bytes,
+    _fetch_range,
+    extract_max_positions,
+    parse_gfa_segment_tags,
+    wrap_as_fetch_error,
+)
+
+# Range-fetch sizing. The first range matches the fixed-window fetchers' 256KiB head;
+# each subsequent range grows so a deep read (tar) costs few round-trips, not many.
+FIRST_CHUNK = HEAD_BYTES
+CHUNK_GROWTH = 4
+MAX_CHUNK = 10 * 1024 * 1024
+
+# Internal decompressed-read granularity for the line drivers.
+_READ_CHUNK = 65536
+
+# Compressed-byte ceilings (network bound). Each is the *maximum* window its old fetcher
+# would read, so if streaming reads to the cap it sees the same bytes (it usually stops
+# earlier). The old fetchers pass an *inclusive* end_byte, hence the +1 over the round
+# window for VCF/FASTQ/FASTA; old GFA already uses HEAD_BYTES-1 (256KiB exactly).
+VCF_COMPRESSED_CAP = 1024 * 1024 + 1  # fetch_vcf_header reads bytes 0..1048576
+HEAD_COMPRESSED_CAP = HEAD_BYTES + 1  # fetch_fastq_reads / fetch_fasta_headers read bytes 0..262144
+GFA_COMPRESSED_CAP = HEAD_BYTES  # fetch_gfa_segment_tags reads bytes 0..262143 (256KiB)
+TAR_COMPRESSED_CAP = 100 * 1024 * 1024  # #260 escalation ceiling
+
+# Decompressed-byte ceiling (memory bound) for the line readers — comfortably above any
+# real header, and the cap a decompression bomb hits instead of exhausting memory.
+MAX_DECOMPRESSED = 16 * 1024 * 1024
+
+
+class _RawRangeReader(io.RawIOBase):
+    """Forward-only raw bytes of a file's head, fetched in escalating ranges up to a cap.
+
+    Fetches large ranges internally and serves ``readinto`` from that buffer, so the
+    small reads a ``BufferedReader`` / ``GzipFile`` / ``tarfile`` make on top do not each
+    become a range request. Ranges start where the last ended (``start_byte``) and grow
+    geometrically; a short read or a 416 marks end-of-object. ``bytes_fetched`` is the
+    total compressed bytes pulled from the origin — the ``raw_bytes_fetched`` an evidence
+    record reports.
+    """
+
+    def __init__(self, md5sum: str, *, url: str | None, cap: int):
+        self._md5sum = md5sum
+        self._url = url
+        self._cap = cap
+        self._pending = b""  # the current fetched range
+        self._pos = 0  # read offset into _pending (advanced, not sliced, so reads stay O(n))
+        self._fetched = 0  # total compressed bytes pulled from the origin
+        self._chunk = FIRST_CHUNK
+        self._eof = False
+
+    def readable(self) -> bool:
+        return True
+
+    @property
+    def bytes_fetched(self) -> int:
+        return self._fetched
+
+    @property
+    def whole_file(self) -> bool:
+        """True once the object has been read to its end (a short read or a 416 after
+        some bytes) — as opposed to stopping at the compressed-byte cap. Lets a consumer
+        tell "the file ended" from "we stopped early", which readinto returning 0 cannot."""
+        return self._eof
+
+    def _fill(self) -> bool:
+        """Ensure unread bytes are available in ``_pending``; return False at end/cap."""
+        if self._pos < len(self._pending):
+            return True
+        if self._eof or self._fetched >= self._cap:
+            return False
+        want = min(self._chunk, self._cap - self._fetched)
+        try:
+            data = _fetch_range(self._md5sum, self._fetched + want - 1, url=self._url, start_byte=self._fetched)
+        except RangeNotSatisfiable:
+            if self._fetched == 0:
+                raise  # 416 on the first range — an empty/absent object, a read failure not EOF
+            self._eof = True  # 416 after some bytes — the object ended on the prior boundary
+            return False
+        if not data:
+            self._eof = True
+            return False
+        self._pending = data
+        self._pos = 0
+        self._fetched += len(data)
+        if len(data) < want:
+            self._eof = True  # short read — the object ended inside this range
+        self._chunk = min(self._chunk * CHUNK_GROWTH, MAX_CHUNK)
+        return True
+
+    def readinto(self, b) -> int:
+        if len(b) == 0:  # a zero-length probe must not trigger a range fetch
+            return 0
+        if not self._fill():
+            return 0
+        n = min(len(b), len(self._pending) - self._pos)
+        b[:n] = memoryview(self._pending)[self._pos : self._pos + n]
+        self._pos += n
+        return n
+
+
+def _open_stream(md5sum: str, *, url: str | None, is_gzipped: bool, compressed_cap: int):
+    """Open a forward-only stream of a file's head, decompressed when gzipped.
+
+    Returns ``(stream, raw)``: ``stream`` yields decompressed bytes (or raw bytes when not
+    gzipped) for a matcher to read; ``raw`` is the underlying :class:`_RawRangeReader`,
+    kept so the caller can read ``raw.bytes_fetched`` for the evidence record afterwards.
+    ``gzip.GzipFile`` decodes concatenated members transparently, so a BGZF head reads
+    past its first block (unlike the fixed-window fetchers, which decode only the first).
+    """
+    raw = _RawRangeReader(md5sum, url=url, cap=compressed_cap)
+    buffered = io.BufferedReader(raw)
+    stream = gzip.GzipFile(fileobj=buffered) if is_gzipped else buffered
+    return stream, raw
+
+
+class _CappedRead:
+    """Iterate a decompressed stream in chunks totalling at most ``cap`` bytes.
+
+    ``complete`` is True after iteration only when the whole object was read: the decoded
+    stream ended AND the raw reader reached genuine object EOF (``raw.whole_file``). It stays
+    False when the read stopped at the decompressed ``cap``, at the compressed cap (which
+    makes the raw reader return 0 bytes indistinguishably from EOF, so ``raw.whole_file`` is
+    the tie-breaker), or on a cut-short/corrupt gzip stream. This is the one place the caps
+    and the truncated-gzip handling live; the line drivers below share it.
+
+    Only gzip *decode* failures are caught here — ``EOFError`` / ``zlib.error`` /
+    ``gzip.BadGzipFile`` from a truncated or corrupt stream. A ``FetchError`` (incl. a
+    transport error, since ``requests`` exceptions subclass ``OSError``) is NOT caught, so a
+    failed range fetch mid-read propagates as a read failure instead of masquerading as a
+    clean truncation.
+    """
+
+    def __init__(self, stream, raw: "_RawRangeReader", cap: int):
+        self._stream = stream
+        self._raw = raw
+        self._cap = cap
+        self.complete = False
+
+    def __iter__(self):
+        read = 0
+        while read < self._cap:
+            try:
+                chunk = self._stream.read(min(_READ_CHUNK, self._cap - read))
+            except (EOFError, zlib.error, gzip.BadGzipFile):
+                return  # gzip stream cut short / corrupt — truncated, so complete stays False
+            if not chunk:
+                # An empty read is EOF only if the object truly ended; at the compressed cap
+                # the raw reader also returns 0, and that is a truncation, not completion.
+                self.complete = self._raw.whole_file
+                return
+            read += len(chunk)
+            yield chunk
+
+
+def _iter_lines(stream, raw: "_RawRangeReader", *, cap: int):
+    """Yield decoded lines from a decompressed stream, reading at most ``cap`` bytes.
+
+    Bytes are split on ``b"\\n"`` and each line is decoded whole, so a multi-byte character
+    is never cut across a read boundary. A trailing line with no terminating newline is
+    yielded only when the whole object was read; if the read stopped at either cap or on a
+    cut-short gzip stream, that final partial line is dropped — the byte window may have
+    split a record in half. (Same truncation rule as
+    :func:`~meta_disco.fetchers.parse_gfa_segment_tags`.)
+    """
+    reader = _CappedRead(stream, raw, cap)
+    remainder = bytearray()  # unterminated tail; extended in place so a newline-sparse read stays O(n)
+    for chunk in reader:
+        remainder += chunk
+        start = 0
+        while (nl := remainder.find(b"\n", start)) >= 0:
+            yield _decode_bytes(bytes(remainder[start:nl]))
+            start = nl + 1
+        del remainder[:start]  # drop the lines already yielded, keep the tail
+    if reader.complete and remainder:
+        yield _decode_bytes(bytes(remainder))
+
+
+def _read_head_text(stream, raw: "_RawRangeReader", *, cap: int) -> tuple[str, bool]:
+    """Decode up to ``cap`` decompressed bytes; report whether the read was truncated.
+
+    ``truncated`` is True when the read stopped at either cap or on a cut-short gzip stream,
+    and False only when the whole object was read — the signal
+    :func:`~meta_disco.fetchers.parse_gfa_segment_tags` needs to decide whether a final
+    unterminated line is a real record or a byte-window artifact.
+    """
+    reader = _CappedRead(stream, raw, cap)
+    data = bytearray()
+    for chunk in reader:
+        data += chunk
+    return _decode_bytes(bytes(data)), not reader.complete
+
+
+class _VcfMatcher:
+    """Collect ``#`` header lines and up to ``max_variants`` variant lines from a VCF head."""
+
+    def __init__(self, max_variants: int = 100):
+        self.header_lines: list[str] = []
+        self.variant_lines: list[str] = []
+        self._max_variants = max_variants
+
+    def feed(self, line: str) -> bool:
+        if line.startswith("#"):
+            self.header_lines.append(line)
+        elif line.strip() and len(self.variant_lines) < self._max_variants:
+            self.variant_lines.append(line)
+        return len(self.variant_lines) >= self._max_variants
+
+
+class _FastqMatcher:
+    """Collect the first ``num_reads`` read-name (``@``) lines, skipping the 3 lines each."""
+
+    def __init__(self, num_reads: int = 10):
+        self.read_names: list[str] = []
+        self._num_reads = num_reads
+        self._skip = 0  # sequence, +, quality lines to skip after a read name
+
+    def feed(self, line: str) -> bool:
+        if self._skip:
+            self._skip -= 1
+            return False
+        line = line.strip()
+        if line.startswith("@"):
+            self.read_names.append(line)
+            self._skip = 3
+        return len(self.read_names) >= self._num_reads
+
+
+class _FastaMatcher:
+    """Collect contig names from ``>`` header lines across the read head."""
+
+    def __init__(self):
+        self.contig_names: list[str] = []
+
+    def feed(self, line: str) -> bool:
+        line = line.strip()
+        if line.startswith(">"):
+            parts = line[1:].split()  # split() drops surrounding whitespace, so a bare ">" yields []
+            if parts:
+                self.contig_names.append(parts[0])
+        return False  # no early signal — read the whole capped head
+
+
+def _scan_lines(stream, raw: "_RawRangeReader", *, cap: int, matcher):
+    """Feed decoded lines to ``matcher`` until it reports it is satisfied (or ``cap`` is hit)."""
+    for line in _iter_lines(stream, raw, cap=cap):
+        if matcher.feed(line):
+            break
+    return matcher
+
+
+def _walk_tar_members(stream, raw: "_RawRangeReader", *, detector, max_members: int, stages) -> list[str]:
+    """Member names from the head of a streamed, already-decompressed tar archive.
+
+    ``detector`` gates *escalation*, not per-member stopping: it is consulted only once the
+    raw reader has crossed the next byte offset in ``stages``, on all members read so far —
+    mirroring the old fixed-head fetcher, which parses a whole byte-stage of members before
+    deciding whether to read deeper. That is why a mixed archive is voted on its full head
+    sample rather than cut at the first recognized member. Walking stops when the detector is
+    conclusive at a stage boundary, at ``max_members``, or when the stream ends / is cut short
+    (a truncated or non-tar head raises ``TarError`` / ``EOFError`` / a gzip error, caught
+    here — the names read before the cut are the result). A non-tar head yields ``[]``.
+    """
+    names: list[str] = []
+    pending = list(stages)
+    try:
+        with tarfile.open(fileobj=stream, mode="r|") as tar:
+            for member in tar:
+                names.append(member.name)
+                if len(names) >= max_members:
+                    break
+                crossed = False
+                while pending and raw.bytes_fetched >= pending[0]:
+                    pending.pop(0)
+                    crossed = True
+                if crossed and detector(names):
+                    break
+    except (tarfile.TarError, EOFError, zlib.error, gzip.BadGzipFile):
+        pass
+    return names
+
+
+def _load_cached(evidence_cls, evidence_dir, md5sum: str, use_cache: bool):
+    """Return a cached payload for ``md5sum`` when caching is on and a record is present, else None.
+
+    An empty-list payload (a valid FASTA / GFA / TAR hit) is returned as-is, not confused
+    with a miss — the ``_EMPTY_IS_MISS`` types already fail their own ``.load`` when empty.
+    """
+    if not use_cache:
+        return None
+    cached = evidence_cls.load(evidence_dir, md5sum)
+    return cached.payload if cached is not None else None
+
+
+@wrap_as_fetch_error("VCF header")
+def fetch_vcf_header_streaming(
+    evidence_dir,
+    md5sum: str,
+    file_name: str = "",
+    is_gzipped: bool = True,
+    use_cache: bool = True,
+    url: str | None = None,
+    **kwargs,
+) -> str:
+    """Streaming counterpart of :func:`~meta_disco.fetchers.fetch_vcf_header`."""
+    payload = _load_cached(VcfEvidence, evidence_dir, md5sum, use_cache)
+    if payload is not None:
+        return payload
+
+    stream, raw = _open_stream(md5sum, url=url, is_gzipped=is_gzipped, compressed_cap=VCF_COMPRESSED_CAP)
+    matcher = _scan_lines(stream, raw, cap=MAX_DECOMPRESSED, matcher=_VcfMatcher())
+
+    if matcher.header_lines:
+        header_text = "\n".join(matcher.header_lines)
+        max_positions = extract_max_positions(matcher.variant_lines) if matcher.variant_lines else None
+        VcfEvidence(
+            md5sum=md5sum,
+            file_name=file_name,
+            header_text=header_text,
+            max_positions=max_positions,
+            raw_bytes_fetched=raw.bytes_fetched,
+            source_url=url,
+        ).save(evidence_dir)
+        return header_text
+
+    raise FetchError("no VCF header lines (no '#' lines) in the read head")
+
+
+@wrap_as_fetch_error("FASTQ")
+def fetch_fastq_reads_streaming(
+    evidence_dir,
+    md5sum: str,
+    file_name: str = "",
+    is_gzipped: bool = True,
+    num_reads: int = 10,
+    use_cache: bool = True,
+    url: str | None = None,
+    **kwargs,
+) -> list[str]:
+    """Streaming counterpart of :func:`~meta_disco.fetchers.fetch_fastq_reads`."""
+    payload = _load_cached(FastqEvidence, evidence_dir, md5sum, use_cache)
+    if payload is not None:
+        return payload
+
+    stream, raw = _open_stream(md5sum, url=url, is_gzipped=is_gzipped, compressed_cap=HEAD_COMPRESSED_CAP)
+    matcher = _scan_lines(stream, raw, cap=MAX_DECOMPRESSED, matcher=_FastqMatcher(num_reads=num_reads))
+
+    if matcher.read_names:
+        FastqEvidence(
+            md5sum=md5sum,
+            file_name=file_name,
+            read_names=matcher.read_names,
+            raw_bytes_fetched=raw.bytes_fetched,
+            source_url=url,
+        ).save(evidence_dir)
+        return matcher.read_names
+
+    raise FetchError("no FASTQ read names (no '@' lines) in the read head")
+
+
+@wrap_as_fetch_error("FASTA")
+def fetch_fasta_headers_streaming(
+    evidence_dir,
+    md5sum: str,
+    file_name: str = "",
+    is_gzipped: bool = True,
+    use_cache: bool = True,
+    url: str | None = None,
+    **kwargs,
+) -> list[str]:
+    """Streaming counterpart of :func:`~meta_disco.fetchers.fetch_fasta_headers`."""
+    payload = _load_cached(FastaEvidence, evidence_dir, md5sum, use_cache)
+    if payload is not None:
+        return payload
+
+    stream, raw = _open_stream(md5sum, url=url, is_gzipped=is_gzipped, compressed_cap=HEAD_COMPRESSED_CAP)
+    matcher = _scan_lines(stream, raw, cap=MAX_DECOMPRESSED, matcher=_FastaMatcher())
+
+    FastaEvidence(
+        md5sum=md5sum,
+        file_name=file_name,
+        contig_names=matcher.contig_names,
+        raw_bytes_fetched=raw.bytes_fetched,
+        source_url=url,
+    ).save(evidence_dir)
+    return matcher.contig_names
+
+
+@wrap_as_fetch_error("GFA head")
+def fetch_gfa_segment_tags_streaming(
+    evidence_dir,
+    md5sum: str,
+    file_name: str = "",
+    is_gzipped: bool = True,
+    use_cache: bool = True,
+    url: str | None = None,
+    **kwargs,
+):
+    """Streaming counterpart of :func:`~meta_disco.fetchers.fetch_gfa_segment_tags`."""
+    payload = _load_cached(GfaEvidence, evidence_dir, md5sum, use_cache)
+    if payload is not None:
+        return payload
+
+    stream, raw = _open_stream(md5sum, url=url, is_gzipped=is_gzipped, compressed_cap=GFA_COMPRESSED_CAP)
+    text, truncated = _read_head_text(stream, raw, cap=MAX_DECOMPRESSED)
+    segment_tags = parse_gfa_segment_tags(text, truncated=truncated)
+
+    GfaEvidence(
+        md5sum=md5sum,
+        file_name=file_name,
+        gfa_segment_tags=segment_tags,
+        raw_bytes_fetched=raw.bytes_fetched,
+        source_url=url,
+    ).save(evidence_dir)
+    return segment_tags
+
+
+@wrap_as_fetch_error("TAR head")
+def fetch_tar_headers_streaming(
+    evidence_dir,
+    md5sum: str,
+    file_name: str = "",
+    is_gzipped: bool = False,
+    use_cache: bool = True,
+    url: str | None = None,
+    head_detector=None,
+    **kwargs,
+) -> list[str]:
+    """Streaming counterpart of :func:`~meta_disco.fetchers.fetch_tar_headers`.
+
+    ``head_detector`` (injected by the caller, ``None`` -> read a single head) decides when
+    the members seen so far are conclusive, exactly as in the escalating fetcher — but here
+    the read escalates by streaming rather than re-decompressing a growing buffer.
+    """
+    payload = _load_cached(TarEvidence, evidence_dir, md5sum, use_cache)
+    if payload is not None:
+        return payload
+
+    detector = head_detector or (lambda _members: True)
+    stream, raw = _open_stream(md5sum, url=url, is_gzipped=is_gzipped, compressed_cap=TAR_COMPRESSED_CAP)
+    member_names = _walk_tar_members(
+        stream, raw, detector=detector, max_members=MAX_TAR_MEMBERS, stages=TAR_HEAD_STAGES
+    )
+
+    TarEvidence(
+        md5sum=md5sum,
+        file_name=file_name,
+        member_names=member_names,
+        raw_bytes_fetched=raw.bytes_fetched,
+        source_url=url,
+    ).save(evidence_dir)
+    return member_names

--- a/src/meta_disco/streaming.py
+++ b/src/meta_disco/streaming.py
@@ -315,12 +315,21 @@ def _walk_tar_members(stream, raw: "_RawRangeReader", *, detector, max_members: 
     ``detector`` gates *escalation*, not per-member stopping: it is consulted only once the
     consumer has read past the next byte offset in ``stages`` (``raw.bytes_served``, i.e. bytes
     actually parsed, not the whole range prefetched into the reader), on all members read so
-    far — mirroring the old fixed-head fetcher, which parses a whole byte-stage of members
-    before deciding whether to read deeper. That is why a mixed archive is voted on its full
-    head sample rather than cut at the first recognized member. Walking stops when the detector
-    is conclusive at a stage boundary, at ``max_members``, or when the stream ends / is cut
-    short (a truncated or non-tar head raises ``TarError`` / ``EOFError`` / a gzip error, caught
-    here — the names read before the cut are the result). A non-tar head yields ``[]``.
+    far. That is why a mixed archive is voted on a head sample rather than cut at the first
+    recognized member.
+
+    This *approximates* the old fixed-head fetcher's staged escalation; it does not byte-mirror
+    it. The old path parses a whole compressed byte-stage and stops at exactly that stage's
+    members, whereas here the detector is checked only at stage *crossings* and ``tarfile``
+    buffers ahead, so the walk overshoots a few members past the conclusive point before the
+    next check fires. The result is a bounded *superset* of the old member set — never fewer, a
+    few more near the boundary (for real stages, a handful out of up to ``max_members``). The
+    stage-2 shadow-diff quantifies any classification impact.
+
+    Walking stops when the detector is conclusive at a stage boundary, at ``max_members``, or
+    when the stream ends / is cut short (a truncated or non-tar head raises ``TarError`` /
+    ``EOFError`` / a gzip error, caught here — the names read before the cut are the result). A
+    non-tar head yields ``[]``.
     """
     names: list[str] = []
     pending = list(stages)

--- a/src/meta_disco/streaming.py
+++ b/src/meta_disco/streaming.py
@@ -161,11 +161,16 @@ def _open_stream(md5sum: str, *, url: str | None, is_gzipped: bool, compressed_c
     kept so the caller can read ``raw.bytes_fetched`` for the evidence record afterwards.
     ``gzip.GzipFile`` decodes concatenated members transparently, so a BGZF head reads
     past its first block (unlike the fixed-window fetchers, which decode only the first).
+
+    Decompression is enabled only when ``is_gzipped`` *and* the head actually starts with the
+    gzip magic (peeked, not consumed) — matching the legacy ``_decompress_head`` magic check, so
+    a plain file misnamed ``.gz`` is read as raw text rather than raising ``BadGzipFile``.
     """
     raw = _RawRangeReader(md5sum, url=url, cap=compressed_cap)
     buffered = io.BufferedReader(raw)
-    stream = gzip.GzipFile(fileobj=buffered) if is_gzipped else buffered
-    return stream, raw
+    if is_gzipped and buffered.peek(2)[:2] == b"\x1f\x8b":
+        return gzip.GzipFile(fileobj=buffered), raw
+    return buffered, raw
 
 
 class _CappedRead:
@@ -516,9 +521,12 @@ def fetch_tar_headers_streaming(
 ) -> list[str]:
     """Streaming counterpart of :func:`~meta_disco.fetchers.fetch_tar_headers`.
 
-    ``head_detector`` (injected by the caller, ``None`` -> read a single head) decides when
-    the members seen so far are conclusive, exactly as in the escalating fetcher — but here
-    the read escalates by streaming rather than re-decompressing a growing buffer.
+    ``head_detector`` is injected by the caller; ``None`` degrades to an always-conclusive
+    detector, which stops the walk at the first stage boundary (a single head — the compressed
+    cap never binds, since the detector concludes before it). It decides when the members seen
+    so far are conclusive; see :func:`_walk_tar_members` for how the stage-boundary gating
+    *approximates* (a bounded superset of) the escalating fetcher rather than mirroring it
+    byte-for-byte.
     """
     payload = _load_cached(TarEvidence, evidence_dir, md5sum, use_cache)
     if payload is not None:

--- a/src/meta_disco/streaming.py
+++ b/src/meta_disco/streaming.py
@@ -31,7 +31,7 @@ import io
 import tarfile
 import zlib
 
-from .evidence import FastaEvidence, FastqEvidence, GfaEvidence, TarEvidence, VcfEvidence
+from .evidence import FastaEvidence, FastqEvidence, GfaEvidence, SegmentTag, TarEvidence, VcfEvidence
 from .fetchers import (
     HEAD_BYTES,
     MAX_TAR_MEMBERS,
@@ -86,6 +86,7 @@ class _RawRangeReader(io.RawIOBase):
         self._pending = b""  # the current fetched range
         self._pos = 0  # read offset into _pending (advanced, not sliced, so reads stay O(n))
         self._fetched = 0  # total compressed bytes pulled from the origin
+        self._served = 0  # total bytes handed to the consumer via readinto
         self._chunk = FIRST_CHUNK
         self._eof = False
 
@@ -94,7 +95,19 @@ class _RawRangeReader(io.RawIOBase):
 
     @property
     def bytes_fetched(self) -> int:
+        """Total bytes pulled from the origin — the ``raw_bytes_fetched`` for evidence.
+
+        Runs *ahead* of what the consumer has read: a fill fetches a whole range (up to
+        ``FIRST_CHUNK``/``MAX_CHUNK``) at once, so this is not a position in the stream."""
         return self._fetched
+
+    @property
+    def bytes_served(self) -> int:
+        """Total bytes handed downstream via ``readinto`` — how far the consumer has actually
+        read, lagging ``bytes_fetched`` by the outstanding fill. The tar walk gates escalation
+        on this (not ``bytes_fetched``, which jumps a whole range ahead on the first fill and
+        would cross a stage boundary before any member is parsed)."""
+        return self._served
 
     @property
     def whole_file(self) -> bool:
@@ -136,6 +149,7 @@ class _RawRangeReader(io.RawIOBase):
         n = min(len(b), len(self._pending) - self._pos)
         b[:n] = memoryview(self._pending)[self._pos : self._pos + n]
         self._pos += n
+        self._served += n
         return n
 
 
@@ -295,12 +309,13 @@ def _walk_tar_members(stream, raw: "_RawRangeReader", *, detector, max_members: 
     """Member names from the head of a streamed, already-decompressed tar archive.
 
     ``detector`` gates *escalation*, not per-member stopping: it is consulted only once the
-    raw reader has crossed the next byte offset in ``stages``, on all members read so far —
-    mirroring the old fixed-head fetcher, which parses a whole byte-stage of members before
-    deciding whether to read deeper. That is why a mixed archive is voted on its full head
-    sample rather than cut at the first recognized member. Walking stops when the detector is
-    conclusive at a stage boundary, at ``max_members``, or when the stream ends / is cut short
-    (a truncated or non-tar head raises ``TarError`` / ``EOFError`` / a gzip error, caught
+    consumer has read past the next byte offset in ``stages`` (``raw.bytes_served``, i.e. bytes
+    actually parsed, not the whole range prefetched into the reader), on all members read so
+    far — mirroring the old fixed-head fetcher, which parses a whole byte-stage of members
+    before deciding whether to read deeper. That is why a mixed archive is voted on its full
+    head sample rather than cut at the first recognized member. Walking stops when the detector
+    is conclusive at a stage boundary, at ``max_members``, or when the stream ends / is cut
+    short (a truncated or non-tar head raises ``TarError`` / ``EOFError`` / a gzip error, caught
     here — the names read before the cut are the result). A non-tar head yields ``[]``.
     """
     names: list[str] = []
@@ -312,7 +327,7 @@ def _walk_tar_members(stream, raw: "_RawRangeReader", *, detector, max_members: 
                 if len(names) >= max_members:
                     break
                 crossed = False
-                while pending and raw.bytes_fetched >= pending[0]:
+                while pending and raw.bytes_served >= pending[0]:
                     pending.pop(0)
                     crossed = True
                 if crossed and detector(names):
@@ -437,7 +452,7 @@ def fetch_gfa_segment_tags_streaming(
     use_cache: bool = True,
     url: str | None = None,
     **kwargs,
-):
+) -> list[SegmentTag]:
     """Streaming counterpart of :func:`~meta_disco.fetchers.fetch_gfa_segment_tags`."""
     payload = _load_cached(GfaEvidence, evidence_dir, md5sum, use_cache)
     if payload is not None:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,357 @@
+"""Unit tests for the streaming read path (#264).
+
+Everything here mocks ``streaming._fetch_range`` to serve a fixed in-memory object in
+response to byte ranges, so nothing touches the network. Coverage: the escalating
+range reader, gzip / concatenated-gzip decode, the decompressed-byte cap (bomb defense),
+the truncation rule, each line matcher, the tar walk, and the five fetchers end to end
+(including equivalence with their fixed-window counterparts on identical bytes).
+"""
+
+import gzip
+import io
+import tarfile
+
+import pytest
+import requests
+
+import meta_disco.fetchers as fetchers
+import meta_disco.streaming as streaming
+from meta_disco.evidence import VcfEvidence
+from meta_disco.fetchers import FetchError, RangeNotSatisfiable
+from meta_disco.streaming import (
+    _FastaMatcher,
+    _FastqMatcher,
+    _iter_lines,
+    _open_stream,
+    _RawRangeReader,
+    _read_head_text,
+    _scan_lines,
+    _VcfMatcher,
+    _walk_tar_members,
+    fetch_fasta_headers_streaming,
+    fetch_fastq_reads_streaming,
+    fetch_gfa_segment_tags_streaming,
+    fetch_tar_headers_streaming,
+    fetch_vcf_header_streaming,
+)
+
+MD5 = "a" * 32
+
+
+def _range_server(obj: bytes, calls: list | None = None):
+    """A fake ``_fetch_range`` serving ``obj`` by range; a start at/past EOF raises 416."""
+
+    def fake(md5sum, end_byte, timeout=60, url=None, start_byte=0):
+        if calls is not None:
+            calls.append((start_byte, end_byte))
+        if start_byte >= len(obj):
+            raise RangeNotSatisfiable("HTTP 416")
+        return obj[start_byte : end_byte + 1]
+
+    return fake
+
+
+def _install(monkeypatch, obj: bytes, calls: list | None = None) -> None:
+    monkeypatch.setattr(streaming, "_fetch_range", _range_server(obj, calls))
+
+
+def _make_tar(names: list[str], *, gzipped: bool = False) -> bytes:
+    """Build an in-memory tar (or tar.gz) of empty members with the given names."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz" if gzipped else "w") as tar:
+        for name in names:
+            tar.addfile(tarfile.TarInfo(name), io.BytesIO(b""))
+    return buf.getvalue()
+
+
+@pytest.fixture
+def evidence_dir(tmp_path):
+    return tmp_path / "ev"
+
+
+# --- _RawRangeReader ---------------------------------------------------------------
+
+
+def test_raw_reader_reassembles_object_in_few_ranges(monkeypatch):
+    obj = bytes(range(256)) * 8000  # ~2 MB, spans several geometric ranges
+    calls: list = []
+    _install(monkeypatch, obj, calls)
+
+    reader = _RawRangeReader(MD5, url=None, cap=len(obj))
+    got = io.BufferedReader(reader).read()
+
+    assert got == obj
+    assert reader.bytes_fetched == len(obj)
+    assert len(calls) <= 4  # geometric growth keeps round-trips low, not one-per-8KB
+
+
+def test_raw_reader_stops_at_compressed_cap(monkeypatch):
+    obj = b"x" * 1000
+    _install(monkeypatch, obj)
+
+    reader = _RawRangeReader(MD5, url=None, cap=500)
+    got = io.BufferedReader(reader).read()
+
+    assert got == obj[:500]
+    assert reader.bytes_fetched == 500
+
+
+def test_raw_reader_416_on_first_range_raises(monkeypatch):
+    # An empty/absent object 416s on the very first range: that is a read failure, not EOF,
+    # so it propagates (mirrors _read_head_until's `if not buf: raise`) rather than yielding
+    # an empty-but-successful head.
+    _install(monkeypatch, b"")
+
+    reader = _RawRangeReader(MD5, url=None, cap=1000)
+    with pytest.raises(RangeNotSatisfiable):
+        io.BufferedReader(reader).read()
+
+
+def test_raw_reader_416_after_bytes_is_eof(monkeypatch):
+    # A 416 on a later range (the object ended exactly on the prior boundary) is clean EOF.
+    obj = b"x" * 100
+    monkeypatch.setattr(streaming, "FIRST_CHUNK", 100)  # first range returns exactly 100 (not short)
+    _install(monkeypatch, obj)
+
+    reader = _RawRangeReader(MD5, url=None, cap=1000)
+    assert io.BufferedReader(reader).read() == obj
+    assert reader.whole_file is True
+
+
+# --- decompression / line drivers --------------------------------------------------
+
+
+def test_iter_lines_plain_stream(monkeypatch):
+    _install(monkeypatch, b"aaa\nbbb\nccc")  # no trailing newline
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=False, compressed_cap=1 << 20)
+    assert list(_iter_lines(stream, raw, cap=1 << 20)) == ["aaa", "bbb", "ccc"]
+
+
+def test_iter_lines_decodes_gzip(monkeypatch):
+    _install(monkeypatch, gzip.compress(b"##head\n#CHROM\n"))
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=True, compressed_cap=1 << 20)
+    assert list(_iter_lines(stream, raw, cap=1 << 20)) == ["##head", "#CHROM"]
+
+
+def test_iter_lines_decodes_concatenated_gzip_members(monkeypatch):
+    # BGZF and `cat a.gz b.gz` are concatenated gzip members; GzipFile must read past the
+    # first, unlike the fixed-window fetchers.
+    _install(monkeypatch, gzip.compress(b"a\n") + gzip.compress(b"b\nc"))
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=True, compressed_cap=1 << 20)
+    assert list(_iter_lines(stream, raw, cap=1 << 20)) == ["a", "b", "c"]
+
+
+def test_iter_lines_drops_partial_trailing_line_when_decompressed_cap_hit(monkeypatch):
+    _install(monkeypatch, b"aaa\nbbbbb")
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=False, compressed_cap=1 << 20)
+    # the decompressed cap cuts inside "bbbbb": that partial record is dropped, "aaa" kept.
+    assert list(_iter_lines(stream, raw, cap=5)) == ["aaa"]
+
+
+def test_compressed_cap_truncation_is_visible(monkeypatch):
+    # A non-gzip object larger than its compressed cap: stopping at the cap returns 0 bytes
+    # just like EOF, so completeness must come from raw.whole_file — else the partial final
+    # line is wrongly kept as a whole record.
+    _install(monkeypatch, b"aaa\nbbb\ncccccc")
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=False, compressed_cap=10)  # cuts inside "cccccc"
+    text, truncated = _read_head_text(stream, raw, cap=1 << 20)
+    assert truncated is True
+    assert text == "aaa\nbbb\ncc"
+
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=False, compressed_cap=10)
+    assert list(_iter_lines(stream, raw, cap=1 << 20)) == ["aaa", "bbb"]  # partial "cc" dropped
+
+
+def test_read_head_text_reports_completion(monkeypatch):
+    _install(monkeypatch, gzip.compress(b"hello\nworld\n"))
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=True, compressed_cap=1 << 20)
+    text, truncated = _read_head_text(stream, raw, cap=1 << 20)
+    assert text == "hello\nworld\n"
+    assert truncated is False
+
+
+def test_read_head_text_caps_a_decompression_bomb(monkeypatch):
+    # ~1 MB of one repeated byte compresses tiny; the cap bounds the decompressed output.
+    _install(monkeypatch, gzip.compress(b"X" * 1_000_000))
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=True, compressed_cap=1 << 20)
+    text, truncated = _read_head_text(stream, raw, cap=1000)
+    assert len(text) == 1000
+    assert truncated is True
+
+
+# --- matchers ----------------------------------------------------------------------
+
+
+def test_vcf_matcher_splits_header_and_variants():
+    m = _VcfMatcher(max_variants=2)
+    assert m.feed("##fileformat=VCFv4.2") is False
+    assert m.feed("#CHROM\tPOS") is False
+    assert m.feed("1\t100") is False
+    assert m.feed("1\t200") is True  # second variant → satisfied
+    assert m.header_lines == ["##fileformat=VCFv4.2", "#CHROM\tPOS"]
+    assert m.variant_lines == ["1\t100", "1\t200"]
+
+
+def test_fastq_matcher_skips_three_lines_per_read():
+    m = _FastqMatcher(num_reads=2)
+    feeds = [m.feed(line) for line in ["@r1", "ACGT", "+", "IIII", "@r2", "ACGT"]]
+    assert m.read_names == ["@r1", "@r2"]
+    assert feeds[4] is True  # satisfied on the second read name
+
+
+def test_fasta_matcher_collects_contig_names():
+    m = _FastaMatcher()
+    for line in [">chr1 description", "ACGT", ">chr2", ">"]:
+        assert m.feed(line) is False  # never an early stop
+    assert m.contig_names == ["chr1", "chr2"]  # bare ">" yields no name
+
+
+# --- tar walk ----------------------------------------------------------------------
+
+
+def test_walk_tar_stops_at_stage_boundary_when_conclusive(monkeypatch):
+    # stages=(1,): the first fetch pulls the whole small tar, so bytes_fetched crosses 1 after
+    # member 0, and the detector is consulted there.
+    _install(monkeypatch, _make_tar(["a.vcf", "b.txt", "c.bam"]))
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=False, compressed_cap=1 << 20)
+    names = _walk_tar_members(stream, raw, detector=lambda ns: "a.vcf" in ns, max_members=200, stages=(1,))
+    assert names == ["a.vcf"]
+
+
+def test_walk_tar_does_not_cut_at_first_recognized_member(monkeypatch):
+    # The bug this guards: applying the detector per-member cut a mixed archive at its first
+    # recognized member. With real stages a small tar never crosses a boundary, so the whole
+    # head is voted on — all members are returned, not just the leading outlier.
+    _install(monkeypatch, _make_tar(["outlier.fasta", "v1.vcf", "v2.vcf", "v3.vcf"]))
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=False, compressed_cap=1 << 20)
+    names = _walk_tar_members(stream, raw, detector=lambda ns: True, max_members=200, stages=streaming.TAR_HEAD_STAGES)
+    assert names == ["outlier.fasta", "v1.vcf", "v2.vcf", "v3.vcf"]
+
+
+def test_walk_tar_stops_at_max_members(monkeypatch):
+    _install(monkeypatch, _make_tar(["m0", "m1", "m2", "m3"]))
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=False, compressed_cap=1 << 20)
+    names = _walk_tar_members(stream, raw, detector=lambda ns: False, max_members=2, stages=(1,))
+    assert names == ["m0", "m1"]
+
+
+def test_walk_tar_reads_gzipped_archive(monkeypatch):
+    _install(monkeypatch, _make_tar(["only.vcf"], gzipped=True))
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=True, compressed_cap=1 << 20)
+    names = _walk_tar_members(stream, raw, detector=lambda ns: False, max_members=200, stages=(1,))
+    assert names == ["only.vcf"]
+
+
+def test_walk_tar_non_tar_head_is_empty(monkeypatch):
+    _install(monkeypatch, b"not a tar at all, just bytes")
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=False, compressed_cap=1 << 20)
+    assert _walk_tar_members(stream, raw, detector=lambda ns: False, max_members=200, stages=(1,)) == []
+
+
+# --- scan driver -------------------------------------------------------------------
+
+
+def test_scan_lines_stops_early_on_matcher(monkeypatch):
+    _install(monkeypatch, b"\n".join(b"line%d" % i for i in range(1000)))
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=False, compressed_cap=1 << 20)
+    m = _scan_lines(stream, raw, cap=1 << 20, matcher=_FastqMatcher(num_reads=1))
+    # no "@" lines → matcher never satisfied → it read the whole (capped) head cleanly
+    assert m.read_names == []
+
+
+# --- error propagation -------------------------------------------------------------
+
+
+def _raise_transport(*_args, **_kwargs):
+    raise requests.exceptions.ConnectionError("connection reset")
+
+
+def test_transport_error_propagates_as_fetch_error(monkeypatch, evidence_dir):
+    # requests exceptions subclass OSError; they must NOT be swallowed by the gzip-truncation
+    # except clauses — a mid-read network failure surfaces as FetchError, not a silent empty read.
+    monkeypatch.setattr(streaming, "_fetch_range", _raise_transport)
+    with pytest.raises(FetchError):
+        fetch_fasta_headers_streaming(evidence_dir, MD5, is_gzipped=False, use_cache=False)
+
+
+def test_transport_error_in_tar_walk_propagates(monkeypatch, evidence_dir):
+    monkeypatch.setattr(streaming, "_fetch_range", _raise_transport)
+    with pytest.raises(FetchError):
+        fetch_tar_headers_streaming(evidence_dir, MD5, is_gzipped=False, use_cache=False)
+
+
+def test_first_range_416_raises_not_empty_success(monkeypatch, evidence_dir):
+    # An empty/absent object must raise (kept as not_classified), not cache an empty-list success.
+    _install(monkeypatch, b"")
+    with pytest.raises(FetchError):
+        fetch_fasta_headers_streaming(evidence_dir, MD5, is_gzipped=False, use_cache=False)
+
+
+# --- fetchers end to end -----------------------------------------------------------
+
+
+def test_fetch_vcf_streaming_returns_header_and_caches(monkeypatch, evidence_dir):
+    obj = gzip.compress(b"##fileformat=VCFv4.2\n#CHROM\tPOS\tID\n1\t100\t.\n")
+    _install(monkeypatch, obj)
+
+    header = fetch_vcf_header_streaming(evidence_dir, MD5, is_gzipped=True, use_cache=False)
+    assert header == "##fileformat=VCFv4.2\n#CHROM\tPOS\tID"
+
+    cached = VcfEvidence.load(evidence_dir, MD5)
+    assert cached is not None and cached.payload == header
+
+    # a second call hits the cache and never re-fetches
+    monkeypatch.setattr(streaming, "_fetch_range", lambda *a, **k: pytest.fail("re-fetched a cached VCF"))
+    assert fetch_vcf_header_streaming(evidence_dir, MD5, is_gzipped=True, use_cache=True) == header
+
+
+def test_fetch_vcf_streaming_matches_fixed_window(monkeypatch, evidence_dir):
+    obj = gzip.compress(b"##fileformat=VCFv4.2\n#CHROM\tPOS\tID\n1\t100\t.\n1\t200\t.\n")
+    monkeypatch.setattr(streaming, "_fetch_range", _range_server(obj))
+    monkeypatch.setattr(fetchers, "_fetch_range", _range_server(obj))
+
+    new = fetch_vcf_header_streaming(evidence_dir / "new", MD5, is_gzipped=True, use_cache=False)
+    old = fetchers.fetch_vcf_header(evidence_dir / "old", MD5, is_gzipped=True, use_cache=False)
+    assert new == old
+
+
+def test_fetch_vcf_streaming_no_header_raises(monkeypatch, evidence_dir):
+    _install(monkeypatch, gzip.compress(b"1\t100\t.\n2\t200\t.\n"))
+    with pytest.raises(FetchError):
+        fetch_vcf_header_streaming(evidence_dir, MD5, is_gzipped=True, use_cache=False)
+
+
+def test_fetch_fastq_streaming(monkeypatch, evidence_dir):
+    _install(monkeypatch, gzip.compress(b"@r1\nACGT\n+\nIIII\n@r2\nTTTT\n+\nIIII\n"))
+    assert fetch_fastq_reads_streaming(evidence_dir, MD5, is_gzipped=True, use_cache=False) == ["@r1", "@r2"]
+
+
+def test_fetch_fasta_streaming(monkeypatch, evidence_dir):
+    _install(monkeypatch, gzip.compress(b">chr1 desc\nACGT\n>chr2\nTTTT\n"))
+    assert fetch_fasta_headers_streaming(evidence_dir, MD5, is_gzipped=True, use_cache=False) == ["chr1", "chr2"]
+
+
+def test_fetch_gfa_streaming(monkeypatch, evidence_dir):
+    _install(monkeypatch, b"S\t1\tACGT\tSN:Z:chr1\tSR:i:0\n")
+    tags = fetch_gfa_segment_tags_streaming(evidence_dir, MD5, is_gzipped=False, use_cache=False)
+    assert len(tags) == 1
+    assert tags[0].is_reference_backbone
+
+
+def test_fetch_tar_streaming_reads_whole_small_head(monkeypatch, evidence_dir):
+    # A tar smaller than the first stage never crosses a detector boundary, so its whole head
+    # is read and voted on — both members returned, regardless of the injected detector. (The
+    # detector's escalation role at a boundary is covered by the _walk_tar_members tests.)
+    obj = _make_tar(["x.vcf", "y.vcf"])
+
+    _install(monkeypatch, obj)
+    assert fetch_tar_headers_streaming(evidence_dir / "a", MD5, is_gzipped=False, use_cache=False) == [
+        "x.vcf",
+        "y.vcf",
+    ]
+
+    _install(monkeypatch, obj)
+    both = fetch_tar_headers_streaming(
+        evidence_dir / "b", MD5, is_gzipped=False, use_cache=False, head_detector=lambda ns: len(ns) >= 2
+    )
+    assert both == ["x.vcf", "y.vcf"]

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -239,11 +239,11 @@ def test_walk_tar_does_not_cut_at_first_recognized_member(monkeypatch):
 
 
 def test_walk_tar_stage_boundary_tracks_consumed_not_fetched_bytes(monkeypatch):
-    # The reader prefetches the whole (61 KiB) archive on the first fill, so bytes_fetched jumps
-    # to the end immediately. Keyed on bytes_fetched the 30 KiB stage would be crossed after
-    # member 0 (degenerating to a per-member early-stop → 1 name); keyed on bytes_served it is
-    # crossed only once tarfile has actually consumed that far, so the head is voted on many
-    # members and the walk still stops at the boundary rather than reading all 100.
+    # _walk_tar_members gates escalation on bytes_served (consumed). The reader prefetches the
+    # whole (61 KiB) archive on the first fill, so bytes_fetched jumps to the end immediately —
+    # gating on it would cross the 30 KiB stage after member 0 (a per-member early-stop → 1 name).
+    # Gating on bytes_served, the boundary is crossed only once tarfile has actually consumed that
+    # far, so the head is voted on many members and the walk still stops before reading all 100.
     _install(monkeypatch, _make_tar([f"m{i}.dat" for i in range(100)]))
     stream, raw = _open_stream(MD5, url=None, is_gzipped=False, compressed_cap=1 << 20)
     names = _walk_tar_members(stream, raw, detector=lambda ns: True, max_members=200, stages=(30_000,))

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -65,12 +65,14 @@ def _tags_json(tags):
     return [t.to_json() for t in tags]
 
 
-def _make_tar(names: list[str], *, gzipped: bool = False) -> bytes:
-    """Build an in-memory tar (or tar.gz) of empty members with the given names."""
+def _make_tar(names: list[str], *, gzipped: bool = False, body_len: int = 0) -> bytes:
+    """Build an in-memory tar (or tar.gz); each member gets a ``body_len``-byte body."""
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz" if gzipped else "w") as tar:
         for name in names:
-            tar.addfile(tarfile.TarInfo(name), io.BytesIO(b""))
+            info = tarfile.TarInfo(name)
+            info.size = body_len
+            tar.addfile(info, io.BytesIO(b"z" * body_len))
     return buf.getvalue()
 
 
@@ -386,3 +388,31 @@ def test_fetch_tar_streaming_reads_whole_small_head(monkeypatch, evidence_dir):
         evidence_dir / "b", MD5, is_gzipped=False, use_cache=False, head_detector=lambda ns: len(ns) >= 2
     )
     assert both == ["x.vcf", "y.vcf"]
+
+
+def test_fetch_tar_streaming_escalation_is_bounded_superset_of_old(monkeypatch, evidence_dir):
+    # Staged escalation (detector false at stage 1, true at a later stage) is NOT byte-equal to
+    # the old fixed-head fetcher: the detector is checked only at stage crossings and tarfile
+    # buffers ahead, so streaming overshoots a few members past the conclusive point. The
+    # contract we hold is a bounded superset — streaming never returns fewer members than old,
+    # both conclude on the same signal, and the extra are only near the boundary.
+    names = [f"m{i}.dat" for i in range(8)]
+    names[5] = "signal.vcf"  # signal member sits past stage 1
+    obj = _make_tar(names, body_len=1024)  # bodies spread member headers across the byte stages
+    detector = lambda ns: "signal.vcf" in ns  # noqa: E731
+
+    monkeypatch.setattr(fetchers, "TAR_HEAD_STAGES", (4000, 9000, 20000))
+    monkeypatch.setattr(streaming, "TAR_HEAD_STAGES", (4000, 9000, 20000))
+    monkeypatch.setattr(streaming, "FIRST_CHUNK", 2048)  # force multi-fetch so bytes_served lags
+    _install_both(monkeypatch, obj)
+
+    old = fetchers.fetch_tar_headers(
+        evidence_dir / "old", MD5, is_gzipped=False, use_cache=False, head_detector=detector
+    )
+    new = fetch_tar_headers_streaming(
+        evidence_dir / "new", MD5, is_gzipped=False, use_cache=False, head_detector=detector
+    )
+
+    assert "signal.vcf" in old and "signal.vcf" in new  # both escalate to and conclude on the signal
+    assert set(old) <= set(new)  # bounded superset: streaming never drops a member old had
+    assert len(new) >= len(old)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -174,6 +174,17 @@ def test_compressed_cap_truncation_is_visible(monkeypatch):
     assert list(_iter_lines(stream, raw, cap=1 << 20)) == ["aaa", "bbb"]  # partial "cc" dropped
 
 
+def test_open_stream_only_gzips_when_magic_present(monkeypatch, evidence_dir):
+    # A file routed as gzipped (name ends .gz) whose bytes are NOT gzip must be read as raw
+    # text — matching legacy _decompress_head's magic check — not raised as BadGzipFile and
+    # dropped. An uncompressed VCF/FASTA misnamed .gz still yields its content.
+    _install_both(monkeypatch, b">chr1 desc\nACGT\n>chr2\nTTTT\n")  # plain FASTA, but is_gzipped=True
+    new = fetch_fasta_headers_streaming(evidence_dir / "new", MD5, is_gzipped=True, use_cache=False)
+    old = fetchers.fetch_fasta_headers(evidence_dir / "old", MD5, is_gzipped=True, use_cache=False)
+    assert new == ["chr1", "chr2"]
+    assert new == old
+
+
 def test_read_head_text_reports_completion(monkeypatch):
     _install(monkeypatch, gzip.compress(b"hello\nworld\n"))
     stream, raw = _open_stream(MD5, url=None, is_gzipped=True, compressed_cap=1 << 20)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -55,6 +55,16 @@ def _install(monkeypatch, obj: bytes, calls: list | None = None) -> None:
     monkeypatch.setattr(streaming, "_fetch_range", _range_server(obj, calls))
 
 
+def _install_both(monkeypatch, obj: bytes) -> None:
+    """Serve the same bytes to both the streaming and fixed-window read paths."""
+    monkeypatch.setattr(streaming, "_fetch_range", _range_server(obj))
+    monkeypatch.setattr(fetchers, "_fetch_range", _range_server(obj))
+
+
+def _tags_json(tags):
+    return [t.to_json() for t in tags]
+
+
 def _make_tar(names: list[str], *, gzipped: bool = False) -> bytes:
     """Build an in-memory tar (or tar.gz) of empty members with the given names."""
     buf = io.BytesIO()
@@ -334,20 +344,29 @@ def test_fetch_vcf_streaming_no_header_raises(monkeypatch, evidence_dir):
 
 
 def test_fetch_fastq_streaming(monkeypatch, evidence_dir):
-    _install(monkeypatch, gzip.compress(b"@r1\nACGT\n+\nIIII\n@r2\nTTTT\n+\nIIII\n"))
-    assert fetch_fastq_reads_streaming(evidence_dir, MD5, is_gzipped=True, use_cache=False) == ["@r1", "@r2"]
+    _install_both(monkeypatch, gzip.compress(b"@r1\nACGT\n+\nIIII\n@r2\nTTTT\n+\nIIII\n"))
+    new = fetch_fastq_reads_streaming(evidence_dir / "new", MD5, is_gzipped=True, use_cache=False)
+    old = fetchers.fetch_fastq_reads(evidence_dir / "old", MD5, is_gzipped=True, use_cache=False)
+    assert new == ["@r1", "@r2"]
+    assert new == old  # drop-in equivalent on identical bytes
 
 
 def test_fetch_fasta_streaming(monkeypatch, evidence_dir):
-    _install(monkeypatch, gzip.compress(b">chr1 desc\nACGT\n>chr2\nTTTT\n"))
-    assert fetch_fasta_headers_streaming(evidence_dir, MD5, is_gzipped=True, use_cache=False) == ["chr1", "chr2"]
+    _install_both(monkeypatch, gzip.compress(b">chr1 desc\nACGT\n>chr2\nTTTT\n"))
+    new = fetch_fasta_headers_streaming(evidence_dir / "new", MD5, is_gzipped=True, use_cache=False)
+    old = fetchers.fetch_fasta_headers(evidence_dir / "old", MD5, is_gzipped=True, use_cache=False)
+    assert new == ["chr1", "chr2"]
+    assert new == old
 
 
 def test_fetch_gfa_streaming(monkeypatch, evidence_dir):
-    _install(monkeypatch, b"S\t1\tACGT\tSN:Z:chr1\tSR:i:0\n")
-    tags = fetch_gfa_segment_tags_streaming(evidence_dir, MD5, is_gzipped=False, use_cache=False)
-    assert len(tags) == 1
-    assert tags[0].is_reference_backbone
+    _install_both(monkeypatch, b"S\t1\tACGT\tSN:Z:chr1\tSR:i:0\n")
+    new = fetch_gfa_segment_tags_streaming(evidence_dir / "new", MD5, is_gzipped=False, use_cache=False)
+    old = fetchers.fetch_gfa_segment_tags(evidence_dir / "old", MD5, is_gzipped=False, use_cache=False)
+    assert len(new) == 1
+    assert new[0].is_reference_backbone
+    # equivalence covers the truncated derivation (raw.whole_file vs got_whole_file+stream_complete)
+    assert _tags_json(new) == _tags_json(old)
 
 
 def test_fetch_tar_streaming_reads_whole_small_head(monkeypatch, evidence_dir):
@@ -356,11 +375,11 @@ def test_fetch_tar_streaming_reads_whole_small_head(monkeypatch, evidence_dir):
     # detector's escalation role at a boundary is covered by the _walk_tar_members tests.)
     obj = _make_tar(["x.vcf", "y.vcf"])
 
-    _install(monkeypatch, obj)
-    assert fetch_tar_headers_streaming(evidence_dir / "a", MD5, is_gzipped=False, use_cache=False) == [
-        "x.vcf",
-        "y.vcf",
-    ]
+    _install_both(monkeypatch, obj)
+    new = fetch_tar_headers_streaming(evidence_dir / "new", MD5, is_gzipped=False, use_cache=False)
+    old = fetchers.fetch_tar_headers(evidence_dir / "old", MD5, is_gzipped=False, use_cache=False)
+    assert new == ["x.vcf", "y.vcf"]
+    assert new == old  # both read the whole small head and return every member
 
     _install(monkeypatch, obj)
     both = fetch_tar_headers_streaming(

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -228,6 +228,18 @@ def test_walk_tar_does_not_cut_at_first_recognized_member(monkeypatch):
     assert names == ["outlier.fasta", "v1.vcf", "v2.vcf", "v3.vcf"]
 
 
+def test_walk_tar_stage_boundary_tracks_consumed_not_fetched_bytes(monkeypatch):
+    # The reader prefetches the whole (61 KiB) archive on the first fill, so bytes_fetched jumps
+    # to the end immediately. Keyed on bytes_fetched the 30 KiB stage would be crossed after
+    # member 0 (degenerating to a per-member early-stop → 1 name); keyed on bytes_served it is
+    # crossed only once tarfile has actually consumed that far, so the head is voted on many
+    # members and the walk still stops at the boundary rather than reading all 100.
+    _install(monkeypatch, _make_tar([f"m{i}.dat" for i in range(100)]))
+    stream, raw = _open_stream(MD5, url=None, is_gzipped=False, compressed_cap=1 << 20)
+    names = _walk_tar_members(stream, raw, detector=lambda ns: True, max_members=200, stages=(30_000,))
+    assert 1 < len(names) < 100
+
+
 def test_walk_tar_stops_at_max_members(monkeypatch):
     _install(monkeypatch, _make_tar(["m0", "m1", "m2", "m3"]))
     stream, raw = _open_stream(MD5, url=None, is_gzipped=False, compressed_cap=1 << 20)


### PR DESCRIPTION
Closes #264. Stage 1 of #263 (unify range-based fetchers onto one streaming read path).

## What changed

A new module `src/meta_disco/streaming.py` builds one streaming read path for the five range-based fetchers, **wired into nothing** — the production path (`pipeline.py`, `file_types.py`, `fetchers.py`) is untouched. It has:

- **`_RawRangeReader(io.RawIOBase)`** — forward-only bytes fetched in escalating ranges (geometric growth), reusing #260's `_fetch_range` / `RangeNotSatisfiable` / `Content-Range` alignment; tracks `bytes_fetched` and `whole_file` (genuine object-EOF vs a compressed-cap stop).
- **`_open_stream`** — wraps the reader in `gzip.GzipFile` when gzipped (transparent multi-member / BGZF).
- **`_CappedRead` + line drivers** (`_iter_lines`, `_read_head_text`), three matcher classes (VCF / FASTQ / FASTA), and a **stage-boundary tar walk** (`_walk_tar_members`).
- **Five `fetch_*_streaming` functions** — same signatures and evidence records as `fetchers.py`, so old and new are drop-in interchangeable.

Plus `scripts/compare_streaming.py`: a differential harness (manual, live-S3) that diffs old vs new at fetcher-output and final-classification level over a per-type sample.

Bomb-safety is structural: the line readers bound decompressed output (`MAX_DECOMPRESSED`) and discard as they scan; the tar walk streams member bodies past without materializing them.

## Why

#259 (decompression-bomb defense) plus the cap-vs-escalation conflict from #260 plus five duplicated read paths all dissolve if every fetcher reads the same way: stream bytes, decompress on the fly, feed a matcher that stops when it has what it needs. This PR builds that path alongside the current one so it can be validated by shadow-diff on real files before any cutover — a read-depth change can shift outputs, and the only way to know is to measure it against live S3.

## Assumptions I made

- **BAM/CRAM stays on samtools** (out of scope, per #263): its compression is fused with the container structure, and htslib already does the range fetch optimally.
- **Caps mirror each old fetcher's window exactly**, including the old inclusive-`end_byte` `+1` (VCF 1 MiB+1; FASTQ/FASTA 256 KiB+1; GFA 256 KiB), so the shadow-diff isolates the architecture change from a change in how much is fetched.
- **The tar detector gates escalation, not per-member stopping.** It is consulted only at byte-stage boundaries on the members read so far, so a mixed archive is voted on a head sample rather than cut at the first recognized member. This *approximates* the old staged escalation but is **not byte-identical**: streaming overshoots a few members past the conclusive point (buffered read-ahead + boundary-only checks), yielding a **bounded superset** of the old member set (never fewer, a handful more near the boundary). Whether that ever shifts a classification is exactly what the stage-2 shadow-diff measures — so tar equivalence is validated, not assumed.
- **A transport error mid-read is a fetch failure, not truncation.** The gzip-truncation `except` clauses catch only `EOFError`/`zlib.error`/`gzip.BadGzipFile`; a `requests` error (an `OSError` subclass) propagates as `FetchError`.
- **A first-range 416** (empty/absent object) raises rather than returning empty-success, mirroring `_read_head_until`'s `if not buf: raise`.
- **Streaming reads deeper than the fixed-window fetchers for BGZF** (all members, not just the first). This is intended and is exactly what the harness measures; a payload-level diff is expected and only matters if it flips a classification.

## How to verify

Definition of done (from #264):

- [x] `streaming.py` has the reader, `_open_stream`, both line drivers, three matchers, the tar walk, and the five streaming fetchers.
- [x] Unit tests cover: geometric escalation + compressed cap; gzip + concatenated-gzip decode; the decompressed-cap bomb truncation; `whole_file` / truncated derivation (incl. the compressed-cap case); each matcher's stop condition; the tar detector at a stage boundary + `MAX_TAR_MEMBERS`; transport-error propagation; and each fetcher end-to-end incl. old-vs-new equivalence.
- [x] The harness runs and produces a per-type old-vs-new diff (fetcher output + final classification).
- [x] Nothing in `pipeline.py` / `file_types.py` references `streaming.py` — production path untouched.
- [x] `make lint`, `make format-check`, `make type` (pyright 0 errors), `make test` (842 pass) are green.

To check locally:

```bash
make lint && make format-check && make type && make test
# Manual shadow-diff against live S3 (this is the stage-2 validation, a follow-up PR):
uv run python scripts/compare_streaming.py --per-type 40
```

The cutover + deletion of the old read code is a separate sub-issue, to be filed once this stage-2 validation is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
