### PR TITLE
Unify HPRC classification onto the shared meta-disco classifier (#276)

### DIFF
--- a/scripts/classify_headers.py
+++ b/scripts/classify_headers.py
@@ -94,6 +94,7 @@ def main():
             config,
             args.md5,
             use_cache=not args.no_resume,
+            evidence_base=args.evidence_base,
         )
         if result:
             print(json.dumps(result, indent=2))

--- a/scripts/classify_headers.py
+++ b/scripts/classify_headers.py
@@ -78,6 +78,12 @@ def main():
         action="store_true",
         help="Skip files that already have cached headers",
     )
+    parser.add_argument(
+        "--evidence-base",
+        type=Path,
+        default=Path("data/evidence/anvil"),
+        help="Evidence cache base directory (per source, e.g. data/evidence/hprc)",
+    )
 
     args = parser.parse_args()
     config = FILE_TYPE_REGISTRY[args.type]
@@ -104,6 +110,7 @@ def main():
         config,
         args.input,
         args.output,
+        evidence_base=args.evidence_base,
         limit=args.limit,
         resume=not args.no_resume,
         workers=args.workers,

--- a/scripts/classify_hprc_files.py
+++ b/scripts/classify_hprc_files.py
@@ -1,36 +1,44 @@
 #!/usr/bin/env python3
-"""Classify HPRC catalog files for validation against catalog metadata.
+"""Ingest the HPRC Data Explorer catalogs and classify them with the shared pipeline.
 
-Fetches headers from HPRC S3 URLs and classifies through the pipeline,
-then outputs classifications for comparison against HPRC ground truth.
+HPRC is a *source*, like AnVIL. This script maps its four GitHub catalogs into the one
+**meta-disco record shape** and calls the single classifier
+(``rerun_all_classifications.run_all_classifications``) — there is no HPRC-specific
+classification logic. Every source maps its native metadata into that shape and calls
+the same path.
 
-Catalogs handled:
-  - sequencing-data (6K files): BAM/FASTQ headers fetched from S3
-  - assemblies (560 files): FASTA contig names fetched from S3
-  - alignments (89 files): classified from filename only (graph formats)
-  - annotations (8.7K files): classified from filename only (.bed, .gff3, etc.)
+AnVIL's own catalog includes the HPRC dataset, and the HPRC Data Explorer's metadata is
+richer ground truth, so classifying the HPRC catalogs and comparing against them
+(``validate_against_hprc.py``) is how we quality-check our calls on the AnVIL HPRC files.
+
+Steps (issue #276):
+  1. Load the catalogs (downloaded by ``download_hprc_catalogs.py`` / ``make download-hprc``).
+  2. Fill ``file_size`` from S3 (HTTP HEAD) where the catalog omits it — only the
+     sequencing-data catalog does; assemblies/alignments/annotations carry ``fileSize``.
+  3. Map every record into the meta-disco shape (``file_name``, ``file_format``,
+     ``file_md5sum``, ``url``, ``file_size``) and write one metadata file.
+  4. Run the shared classifier over it, exactly as AnVIL does.
 """
 
 import argparse
 import hashlib
 import json
-from datetime import datetime
+import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from meta_disco.fetchers import (
-    FetchError,
-    fetch_bam_header,
-    fetch_fasta_headers,
-    fetch_fastq_reads,
-)
+from meta_disco.classify_run import run_all_classifications
+from meta_disco.fetchers import FetchError, fetch_content_length
 from meta_disco.file_name import FileName
-from meta_disco.header_classifier import (
-    classify_from_fasta_header,
-    classify_from_fastq_header,
-    classify_from_header,
-)
-from meta_disco.models import FileInfo
-from meta_disco.rule_engine import RuleEngine
+
+# The S3 location field differs per HPRC catalog; each maps to the meta-disco ``url``.
+# alignments/annotations also carry it, so every catalog record gets a real content URL.
+CATALOG_URL_FIELD = {
+    "sequencing-data": "path",
+    "assemblies": "awsFasta",
+    "alignments": "loc",
+    "annotations": "fileLocation",
+}
 
 
 def s3_to_https(s3_path: str) -> str:
@@ -41,289 +49,141 @@ def s3_to_https(s3_path: str) -> str:
     return s3_path
 
 
-def filename_key(filename: str) -> str:
-    """Generate a stable cache key from filename (HPRC catalogs don't provide MD5s)."""
-    return hashlib.md5(filename.encode()).hexdigest()
+def path_key(path: str) -> str:
+    """Stable cache key hashed from a file's FULL path/url (HPRC catalogs have no md5).
+
+    Keyed on the full path, not the basename: basenames collide across sample
+    directories (e.g. two ``…grch38.vcf.gz`` at different paths — 5 such HPRC files),
+    which would alias them in the evidence cache; full paths are unique (issue #276).
+    Returns a valid lowercase-hex md5, so it satisfies the input contract's
+    ``file_md5sum`` pattern and keys the evidence cache like a real md5. The uniform
+    ``hash(full path)`` cache key across all sources is the follow-up (#277).
+    """
+    return hashlib.md5(path.encode()).hexdigest()
 
 
-def classify_sequencing_data(
-    catalog: list[dict],
-    evidence_base: Path,
-    limit: int | None = None,
-) -> list[dict]:
-    """Classify sequencing-data catalog files (BAM/FASTQ) by fetching headers."""
-    bam_evidence = evidence_base / "bam"
-    fastq_evidence = evidence_base / "fastq"
-    bam_evidence.mkdir(parents=True, exist_ok=True)
-    fastq_evidence.mkdir(parents=True, exist_ok=True)
+def build_metadata_records(catalog: list[dict], url_field: str, *, workers: int) -> list[dict]:
+    """Map one HPRC catalog into meta-disco records, S3-HEAD-filling any missing file_size.
 
-    engine = RuleEngine()
-    records = catalog[:limit] if limit is not None else catalog
-    results = []
-    success = 0
-    skipped = 0
-
-    print(f"\nClassifying {len(records)} sequencing-data files...")
-
-    for i, rec in enumerate(records):
-        fn = rec.get("filename", "")
-        s3_path = rec.get("path", "")
-        url = s3_to_https(s3_path) if s3_path else None
-        key = filename_key(fn)
-        file_size = rec.get("fileSize")  # not available in sequencing catalog
-
-        if (i + 1) % 100 == 0 or i == 0:
-            print(f"  [{i + 1}/{len(records)}] {fn[:50]}", flush=True)
-
-        classifications = None
-
-        if fn.endswith((".bam", ".cram")):
-            # A FetchError (unreadable content) skips the file, as the pre-#155
-            # None return did; a missing-samtools FileNotFoundError still propagates.
-            try:
-                raw_data = fetch_bam_header(
-                    bam_evidence,
-                    key,
-                    file_name=fn,
-                    use_cache=True,
-                    url=url,
-                )
-                classifications = classify_from_header(
-                    raw_data,
-                    name=FileName.parse(fn),
-                    file_size=file_size,
-                    file_format=".cram" if fn.endswith(".cram") else ".bam",
-                )
-            except FetchError:
-                pass
-        elif fn.endswith((".fastq.gz", ".fastq")):
-            try:
-                raw_data = fetch_fastq_reads(
-                    fastq_evidence,
-                    key,
-                    file_name=fn,
-                    is_gzipped=fn.endswith(".gz"),
-                    use_cache=True,
-                    url=url,
-                )
-                classifications = classify_from_fastq_header(
-                    raw_data,
-                    name=FileName.parse(fn),
-                    file_size=file_size,
-                )
-            except FetchError:
-                pass
-        else:
-            # FAST5, POD5, etc. — classify from filename only
-            skipped += 1
-            result = engine.classify_extended(FileInfo.from_filename(fn, file_size=file_size))
-            classifications = result.to_output_dict()
-
-        if classifications:
-            success += 1
-            results.append(
-                {
-                    "file_name": fn,
-                    "key": key,
-                    "file_size": file_size,
-                    "classifications": classifications,
-                    "catalog": "sequencing-data",
-                }
-            )
-
-    print(f"  Classified: {success}, Skipped/failed: {len(records) - success}")
-    return results
-
-
-def classify_assemblies(
-    catalog: list[dict],
-    evidence_base: Path,
-    limit: int | None = None,
-) -> list[dict]:
-    """Classify assembly catalog files (FASTA) by fetching contig names."""
-    fasta_evidence = evidence_base / "fasta"
-    fasta_evidence.mkdir(parents=True, exist_ok=True)
-
-    records = catalog[:limit] if limit is not None else catalog
-    results = []
-    success = 0
-
-    print(f"\nClassifying {len(records)} assembly files...")
-
-    for i, rec in enumerate(records):
-        fn = rec.get("filename", "")
-        s3_path = rec.get("awsFasta", "")
-        url = s3_to_https(s3_path) if s3_path else None
-        key = filename_key(fn)
-        file_size = rec.get("fileSize")
-
-        if (i + 1) % 100 == 0 or i == 0:
-            print(f"  [{i + 1}/{len(records)}] {fn[:50]}", flush=True)
-
-        try:
-            raw_data = fetch_fasta_headers(
-                fasta_evidence,
-                key,
-                file_name=fn,
-                is_gzipped=fn.endswith(".gz"),
-                use_cache=True,
-                url=url,
-            )
-        except FetchError:
-            # Unreadable content skips the file, as the pre-#155 None return did.
-            continue
-
-        classifications = classify_from_fasta_header(
-            raw_data,
-            name=FileName.parse(fn),
-            file_size=file_size,
-        )
-        success += 1
-        results.append(
-            {
-                "file_name": fn,
-                "key": key,
-                "file_size": file_size,
-                "classifications": classifications,
-                "catalog": "assemblies",
-            }
-        )
-
-    print(f"  Classified: {success}, Failed: {len(records) - success}")
-    return results
-
-
-def classify_filename_only(
-    catalog: list[dict],
-    catalog_name: str,
-) -> list[dict]:
-    """Classify files from filename only (no header fetching)."""
-    engine = RuleEngine()
-    results = []
-
-    print(f"\nClassifying {len(catalog)} {catalog_name} files (filename only)...")
-
+    Each record carries the meta-disco fields the classifier reads: ``file_name``,
+    ``file_format``, ``file_md5sum`` (synthesized as the cache key — a hash of the full
+    path, not the basename, so same-named files at different paths don't collide),
+    ``url`` (explicit S3, from the catalog's own location field), and ``file_size``. A
+    size the catalog omits is read from S3 in parallel (HEAD); a size that cannot be
+    obtained is left ``None`` — never fabricated — so the classifier's contract gate
+    marks the file not_classified rather than guessing (issue #276). In practice only
+    the sequencing-data catalog lacks ``fileSize``; the others supply it and are never HEADed.
+    """
+    records = []
+    needs_size = []  # records missing a catalog fileSize — filled by S3 HEAD below
     for rec in catalog:
         fn = rec.get("filename", "")
-        if not fn:
-            continue
-        file_size = rec.get("fileSize")
-        result = engine.classify_extended(FileInfo.from_filename(fn, file_size=file_size))
-        results.append(
-            {
-                "file_name": fn,
-                "key": filename_key(fn),
-                "file_size": file_size,
-                "classifications": result.to_output_dict(),
-                "catalog": catalog_name,
-            }
-        )
+        s3_path = rec.get(url_field, "")
+        url = s3_to_https(s3_path) if s3_path else None
+        size = rec.get("fileSize")
+        record = {
+            "file_name": fn,
+            # file_format is the parsed core extension from the canonical FileName model
+            # (.bam/.cram/.fastq/.fa/.vcf/.gfa …), or "" when the name carries no known
+            # extension — never a junk last-dot suffix. The content-fetched types need it
+            # for the contract gate; the rest classify from the name via the catch-all.
+            "file_format": FileName.parse(fn).extension or "",
+            # Cache key = hash of the full path (the unique identity). No location means the
+            # file can't be read and can't be keyed, so file_md5sum is left None and the
+            # contract gate marks it not_classified — never a fabricated basename key (#276).
+            "file_md5sum": path_key(url) if url else None,
+            "url": url,
+            "file_size": size if isinstance(size, int) else None,
+        }
+        records.append(record)
+        if record["file_size"] is None and url:
+            needs_size.append(record)
 
-    print(f"  Classified: {len(results)}")
-    return results
+    if needs_size:
+        print(f"Fetching {len(needs_size)} file sizes from S3 (HEAD, {workers} workers)...", flush=True)
+
+        def fill_size(record: dict) -> bool:
+            try:
+                record["file_size"] = fetch_content_length(record["url"])
+                return True
+            except FetchError:
+                return False  # leave file_size None → the contract gate marks it not_classified
+
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            failed = sum(1 for ok in executor.map(fill_size, needs_size) if not ok)
+        if failed:
+            print(f"  {failed} size lookups failed — those files are not_classified (size unavailable)")
+
+    return records
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Classify HPRC catalog files for validation",
+        description="Map the HPRC catalogs into the meta-disco shape and run the shared classifier",
     )
     parser.add_argument(
         "--catalog-dir",
         type=Path,
         default=Path("data/hprc"),
-        help="Directory containing HPRC catalog JSON files",
+        help="Directory containing the downloaded HPRC catalog JSON files",
+    )
+    parser.add_argument(
+        "--metadata-out",
+        type=Path,
+        default=Path("data/hprc/hprc_files_metadata.json"),
+        help="Where to write the mapped meta-disco metadata file (the classifier's input)",
     )
     parser.add_argument(
         "--output-dir",
         type=Path,
         default=Path("output/hprc"),
-        help="Output directory for classification results",
+        help="Base output directory for classification run dirs",
     )
     parser.add_argument(
         "--evidence-base",
         type=Path,
         default=Path("data/evidence/hprc"),
-        help="Evidence cache base directory",
+        help="Evidence cache base directory for HPRC header fetches",
     )
     parser.add_argument(
         "--limit",
         "-l",
         type=int,
         default=None,
-        help="Limit files per catalog (for testing)",
+        help="Limit records per catalog (for testing)",
     )
     parser.add_argument(
-        "--catalogs",
-        type=str,
-        default="all",
-        help="Comma-separated catalogs to classify (sequencing,assemblies,alignments,annotations or all)",
+        "--workers",
+        "-w",
+        type=int,
+        default=30,
+        help="Parallel workers for the S3 HEAD size lookups and the header fetches",
     )
     args = parser.parse_args()
 
-    # Create timestamped output directory
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_dir = args.output_dir / timestamp
-    output_dir.mkdir(parents=True, exist_ok=True)
+    all_records = []
+    for catalog_name, url_field in CATALOG_URL_FIELD.items():
+        catalog_path = args.catalog_dir / f"{catalog_name}.json"
+        if not catalog_path.exists():
+            print(f"  Skipping {catalog_name} (not found: {catalog_path}); run `make download-hprc` first")
+            continue
+        with catalog_path.open() as f:
+            catalog = json.load(f)
+        if args.limit is not None:
+            catalog = catalog[: args.limit]
+        print(f"Mapping {len(catalog)} {catalog_name} records into the meta-disco shape...")
+        all_records += build_metadata_records(catalog, url_field, workers=args.workers)
 
-    catalogs_to_run = (
-        args.catalogs.split(",")
-        if args.catalogs != "all"
-        else ["sequencing", "assemblies", "alignments", "annotations"]
-    )
+    args.metadata_out.parent.mkdir(parents=True, exist_ok=True)
+    with args.metadata_out.open("w") as f:
+        # "files" is the canonical meta-disco metadata key (what the AnVIL source emits);
+        # every classifier loads it, so the mapped HPRC input is shape-identical to AnVIL's.
+        json.dump({"files": all_records}, f)
+    print(f"Wrote {len(all_records):,} meta-disco records to {args.metadata_out}")
 
-    all_results = {}
-
-    # Load and classify each catalog
-    if "sequencing" in catalogs_to_run:
-        catalog_path = args.catalog_dir / "sequencing-data.json"
-        if catalog_path.exists():
-            with catalog_path.open() as f:
-                catalog = json.load(f)
-            results = classify_sequencing_data(catalog, args.evidence_base, limit=args.limit)
-            all_results["sequencing"] = results
-            with (output_dir / "sequencing_classifications.json").open("w") as f:
-                json.dump({"classifications": results, "metadata": {"total": len(results)}}, f, indent=2)
-
-    if "assemblies" in catalogs_to_run:
-        catalog_path = args.catalog_dir / "assemblies.json"
-        if catalog_path.exists():
-            with catalog_path.open() as f:
-                catalog = json.load(f)
-            results = classify_assemblies(catalog, args.evidence_base, limit=args.limit)
-            all_results["assemblies"] = results
-            with (output_dir / "assembly_classifications.json").open("w") as f:
-                json.dump({"classifications": results, "metadata": {"total": len(results)}}, f, indent=2)
-
-    if "alignments" in catalogs_to_run:
-        catalog_path = args.catalog_dir / "alignments.json"
-        if catalog_path.exists():
-            with catalog_path.open() as f:
-                catalog = json.load(f)
-            results = classify_filename_only(catalog, "alignments")
-            all_results["alignments"] = results
-            with (output_dir / "alignment_classifications.json").open("w") as f:
-                json.dump({"classifications": results, "metadata": {"total": len(results)}}, f, indent=2)
-
-    if "annotations" in catalogs_to_run:
-        catalog_path = args.catalog_dir / "annotations.json"
-        if catalog_path.exists():
-            with catalog_path.open() as f:
-                catalog = json.load(f)
-            results = classify_filename_only(catalog, "annotations")
-            all_results["annotations"] = results
-            with (output_dir / "annotation_classifications.json").open("w") as f:
-                json.dump({"classifications": results, "metadata": {"total": len(results)}}, f, indent=2)
-
-    # Summary
-    print(f"\n{'=' * 70}")
-    print("HPRC CLASSIFICATION SUMMARY")
-    print(f"{'=' * 70}")
-    total = 0
-    for name, results in all_results.items():
-        print(f"  {name}: {len(results)}")
-        total += len(results)
-    print(f"  Total: {total}")
-    print(f"\nOutput: {output_dir}/")
+    # Step 4: call the one classifier, exactly as AnVIL does; propagate its success.
+    ok = run_all_classifications(args.metadata_out, args.output_dir, args.evidence_base, workers=args.workers)
+    sys.exit(0 if ok else 1)
 
 
 if __name__ == "__main__":

--- a/scripts/classify_hprc_files.py
+++ b/scripts/classify_hprc_files.py
@@ -32,7 +32,8 @@ from meta_disco.fetchers import FetchError, fetch_content_length
 from meta_disco.file_name import FileName
 
 # The S3 location field differs per HPRC catalog; each maps to the meta-disco ``url``.
-# alignments/annotations also carry it, so every catalog record gets a real content URL.
+# All four catalogs carry one, so records normally get a content URL — but a record that
+# omits it maps to url=None and is left not_classified (never fetched from a guessed URL).
 CATALOG_URL_FIELD = {
     "sequencing-data": "path",
     "assemblies": "awsFasta",

--- a/scripts/classify_hprc_files.py
+++ b/scripts/classify_hprc_files.py
@@ -3,7 +3,7 @@
 
 HPRC is a *source*, like AnVIL. This script maps its four GitHub catalogs into the one
 **meta-disco record shape** and calls the single classifier
-(``rerun_all_classifications.run_all_classifications``) — there is no HPRC-specific
+(``meta_disco.classify_run.run_all_classifications``) — there is no HPRC-specific
 classification logic. Every source maps its native metadata into that shape and calls
 the same path.
 

--- a/scripts/rerun_all_classifications.py
+++ b/scripts/rerun_all_classifications.py
@@ -6,6 +6,7 @@ path shared with the HPRC source); this script is just the AnVIL-facing entry po
 """
 
 import argparse
+import sys
 from pathlib import Path
 
 from meta_disco.classify_run import run_all_classifications
@@ -42,7 +43,8 @@ def main():
         "for a cold full re-fetch of the network-bound long poles)",
     )
     args = parser.parse_args()
-    run_all_classifications(args.metadata, args.output_dir, args.evidence_base, workers=args.workers)
+    ok = run_all_classifications(args.metadata, args.output_dir, args.evidence_base, workers=args.workers)
+    sys.exit(0 if ok else 1)
 
 
 if __name__ == "__main__":

--- a/scripts/rerun_all_classifications.py
+++ b/scripts/rerun_all_classifications.py
@@ -1,68 +1,14 @@
 #!/usr/bin/env python3
-"""Re-run all classification scripts with timestamped output.
+"""CLI wrapper: run all classifications over the AnVIL metadata, with timestamped output.
 
-Uses cached headers from previous runs and applies updated classification rules.
-Runs independent classifiers in parallel for speed.
+The orchestration itself lives in ``meta_disco.classify_run`` (the single classification
+path shared with the HPRC source); this script is just the AnVIL-facing entry point.
 """
 
 import argparse
-import subprocess
-import sys
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime
 from pathlib import Path
 
-from meta_disco.file_types import FILE_TYPE_REGISTRY
-
-# Phase 1 classifiers that are NOT header-based, so they have their own script
-# rather than a FILE_TYPE_REGISTRY entry.
-NON_HEADER_JOBS = (
-    ("classify_bed_files.py", "bed_classifications.json"),
-    ("classify_images.py", "image_classifications.json"),
-    ("classify_auxiliary_genomic.py", "auxiliary_classifications.json"),
-)
-
-
-def build_parallel_jobs(metadata: Path, output_dir: Path) -> list[tuple]:
-    """Phase 1 jobs: one per header-based file type, plus the non-header scripts.
-
-    The header jobs are derived from FILE_TYPE_REGISTRY rather than hand-listed,
-    so registering a new file type cannot silently skip production. That is what
-    happened to `gfa` in #151: it was added to the registry and to nothing else,
-    so `make classify` never invoked it and graph files fell through to the
-    filename-only Phase 3 catch-all.
-
-    Every output filename here must also appear in output_utils.CLASSIFICATION_FILES
-    or the reports will not read it — pinned by tests/test_orchestration.py.
-    """
-    jobs = [
-        (
-            "classify_headers.py",
-            output_dir / f"{ftype}_classifications.json",
-            ["--type", ftype, "--input", str(metadata)],
-        )
-        for ftype in FILE_TYPE_REGISTRY
-    ]
-    jobs += [(script, output_dir / out, ["--metadata", str(metadata)]) for script, out in NON_HEADER_JOBS]
-    return jobs
-
-
-def run_script(script_name: str, output_path: Path, extra_args: list[str] | None = None):
-    """Run a classification script."""
-    cmd = [sys.executable, f"scripts/{script_name}", "--output", str(output_path)]
-    if extra_args:
-        cmd.extend(extra_args)
-
-    print(f"  Starting: {script_name}")
-
-    result = subprocess.run(cmd, cwd=Path(__file__).parent.parent, capture_output=True, text=True)
-    if result.returncode != 0:
-        print(f"  ERROR: {script_name} failed with code {result.returncode}")
-        if result.stderr:
-            print(f"  stderr: {result.stderr[-500:]}")
-        return script_name, False
-    print(f"  Done: {script_name}")
-    return script_name, True
+from meta_disco.classify_run import run_all_classifications
 
 
 def main():
@@ -81,77 +27,14 @@ def main():
         default=Path("data/anvil/anvil_files_metadata.json"),
         help="Source metadata file (JSON format)",
     )
+    parser.add_argument(
+        "--evidence-base",
+        type=Path,
+        default=Path("data/evidence/anvil"),
+        help="Evidence cache base directory (per source, e.g. data/evidence/hprc)",
+    )
     args = parser.parse_args()
-
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_dir = args.output_dir / timestamp
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    print(f"Re-running classifications with timestamp: {timestamp}")
-    print(f"Output directory: {output_dir}")
-
-    parallel_jobs = build_parallel_jobs(args.metadata, output_dir)
-
-    # Track all classification output paths for Phase 3
-    all_classification_files = [path for _, path, _ in parallel_jobs]
-
-    print(f"\nPhase 1: Running {len(parallel_jobs)} classifiers in parallel...")
-    success = True
-    with ThreadPoolExecutor(max_workers=len(parallel_jobs)) as executor:
-        futures = {executor.submit(run_script, name, path, extra): name for name, path, extra in parallel_jobs}
-        for future in as_completed(futures):
-            _script_name, ok = future.result()
-            success &= ok
-
-    # Phase 2: Index classification (inherits from parent file classifications)
-    index_output = output_dir / "index_classifications.json"
-    if not success:
-        print("\nPhase 2: SKIPPED — one or more Phase 1 classifiers failed")
-    else:
-        print("\nPhase 2: Classifying index files...")
-        _, ok = run_script(
-            "classify_index_files.py",
-            index_output,
-            [
-                "--metadata",
-                str(args.metadata),
-                "--classifications",
-                *[str(p) for p in all_classification_files],
-            ],
-        )
-        success &= ok
-        all_classification_files.append(index_output)
-
-    # Phase 3: Catch-all for files not handled by any other classifier
-    if not success:
-        print("\nPhase 3: SKIPPED — one or more earlier classifiers failed")
-    else:
-        print("\nPhase 3: Classifying remaining files...")
-        _, ok = run_script(
-            "classify_remaining_files.py",
-            output_dir / "remaining_classifications.json",
-            [
-                "--metadata",
-                str(args.metadata),
-                "--classifications",
-                *[str(p) for p in all_classification_files],
-            ],
-        )
-        success &= ok
-
-    print(f"\n{'=' * 70}")
-    if success:
-        print("All classifications complete!")
-        print(f"Results saved to: {output_dir}/")
-    else:
-        print("Some classifications failed - check output above")
-    print("=" * 70)
-
-    # List output files
-    print("\nOutput files:")
-    for f in sorted(output_dir.glob("*.json")):
-        size_mb = f.stat().st_size / (1024 * 1024)
-        print(f"  {f.name}: {size_mb:.1f} MB")
+    run_all_classifications(args.metadata, args.output_dir, args.evidence_base)
 
 
 if __name__ == "__main__":

--- a/scripts/rerun_all_classifications.py
+++ b/scripts/rerun_all_classifications.py
@@ -33,8 +33,16 @@ def main():
         default=Path("data/evidence/anvil"),
         help="Evidence cache base directory (per source, e.g. data/evidence/hprc)",
     )
+    parser.add_argument(
+        "--workers",
+        "-w",
+        type=int,
+        default=None,
+        help="Header-fetch concurrency (default: the pipeline default; raise it, e.g. -w 30, "
+        "for a cold full re-fetch of the network-bound long poles)",
+    )
     args = parser.parse_args()
-    run_all_classifications(args.metadata, args.output_dir, args.evidence_base)
+    run_all_classifications(args.metadata, args.output_dir, args.evidence_base, workers=args.workers)
 
 
 if __name__ == "__main__":

--- a/src/meta_disco/classify_run.py
+++ b/src/meta_disco/classify_run.py
@@ -1,0 +1,161 @@
+"""The single classification run — shared by every source.
+
+A source (AnVIL, HPRC, …) maps its native metadata into the meta-disco record shape and
+calls :func:`run_all_classifications`; there is no per-source classifier. This module holds
+the orchestration — Phase 1 (header types + the non-header scripts), Phase 2 (index
+inheritance), Phase 3 (the remaining catch-all). ``scripts/rerun_all_classifications.py``
+(AnVIL) and ``scripts/classify_hprc_files.py`` (HPRC) are thin CLI wrappers over it, so the
+shared path lives in the package alongside the rest of the pipeline rather than being
+imported across scripts.
+"""
+
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from pathlib import Path
+
+from meta_disco.file_types import FILE_TYPE_REGISTRY
+
+# This module is <root>/src/meta_disco/classify_run.py; the classifier scripts it shells
+# out to live at <root>/scripts/, so the subprocess cwd is the repo root three levels up.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Phase 1 classifiers that are NOT header-based, so they have their own script
+# rather than a FILE_TYPE_REGISTRY entry.
+NON_HEADER_JOBS = (
+    ("classify_bed_files.py", "bed_classifications.json"),
+    ("classify_images.py", "image_classifications.json"),
+    ("classify_auxiliary_genomic.py", "auxiliary_classifications.json"),
+)
+
+
+def build_parallel_jobs(
+    metadata: Path, output_dir: Path, evidence_base: Path, workers: int | None = None
+) -> list[tuple]:
+    """Phase 1 jobs: one per header-based file type, plus the non-header scripts.
+
+    The header jobs are derived from FILE_TYPE_REGISTRY rather than hand-listed,
+    so registering a new file type cannot silently skip production. That is what
+    happened to `gfa` in #151: it was added to the registry and to nothing else,
+    so `make classify` never invoked it and graph files fell through to the
+    filename-only Phase 3 catch-all.
+
+    ``evidence_base`` is the per-source header cache root (``data/evidence/anvil`` for
+    AnVIL, ``data/evidence/hprc`` for HPRC) and ``workers`` (when set) the header-fetch
+    concurrency; both are passed only to the header jobs — the ones that fetch headers.
+    The non-header scripts take neither: image/auxiliary classify from the filename, and
+    bed reads a *separate* pre-fetched coordinate-evidence cache (hardcoded to the AnVIL
+    dir today, not this ``evidence_base`` — see #279).
+
+    Every output filename here must also appear in output_utils.CLASSIFICATION_FILES
+    or the reports will not read it — pinned by tests/test_orchestration.py.
+    """
+    header_args = ["--evidence-base", str(evidence_base)]
+    if workers is not None:
+        header_args += ["-w", str(workers)]
+    jobs = [
+        (
+            "classify_headers.py",
+            output_dir / f"{ftype}_classifications.json",
+            ["--type", ftype, "--input", str(metadata), *header_args],
+        )
+        for ftype in FILE_TYPE_REGISTRY
+    ]
+    jobs += [(script, output_dir / out, ["--metadata", str(metadata)]) for script, out in NON_HEADER_JOBS]
+    return jobs
+
+
+def run_script(script_name: str, output_path: Path, extra_args: list[str] | None = None):
+    """Run a classification script."""
+    cmd = [sys.executable, f"scripts/{script_name}", "--output", str(output_path)]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    print(f"  Starting: {script_name}")
+
+    result = subprocess.run(cmd, cwd=_REPO_ROOT, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"  ERROR: {script_name} failed with code {result.returncode}")
+        if result.stderr:
+            print(f"  stderr: {result.stderr[-500:]}")
+        return script_name, False
+    print(f"  Done: {script_name}")
+    return script_name, True
+
+
+def run_all_classifications(
+    metadata: Path, output_dir_base: Path, evidence_base: Path, workers: int | None = None
+) -> bool:
+    """Run the full classification pipeline over one meta-disco metadata file.
+
+    This is the single classification path shared by every source. A source (AnVIL,
+    HPRC, …) maps its native metadata into the meta-disco record shape and calls this;
+    there is no per-source classifier. It writes a timestamped run dir under
+    ``output_dir_base`` and caches header evidence under ``evidence_base``, running
+    Phase 1 (header types + non-header scripts), Phase 2 (index inheritance), and
+    Phase 3 (the remaining catch-all). ``workers`` sets the header-fetch concurrency
+    (``None`` = the pipeline default). Returns True only if every phase succeeded.
+    """
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = output_dir_base / timestamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Re-running classifications with timestamp: {timestamp}")
+    print(f"Output directory: {output_dir}")
+    print(f"Evidence cache: {evidence_base}")
+
+    parallel_jobs = build_parallel_jobs(metadata, output_dir, evidence_base, workers)
+
+    # Track all classification output paths for Phase 3
+    all_classification_files = [path for _, path, _ in parallel_jobs]
+
+    print(f"\nPhase 1: Running {len(parallel_jobs)} classifiers in parallel...")
+    success = True
+    with ThreadPoolExecutor(max_workers=len(parallel_jobs)) as executor:
+        futures = {executor.submit(run_script, name, path, extra): name for name, path, extra in parallel_jobs}
+        for future in as_completed(futures):
+            _script_name, ok = future.result()
+            success &= ok
+
+    # Phase 2: Index classification (inherits from parent file classifications)
+    index_output = output_dir / "index_classifications.json"
+    if not success:
+        print("\nPhase 2: SKIPPED — one or more Phase 1 classifiers failed")
+    else:
+        print("\nPhase 2: Classifying index files...")
+        _, ok = run_script(
+            "classify_index_files.py",
+            index_output,
+            ["--metadata", str(metadata), "--classifications", *[str(p) for p in all_classification_files]],
+        )
+        success &= ok
+        all_classification_files.append(index_output)
+
+    # Phase 3: Catch-all for files not handled by any other classifier
+    if not success:
+        print("\nPhase 3: SKIPPED — one or more earlier classifiers failed")
+    else:
+        print("\nPhase 3: Classifying remaining files...")
+        _, ok = run_script(
+            "classify_remaining_files.py",
+            output_dir / "remaining_classifications.json",
+            ["--metadata", str(metadata), "--classifications", *[str(p) for p in all_classification_files]],
+        )
+        success &= ok
+
+    print(f"\n{'=' * 70}")
+    if success:
+        print("All classifications complete!")
+        print(f"Results saved to: {output_dir}/")
+    else:
+        print("Some classifications failed - check output above")
+    print("=" * 70)
+
+    # List output files
+    print("\nOutput files:")
+    for f in sorted(output_dir.glob("*.json")):
+        size_mb = f.stat().st_size / (1024 * 1024)
+        print(f"  {f.name}: {size_mb:.1f} MB")
+
+    return success

--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -142,6 +142,27 @@ def _content_range_start(content_range: str) -> int | None:
         return None
 
 
+@wrap_as_fetch_error("fetch_content_length")
+def fetch_content_length(url: str, timeout: int = 60) -> int:
+    """Return the size in bytes of the S3 object at ``url``, from an HTTP ``HEAD``.
+
+    The HPRC adapter (#276) uses this because its sequencing catalog carries no file
+    size, yet ``file_size`` is required by the input contract and feeds the WGS/WES
+    assay heuristic — so the real size is read from the object (a HEAD's
+    ``Content-Length``) rather than guessed. Raises ``FetchError`` when the HEAD yields
+    no size, so the caller records the file as unclassifiable rather than inventing one.
+    S3 always answers HEAD with ``Content-Length``; a failure here means the object was
+    unreachable, and a resume re-attempts it (the size is not cached).
+    """
+    resp = requests.head(url, timeout=timeout, allow_redirects=True)
+    if resp.status_code not in (200, 206):
+        raise FetchError(f"HTTP {resp.status_code} from HEAD {url}")
+    length = resp.headers.get("Content-Length")
+    if length is None:
+        raise FetchError(f"no Content-Length from HEAD {url}")
+    return int(length)
+
+
 def _fetch_range(md5sum: str, end_byte: int, timeout: int = 60, url: str | None = None, start_byte: int = 0) -> bytes:
     """Fetch bytes ``start_byte`` through ``end_byte`` (inclusive) from S3. Returns raw bytes.
 

--- a/src/meta_disco/fetchers.py
+++ b/src/meta_disco/fetchers.py
@@ -144,15 +144,17 @@ def _content_range_start(content_range: str) -> int | None:
 
 @wrap_as_fetch_error("fetch_content_length")
 def fetch_content_length(url: str, timeout: int = 60) -> int:
-    """Return the size in bytes of the S3 object at ``url``, from an HTTP ``HEAD``.
+    """Return the size in bytes of the object at ``url``, from an HTTP ``HEAD`` (following
+    redirects).
 
     The HPRC adapter (#276) uses this because its sequencing catalog carries no file
     size, yet ``file_size`` is required by the input contract and feeds the WGS/WES
     assay heuristic — so the real size is read from the object (a HEAD's
-    ``Content-Length``) rather than guessed. Raises ``FetchError`` when the HEAD yields
-    no size, so the caller records the file as unclassifiable rather than inventing one.
-    S3 always answers HEAD with ``Content-Length``; a failure here means the object was
-    unreachable, and a resume re-attempts it (the size is not cached).
+    ``Content-Length``) rather than guessed. Raises ``FetchError`` when the HEAD is
+    non-2xx or omits ``Content-Length``, so the caller records the file as unclassifiable
+    rather than inventing a size. (The S3 objects this is pointed at answer HEAD with
+    ``Content-Length``; the raise is the backstop for when a response does not, and a
+    resume re-attempts it since the size is not cached.)
     """
     resp = requests.head(url, timeout=timeout, allow_redirects=True)
     if resp.status_code not in (200, 206):

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -112,6 +112,7 @@ def _fetch_and_classify(
     file_format: str | None,
     is_gzipped: bool,
     use_cache: bool,
+    url: str | None = None,
 ) -> tuple[dict, bool]:
     """Fetch a file's content and classify it.
 
@@ -131,6 +132,11 @@ def _fetch_and_classify(
     ``file_name`` (the raw string) goes to the fetcher and the progress line; ``name``
     (the parsed :class:`FileName`, #242) goes to the classifiers, which read the
     extension and filename tokens from it without re-parsing.
+
+    ``url`` is an optional explicit content URL (#276). When ``None`` (the AnVIL path)
+    the fetcher derives its URL from ``md5sum`` (the S3 mirror); when supplied (HPRC)
+    the fetcher streams from it instead. Every fetcher accepts ``url`` and defaults it
+    to ``None``, so passing it unconditionally leaves the AnVIL path byte-for-byte.
     """
     try:
         raw_data = config.fetcher(
@@ -140,6 +146,7 @@ def _fetch_and_classify(
             is_gzipped=is_gzipped,
             use_cache=use_cache,
             head_detector=config.head_detector,
+            url=url,
         )
     except FetchError as e:
         print(f"Content unreadable, classifying from filename — {file_name or md5sum}: {e.reason}")
@@ -288,12 +295,16 @@ class ClassifyPipeline:
         is_gzipped: bool = True,
         use_cache: bool = True,
         evidence_base: Path = Path("data/evidence/anvil"),
+        url: str | None = None,
     ) -> dict:
         """Classify a single file by MD5. Does not require a full pipeline instance.
 
         Returns the canonical seven-key ``OutputRecord`` envelope (#204), the same
         shape the batch path writes; ``dataset_title``/``entry_id`` are ``None`` here
         since there is no source record.
+
+        ``url`` is an optional explicit content URL (#276): ``None`` derives the URL
+        from ``md5sum`` (AnVIL mirror), a value streams from it instead (HPRC).
 
         Never returns ``None`` (#155): a fetch failure surfaces as a ``FetchError``,
         which yields filename-only ``not_classified`` classifications. It does not
@@ -314,6 +325,7 @@ class ClassifyPipeline:
             file_format=file_format,
             is_gzipped=is_gzipped,
             use_cache=use_cache,
+            url=url,
         )
         return OutputRecord.from_single(
             md5sum=md5sum,
@@ -473,6 +485,7 @@ class ClassifyPipeline:
             file_format=item.file_format,
             is_gzipped=is_gzipped,
             use_cache=self.resume,
+            url=item.url,
         )
         if content_unreadable:
             # was_cached is a file-existence stat taken before the fetch. A fetcher

--- a/src/meta_disco/records.py
+++ b/src/meta_disco/records.py
@@ -70,6 +70,12 @@ class ClassifierRecord:
     nothing downstream re-parses. The raw ``file_name`` string is kept alongside it:
     it is the identity echoed into the output row and the shared attribute the
     ``InvalidRecord`` stream also exposes (``name`` is a valid-stream-only fact).
+
+    ``url`` is an optional explicit content URL (#276). It is ``None`` for the AnVIL
+    path, where the fetcher derives the S3-mirror URL from ``file_md5sum``; a caller
+    whose files are not on that mirror (the HPRC catalogs, keyed on ``md5(filename)``
+    and served from their own S3 paths) supplies it here and the fetcher streams from
+    it instead. Not a classifier-relevant field, so its absence never diverts a record.
     """
 
     file_name: str
@@ -79,6 +85,7 @@ class ClassifierRecord:
     dataset_title: Any
     entry_id: Any
     name: FileName
+    url: str | None = None
 
     @classmethod
     def from_record(cls, record: dict) -> ClassifierRecord:
@@ -92,7 +99,8 @@ class ClassifierRecord:
         have.
 
         ``file_name`` is parsed into a :class:`FileName` exactly once here — the
-        single parse site on the pipeline path (#242).
+        single parse site on the pipeline path (#242). ``url`` is optional (#276) and
+        absent on the AnVIL path, so it is read with ``.get`` and defaults to ``None``.
         """
         return cls(
             file_name=record["file_name"],
@@ -102,6 +110,7 @@ class ClassifierRecord:
             dataset_title=record.get("dataset_title"),
             entry_id=record.get("entry_id"),
             name=FileName.parse(record["file_name"]),
+            url=record.get("url"),
         )
 
 

--- a/src/meta_disco/records.py
+++ b/src/meta_disco/records.py
@@ -73,9 +73,10 @@ class ClassifierRecord:
 
     ``url`` is an optional explicit content URL (#276). It is ``None`` for the AnVIL
     path, where the fetcher derives the S3-mirror URL from ``file_md5sum``; a caller
-    whose files are not on that mirror (the HPRC catalogs, keyed on ``md5(filename)``
-    and served from their own S3 paths) supplies it here and the fetcher streams from
-    it instead. Not a classifier-relevant field, so its absence never diverts a record.
+    whose files are not on that mirror (the HPRC catalogs, keyed on a hash of their
+    full path and served from their own S3 paths) supplies it here and the fetcher
+    streams from it instead. Not a classifier-relevant field, so its absence never
+    diverts a record.
     """
 
     file_name: str

--- a/tests/test_classify_hprc.py
+++ b/tests/test_classify_hprc.py
@@ -1,0 +1,94 @@
+"""Tests for the HPRC catalog adapter (scripts/classify_hprc_files.py, #276).
+
+The adapter maps each HPRC catalog into the shared meta-disco record shape: a
+synthesized md5 key, an explicit S3 url from the catalog's own location field, and a
+file_size taken from the catalog or read from S3 via HEAD. These tests cover that
+mapping in isolation, without touching the network (fetch_content_length is monkeypatched).
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import classify_hprc_files as hprc
+
+from meta_disco.metadata_schema import classification_blocking_reasons
+
+
+class TestPathKey:
+    def test_is_contract_valid_md5(self):
+        # The synthesized key must satisfy the input contract's file_md5sum pattern.
+        key = hprc.path_key("s3://bucket/HG01891/m54329U_200124_193652.ccs.bam")
+        assert re.fullmatch(r"[0-9a-f]{32}", key)
+
+    def test_is_stable(self):
+        assert hprc.path_key("s3://b/x.bam") == hprc.path_key("s3://b/x.bam")
+
+    def test_distinguishes_same_basename_at_different_paths(self):
+        # The collision fix: key on the full path, so two files that share a basename
+        # (e.g. the 5 real HPRC cases) do NOT alias in the evidence cache.
+        assert hprc.path_key("s3://b/sampleA/x.vcf.gz") != hprc.path_key("s3://b/sampleB/x.vcf.gz")
+
+
+class TestBuildMetadataRecords:
+    def test_maps_url_from_catalog_field_without_head_when_size_present(self, monkeypatch):
+        # A catalog fileSize is used as-is and the S3 HEAD is never issued; the url
+        # comes from the given catalog location field.
+        monkeypatch.setattr(hprc, "fetch_content_length", lambda url, **kw: pytest.fail("should not HEAD"))
+        catalog = [{"filename": "asm.fa.gz", "awsFasta": "s3://bucket/asm.fa.gz", "fileSize": 12345}]
+        records = hprc.build_metadata_records(catalog, "awsFasta", workers=2)
+        assert records[0]["file_size"] == 12345
+        assert records[0]["url"] == "https://s3-us-west-2.amazonaws.com/bucket/asm.fa.gz"
+        assert records[0]["file_format"] == ".fa"  # FileName.parse core extension (wrappers split off)
+        assert records[0]["file_name"] == "asm.fa.gz"
+
+    def test_heads_for_size_when_catalog_omits_it(self, monkeypatch):
+        monkeypatch.setattr(hprc, "fetch_content_length", lambda url, **kw: 999)
+        catalog = [{"filename": "r.bam", "path": "s3://bucket/r.bam"}]
+        records = hprc.build_metadata_records(catalog, "path", workers=2)
+        assert records[0]["file_size"] == 999
+
+    def test_head_failure_leaves_size_none_and_unclassifiable(self, monkeypatch):
+        # No fabrication (#276): a failed size lookup leaves file_size None, which the
+        # contract gate diverts to a not_classified row — an unreadable size makes the
+        # file unclassifiable, never a guessed 0 (which would falsely match WES rules).
+        def boom(url, **kw):
+            raise hprc.FetchError("nope")
+
+        monkeypatch.setattr(hprc, "fetch_content_length", boom)
+        catalog = [{"filename": "r.bam", "path": "s3://bucket/r.bam"}]
+        records = hprc.build_metadata_records(catalog, "path", workers=2)
+        assert records[0]["file_size"] is None
+        assert classification_blocking_reasons(records[0])  # diverted to validation_failed
+
+    def test_records_with_size_pass_the_classifier_contract(self, monkeypatch):
+        # A record with a real size has no classifier-relevant contract violations, so
+        # the pipeline builds a ClassifierRecord (which fetches), not a validation_failed row.
+        monkeypatch.setattr(hprc, "fetch_content_length", lambda url, **kw: 100)
+        catalog = [{"filename": "r.bam", "path": "s3://bucket/r.bam"}]
+        records = hprc.build_metadata_records(catalog, "path", workers=1)
+        assert classification_blocking_reasons(records[0]) == []
+
+    def test_same_basename_different_path_get_distinct_keys(self, monkeypatch):
+        # Two records with the same basename at different paths (the real HPRC collision
+        # case) must get distinct file_md5sum cache keys — keyed on the full path.
+        monkeypatch.setattr(hprc, "fetch_content_length", lambda url, **kw: 1)
+        catalog = [
+            {"filename": "x.vcf.gz", "path": "s3://bucket/sampleA/x.vcf.gz", "fileSize": 1},
+            {"filename": "x.vcf.gz", "path": "s3://bucket/sampleB/x.vcf.gz", "fileSize": 1},
+        ]
+        records = hprc.build_metadata_records(catalog, "path", workers=1)
+        assert records[0]["file_md5sum"] != records[1]["file_md5sum"]
+
+    def test_missing_location_leaves_url_none_and_no_head(self, monkeypatch):
+        # A record whose catalog omits the location field gets url None and is not HEADed
+        # (nothing to fetch a size from); it stays None → unclassifiable.
+        monkeypatch.setattr(hprc, "fetch_content_length", lambda url, **kw: pytest.fail("no url to HEAD"))
+        catalog = [{"filename": "r.bam"}]  # no "path"
+        records = hprc.build_metadata_records(catalog, "path", workers=1)
+        assert records[0]["url"] is None
+        assert records[0]["file_size"] is None

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -601,3 +601,26 @@ def test_fetch_tar_warns_when_member_cap_reached(monkeypatch, evidence_dir, caps
     assert len(names) == fetchers.MAX_TAR_MEMBERS
     out = capsys.readouterr().out
     assert "reached the" in out and "big.tar" in out
+
+
+# =============================================================================
+# fetch_content_length — S3 object size for the HPRC adapter (#276)
+# =============================================================================
+
+
+class TestFetchContentLength:
+    def test_head_returns_content_length(self, monkeypatch):
+        monkeypatch.setattr(
+            fetchers.requests, "head", lambda *a, **k: _Resp(200, headers={"Content-Length": "23303924936"})
+        )
+        assert fetchers.fetch_content_length("https://example.org/o.bam") == 23303924936
+
+    def test_missing_content_length_raises(self, monkeypatch):
+        monkeypatch.setattr(fetchers.requests, "head", lambda *a, **k: _Resp(200))  # no Content-Length
+        with pytest.raises(FetchError):
+            fetchers.fetch_content_length("https://example.org/o.bam")
+
+    def test_non_2xx_raises_fetcherror(self, monkeypatch):
+        monkeypatch.setattr(fetchers.requests, "head", lambda *a, **k: _Resp(403))
+        with pytest.raises(FetchError):
+            fetchers.fetch_content_length("https://example.org/o.bam")

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -11,22 +11,19 @@ call the classifier directly.
 These tests pin the three together.
 """
 
-import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-
-from rerun_all_classifications import build_parallel_jobs
-
+from meta_disco.classify_run import build_parallel_jobs
 from meta_disco.file_types import FILE_TYPE_REGISTRY
 from meta_disco.output_utils import CLASSIFICATION_FILES
 
 METADATA = Path("data/anvil/anvil_files_metadata.json")
 OUTPUT_DIR = Path("output/anvil/20260101_000000")
+EVIDENCE_BASE = Path("data/evidence/anvil")
 
 
 def _jobs():
-    return build_parallel_jobs(METADATA, OUTPUT_DIR)
+    return build_parallel_jobs(METADATA, OUTPUT_DIR, EVIDENCE_BASE)
 
 
 def test_every_registered_file_type_has_a_phase1_job():
@@ -37,6 +34,30 @@ def test_every_registered_file_type_has_a_phase1_job():
         f"FILE_TYPE_REGISTRY types with no Phase 1 job: {sorted(missing)}. "
         "They would be classified by the filename-only Phase 3 catch-all."
     )
+
+
+def test_header_jobs_receive_the_evidence_base():
+    """The per-source evidence cache root (#276) must reach the header jobs — the only
+    ones that fetch and cache — so HPRC evidence lands under data/evidence/hprc, not anvil."""
+    header_jobs = [extra for _, _, extra in _jobs() if "--type" in extra]
+    assert header_jobs, "expected at least one header job"
+    for extra in header_jobs:
+        assert "--evidence-base" in extra
+        assert extra[extra.index("--evidence-base") + 1] == str(EVIDENCE_BASE)
+
+
+def test_workers_thread_to_header_jobs_only():
+    """--workers (#276) reaches the fetching header jobs as `-w`; the non-header scripts,
+    which don't fetch, never get it. Omitting workers adds no `-w` anywhere."""
+    jobs = build_parallel_jobs(METADATA, OUTPUT_DIR, EVIDENCE_BASE, workers=30)
+    header = [extra for _, _, extra in jobs if "--type" in extra]
+    non_header = [extra for _, _, extra in jobs if "--type" not in extra]
+    assert header, "expected at least one header job"
+    for extra in header:
+        assert extra[extra.index("-w") + 1] == "30"
+    assert all("-w" not in extra for extra in non_header)
+    # workers omitted -> no -w on any job
+    assert all("-w" not in extra for _, _, extra in build_parallel_jobs(METADATA, OUTPUT_DIR, EVIDENCE_BASE))
 
 
 def test_every_phase1_output_is_read_by_the_reports():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -736,3 +736,63 @@ class TestFileTypeConfigs:
             assert len(config.extensions) > 0
             assert callable(config.fetcher)
             assert callable(config.classifier)
+
+
+# --- url seam (#276) ---
+
+
+class TestUrlSeam:
+    """The optional explicit content URL (#276) reaches the fetcher, defaulting to None."""
+
+    def _capturing_config(self, captured):
+        def fetcher(evidence_dir, md5, **kw):
+            captured[md5] = kw.get("url")
+            return f"header_for_{md5}"
+
+        return _make_config(fetcher=fetcher)
+
+    def _input(self, tmp_path, record):
+        path = tmp_path / "in.json"
+        path.write_text(json.dumps({"results": [record]}))
+        return path
+
+    def test_url_from_record_reaches_fetcher(self, tmp_path):
+        captured = {}
+        config = self._capturing_config(captured)
+        input_file = self._input(
+            tmp_path,
+            {
+                "file_md5sum": "a" * 32,
+                "file_name": "s.test",
+                "file_format": ".test",
+                "file_size": 5,
+                "url": "https://example.org/s.test",
+            },
+        )
+        ClassifyPipeline(config, input_file, tmp_path / "out.json", evidence_base=tmp_path / "ev").run()
+        assert captured["a" * 32] == "https://example.org/s.test"
+
+    def test_url_defaults_to_none_without_url_field(self, tmp_path):
+        # A record with no url (the AnVIL shape) must pass url=None so the fetcher
+        # derives its URL from the md5 — byte-for-byte the pre-#276 behavior.
+        captured = {}
+        config = self._capturing_config(captured)
+        input_file = self._input(
+            tmp_path,
+            {"file_md5sum": "b" * 32, "file_name": "t.test", "file_format": ".test", "file_size": 5},
+        )
+        ClassifyPipeline(config, input_file, tmp_path / "out.json", evidence_base=tmp_path / "ev").run()
+        assert captured["b" * 32] is None
+
+    def test_classify_single_passes_url(self, tmp_path):
+        captured = {}
+        config = self._capturing_config(captured)
+        ClassifyPipeline.classify_single(
+            config,
+            "c" * 32,
+            file_name="s.test",
+            file_format=".test",
+            url="https://example.org/single",
+            evidence_base=tmp_path / "ev",
+        )
+        assert captured["c" * 32] == "https://example.org/single"


### PR DESCRIPTION
Closes #276.

## What changed
HPRC becomes a **source adapter**, like AnVIL — no bespoke HPRC classification path. `scripts/classify_hprc_files.py` maps the four HPRC Data Explorer catalogs into the one **meta-disco record shape** and calls the single classifier; there is now one classifier for all sources.

- **One orchestrator, in the package**: moved `run_all_classifications` / `build_parallel_jobs` / `run_script` out of `scripts/rerun_all_classifications.py` into `src/meta_disco/classify_run.py`. `rerun_all_classifications.py` (AnVIL) and `classify_hprc_files.py` (HPRC) are now thin CLI wrappers that import it.
- **HPRC adapter** (`classify_hprc_files.py`): for each catalog record it builds a meta-disco record — `file_format` from `FileName.parse`, `file_md5sum` = `hash(full path)` (the cache key), `url` from the catalog's own S3-location field (`path`/`awsFasta`/`loc`/`fileLocation`), `file_size` from the catalog or a parallel S3 `HEAD` — writes one `{"files": […]}` metadata file, and runs the shared classifier over it (`output/hprc/…`, `data/evidence/hprc/…`).
- **Seams on the shared path**: an optional `url` on the record (threaded to the fetcher; AnVIL passes `None` and derives from md5, unchanged) and `--evidence-base` on the header jobs, so HPRC fetches into its own evidence cache.
- **No fabrication**: an unavailable size, a missing location, or an unknown format leaves the record `not_classified` — never a guessed value. Cache key is the full path (basename collisions can't alias). `fetch_content_length` reads size via `HEAD`.
- **`--workers`** (default 30) threaded to the header-fetch jobs.

## Why
AnVIL's catalog includes the HPRC dataset, and the HPRC Data Explorer's metadata is richer ground truth — so classifying the HPRC catalogs and comparing (`validate_against_hprc.py`) quality-checks our calls on the AnVIL HPRC files. Previously HPRC had its own hand-rolled fetch/classify loops; this routes it through the same fetchers, classifier, cache, and output envelope as AnVIL, so the two can never drift.

## Assumptions I made
- The **canonical meta-disco metadata key is `"files"`** (what AnVIL emits); the adapter writes that.
- The **cache key is a hash of the full path**, not the content md5 (HPRC has none; S3 multipart ETags aren't md5s). This is a down-payment on the uniform hash-of-path key (#277); AnVIL still keys on its real md5 for now.
- Only **sequencing-data** lacks `fileSize` (verified: 0/6048), so only those ~6K files get an S3 `HEAD`; the other catalogs carry it.
- **BED coordinate evidence is still read from the hardcoded AnVIL dir** — harmless for HPRC today (path-hash keys don't match AnVIL md5 keys → filename-only), tracked in #279.
- `_REPO_ROOT` in `classify_run.py` assumes the project runs from the source checkout (it does).

## How to verify
Definition-of-done checks:
- [ ] **AnVIL path unchanged** — `uv run pytest tests/ -m "not e2e"` is green (820 pass); the `url` seam defaults to `None` on the AnVIL path (`tests/test_pipeline.py::TestUrlSeam`).
- [ ] **HPRC drives the shared classifier; no bespoke loops** — read `scripts/classify_hprc_files.py`: it ends in `run_all_classifications(...)`; the old `classify_sequencing_data`/`classify_assemblies` loops are gone.
- [ ] **Adapter mapping is correct** — `uv run pytest tests/test_classify_hprc.py` (url from the catalog field, size from catalog vs HEAD, no fabrication on HEAD failure, cache key distinguishes same-basename-different-path).
- [ ] **`--evidence-base` + `--workers` reach only the header jobs** — `tests/test_orchestration.py::test_header_jobs_receive_the_evidence_base` and `::test_workers_thread_to_header_jobs_only`.
- [ ] **End-to-end run** (operational, tracked as #275, needs network): `uv run python scripts/classify_hprc_files.py -w 30` → writes `data/hprc/hprc_files_metadata.json` and `output/hprc/<ts>/*_classifications.json`; then `make validate-hprc` reproduces the HPRC validation numbers.

Follow-ups filed: #277 (uniform hash-of-path key + AnVIL migration), #278 (input path-uniqueness validation), #279 (BED evidence base), #280 (fabricate-and-continue extermination), #281 (source-neutral record model), #282 (`fetch_bed_headers` gzip reuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)