### PR TITLE
Unreadable fetch yields a fully not_classified record (#293)

### DIFF
--- a/src/meta_disco/file_types.py
+++ b/src/meta_disco/file_types.py
@@ -35,8 +35,6 @@ BAM_CONFIG = FileTypeConfig(
     fetcher=fetch_bam_header,
     classifier=classify_from_header,
     summary_printer=print_bam_summary,
-    # @SQ contig lengths, @RG platform; assay_type is inferred from those.
-    content_fields=("data_modality", "data_type", "reference_assembly", "platform", "assay_type"),
     # samtools reads BAM/CRAM headers — fail fast if it is not installed.
     preflight=require_samtools,
 )
@@ -47,8 +45,6 @@ VCF_CONFIG = FileTypeConfig(
     fetcher=fetch_vcf_header,
     classifier=classify_from_vcf_header,
     summary_printer=print_vcf_summary,
-    # ##contig lengths and header tokens; the VCF header names no platform.
-    content_fields=("data_modality", "data_type", "reference_assembly"),
 )
 
 FASTQ_CONFIG = FileTypeConfig(
@@ -56,8 +52,6 @@ FASTQ_CONFIG = FileTypeConfig(
     extensions=(".fastq", ".fastq.gz", ".fq", ".fq.gz"),
     fetcher=fetch_fastq_reads,
     classifier=classify_from_fastq_header,
-    # Read names give the instrument, hence platform; reads name no assembly.
-    content_fields=("data_modality", "platform", "assay_type"),
     summary_printer=print_fastq_summary,
 )
 
@@ -66,8 +60,6 @@ FASTA_CONFIG = FileTypeConfig(
     extensions=(".fasta", ".fasta.gz", ".fa", ".fa.gz"),
     fetcher=fetch_fasta_headers,
     classifier=classify_from_fasta_header,
-    # Contig names distinguish reference / assembly / transcriptome.
-    content_fields=("data_modality", "data_type", "reference_assembly"),
 )
 
 # Text GFA only (GRAPH_TEXT_EXTENSIONS). The other graph extensions the
@@ -78,10 +70,6 @@ GFA_CONFIG = FileTypeConfig(
     extensions=GRAPH_TEXT_EXTENSIONS,
     fetcher=fetch_gfa_segment_tags,
     classifier=classify_from_gfa_segment_tags,
-    # rGFA stable-rank tags refine data_type to pangenome.reference. Nothing
-    # else: reference_assembly comes only from the filename (no lengths are
-    # parsed, and the visible stable name `chr1` is shared across assemblies).
-    content_fields=("data_type",),
 )
 
 # Tar archives (#255). A container carries no format of its own (#245); the head
@@ -92,9 +80,6 @@ TAR_CONFIG = FileTypeConfig(
     extensions=(".tar", ".tar.gz"),
     fetcher=fetch_tar_headers,
     classifier=classify_from_tar_members,
-    # The inner member formats determine what the contents are; nothing here reads a
-    # member's own header, so no reference_assembly / platform / assay_type.
-    content_fields=("data_modality", "data_type"),
     # Escalating head-read (#260): read deeper only until the members are classifiable,
     # so a GenomicsDB store whose variant signal sits past the first 256KiB is reached.
     head_detector=tar_head_is_conclusive,
@@ -102,15 +87,13 @@ TAR_CONFIG = FileTypeConfig(
 
 # BED reference is inferred from coordinate content (chromosome names + per-contig max
 # end positions), so it is a header/content type read through the shared pipeline (#282) —
-# not a hand-rolled orphan fetcher. Only reference_assembly is content-derived (hence
-# content_fields); data_modality/data_type still come from the filename/extension rules,
-# while platform and assay_type carry no BED signal.
+# not a hand-rolled orphan fetcher. reference_assembly is content-derived; data_modality/
+# data_type come from the filename/extension rules; platform and assay_type carry no BED signal.
 BED_CONFIG = FileTypeConfig(
     name="bed",
     extensions=(".bed", ".bed.gz"),
     fetcher=fetch_bed_signals,
     classifier=classify_from_bed_signals,
-    content_fields=("reference_assembly",),
 )
 
 FILE_TYPE_REGISTRY = {

--- a/src/meta_disco/header_classifier.py
+++ b/src/meta_disco/header_classifier.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 
 from .evidence import BedSignals, SegmentTag
 from .file_name import FileName
-from .models import CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED, build_field_entry
+from .models import CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED, all_not_classified, build_field_entry
 from .validators.read_name_parsers import (
     detect_paired_end_indicators,
     extract_archive_accession,
@@ -382,66 +382,26 @@ _ASSEMBLER_PATTERN = re.compile(
 _TRANSCRIPT_PATTERN = re.compile(r"^(ENST\d|NM_\d|NR_\d|XM_\d|rna-)", re.IGNORECASE)
 
 
-def classify_without_content(
-    reason: str,
-    *,
-    name: FileName = FileName.EMPTY,
-    file_size: int | None = None,
-    file_format: str | None = None,
-    content_fields: tuple[str, ...] = (),
-) -> dict:
-    """Classify a file whose content could not be read, from its name alone.
+FETCH_FAILED_RULE_ID = "fetch_failed"
 
-    Keeps the file in the output with a stated cause instead of dropping its row
-    — a missing record is indistinguishable from a file that was never seen.
 
-    Runs the tier-1/2 (extension and filename) rules only, so everything knowable
-    without reading bytes is still classified: a `.gfa` is still `pangenome`,
-    still `genomic`, still `not_applicable` for platform and assay. The parsed
-    ``name`` and the declared ``file_format`` are handed to the engine, which
-    reconciles them (name-extension wins, else ``file_format``); an archive name
-    with no inner format (``x.tar.gz`` → ``extension=None``) falls through to
-    ``file_format``. With neither, no *extension-scoped* rule fires, so the
-    container yields no content type of its own — though a filename/dataset rule
-    that carries no ``extensions:`` filter (e.g. a reference token in the name)
-    may still classify a field. We do not fabricate a content type for a
-    container we could not read (#245).
+def classify_without_content(reason: str) -> dict:
+    """Classify a file whose content could not be read: every dimension not_classified.
 
-    ``content_fields`` names the dimensions *this file type's content* can
-    determine (``FileTypeConfig.content_fields``). Only those carry the
-    ``fetch_failed`` note, so the evidence says which answers the unread bytes
-    would have informed. Annotating every unresolved dimension instead would lie:
-    GFA content never determines reference_assembly (see
-    ``classify_from_gfa_segment_tags``), so a note there would tell a reader that
-    re-fetching could resolve an assembly the filename alone must supply.
+    We have nothing to say about a file we cannot read (#293). A fetch failure
+    (404 from the mirror, DNS/connection failure, timeout) means the content —
+    the signal that would refine the classification — is unavailable, so no
+    dimension is asserted, not even ones the filename alone could support: a
+    filename token is a guess the unread bytes exist to confirm or overturn.
 
-    The note is attached whether or not the dimension is already classified — a
-    filename-derived `pangenome` may be an unrefined `pangenome.reference`. It
-    declares a status, not a value, so ``evaluate_claims`` treats it as
-    non-assertive and it never competes with a real claim.
+    The record is still written, with the failure ``reason`` as each dimension's
+    evidence, rather than dropped — a missing row is indistinguishable from a
+    file that was never seen (#155). This is the same all-``not_classified``
+    stance ``validation_failed_classifications`` takes for an untrusted record.
 
     ``reason`` should name the cause (e.g. ``"HTTP 404 from AnVIL S3 mirror ..."``).
     """
-    from .rule_engine import ExtendedFileInfo
-
-    file_info = ExtendedFileInfo(
-        name=name,
-        file_format=file_format,
-        file_size=file_size,
-    )
-    result = _get_engine().classify_extended(file_info, include_tier3=False)
-
-    output = result.to_output_dict()
-    for fld in content_fields:
-        if fld in output:
-            output[fld]["evidence"].append(
-                {
-                    "rule_id": "fetch_failed",
-                    "reason": reason,
-                    "status": NOT_CLASSIFIED,
-                }
-            )
-    return output
+    return all_not_classified([{"rule_id": FETCH_FAILED_RULE_ID, "reason": reason}])
 
 
 def classify_from_gfa_segment_tags(

--- a/src/meta_disco/metadata_schema.py
+++ b/src/meta_disco/metadata_schema.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 from pydantic import ConfigDict, ValidationError
 from pydantic_core import ErrorDetails
 
-from .models import CLASSIFICATION_FIELDS, NOT_CLASSIFIED, build_field_entry
+from .models import all_not_classified
 from .schema.metadata_model import AnvilFileMetadataRecord
 
 # rule_id stamped on the evidence of a record that failed input validation.
@@ -150,18 +150,12 @@ def validation_failed_classifications(reasons: list[str]) -> dict:
     indistinguishable from a file that was never seen (issue #155).
 
     Every dimension is blanked deliberately, even ones the filename alone could
-    support (unlike the fetch-failure path, which keeps filename-derived values):
-    a contract violation means the record's provenance is untrusted wholesale, so
-    it is marked uniformly unclassifiable rather than partly classified.
+    support: a contract violation means the record's provenance is untrusted
+    wholesale, so it is marked uniformly unclassifiable rather than partly
+    classified — the same stance the fetch-failure path takes for unreadable
+    content (#293).
     """
-
-    # A fresh evidence list (and fresh dicts) per field: sharing one list across
-    # all five dimensions would alias them, so a later in-place edit of one field's
-    # evidence would silently mutate all five.
-    def _evidence():
-        return [{"rule_id": VALIDATION_RULE_ID, "reason": reason} for reason in reasons]
-
-    return {fld: build_field_entry(None, status=NOT_CLASSIFIED, evidence=_evidence()) for fld in CLASSIFICATION_FIELDS}
+    return all_not_classified([{"rule_id": VALIDATION_RULE_ID, "reason": reason} for reason in reasons])
 
 
 @dataclass

--- a/src/meta_disco/models.py
+++ b/src/meta_disco/models.py
@@ -111,6 +111,22 @@ def build_field_entry(value, status=None, evidence=None) -> dict:
     }
 
 
+def all_not_classified(evidence: list[dict]) -> dict:
+    """Build a classifications dict marking every dimension ``not_classified``.
+
+    The shared shape for a record we assert *nothing* about — a failed input
+    contract (``metadata_schema.validation_failed_classifications``) or an
+    unreadable fetch (``header_classifier.classify_without_content``). Each of the
+    five dimensions gets ``not_classified`` status and a *fresh copy* of
+    ``evidence`` (its cause). The per-field copy is deliberate: one shared list
+    aliased across five fields would let a later in-place edit of one mutate all.
+    """
+    return {
+        fld: build_field_entry(None, status=NOT_CLASSIFIED, evidence=[dict(e) for e in evidence])
+        for fld in CLASSIFICATION_FIELDS
+    }
+
+
 def _entry_status(entry) -> str:
     """Status from a per-field entry: explicit ``status`` if set, else derived.
 

--- a/src/meta_disco/pipeline.py
+++ b/src/meta_disco/pipeline.py
@@ -65,9 +65,9 @@ class RecordOutcome(NamedTuple):
     ``errored`` in ``_run_parallel`` by *raising*, which produces no ``RecordOutcome``).
     The three flags are mutually exclusive and only one, at most, is set:
     ``validation_failed`` (failed the input contract), ``was_cached`` (evidence already
-    on disk), ``content_unreadable`` (fetch failed, classified from the filename), or
-    none of these (a fresh fetch). Named so the four fields cannot be transposed at the
-    unpack sites.
+    on disk), ``content_unreadable`` (fetch failed; the record is fully not_classified,
+    #293), or none of these (a fresh fetch). Named so the four fields cannot be transposed
+    at the unpack sites.
     """
 
     result: OutputRecord
@@ -85,10 +85,6 @@ class FileTypeConfig:
     fetcher: Callable
     classifier: Callable
     summary_printer: Callable | None = None
-    # Dimensions this file type's *content* can determine. Used to attribute a
-    # fetch failure to the answers the unread bytes would have informed — never
-    # to dimensions only the filename can supply.
-    content_fields: tuple[str, ...] = ()
     # Environment check run once before the worker pool (e.g. an external tool
     # must be installed). Raises to abort the run fast, instead of letting every
     # record fail the same way and vanish. None means no check.
@@ -119,9 +115,10 @@ def _fetch_and_classify(
     Returns ``(classifications, content_unreadable)``:
 
     * content read        -> ``(classifications, False)``
-    * content unreadable  -> ``(filename-only classifications, True)``, when the
-      fetcher raised ``FetchError``; the file stays in the output as a
-      ``not_classified`` row rather than vanishing (#155).
+    * content unreadable  -> ``(all-not_classified classifications, True)``, when the
+      fetcher raised ``FetchError``; the file stays in the output as a fully
+      ``not_classified`` row rather than vanishing (#155), asserting nothing about
+      a file we could not read (#293).
 
     A fetcher signals failure by raising ``FetchError``, not by returning ``None``.
     An exception the fetcher does not wrap (e.g. a missing-tool ``FileNotFoundError``)
@@ -149,14 +146,8 @@ def _fetch_and_classify(
             url=url,
         )
     except FetchError as e:
-        print(f"Content unreadable, classifying from filename — {file_name or md5sum}: {e.reason}")
-        return classify_without_content(
-            e.reason,
-            name=name,
-            file_size=file_size,
-            file_format=file_format,
-            content_fields=config.content_fields,
-        ), True
+        print(f"Content unreadable, classified as nothing — {file_name or md5sum}: {e.reason}")
+        return classify_without_content(e.reason), True
 
     return config.classifier(
         raw_data,
@@ -307,7 +298,7 @@ class ClassifyPipeline:
         from ``md5sum`` (AnVIL mirror), a value streams from it instead (HPRC).
 
         Never returns ``None`` (#155): a fetch failure surfaces as a ``FetchError``,
-        which yields filename-only ``not_classified`` classifications. It does not
+        which yields an all-``not_classified`` record (#293). It does not
         catch everything, though — an environment error (missing samtools raises
         ``FileNotFoundError``) or an unexpected exception from the fetcher/classifier
         propagates rather than returning a record.
@@ -455,11 +446,10 @@ class ClassifyPipeline:
         md5 ``str``, ``file_name``/``file_format`` are ``str``, ``file_size`` an
         ``int`` — by construction, so this path carries no per-field type guards.
 
-        ``content_unreadable`` is reported explicitly rather than sniffed out of
-        the output: ``classify_without_content`` annotates only the dimensions
-        this file type's *content* can determine, so a type whose
-        ``content_fields`` is empty would leave no ``fetch_failed`` evidence at
-        all. Detection must not depend on evidence that a config may not emit.
+        ``content_unreadable`` is reported explicitly, as the boolean
+        ``_fetch_and_classify`` returns on a ``FetchError``, rather than sniffed
+        out of the output — detection must not depend on the shape of the
+        classifications a fetch failure produces.
         """
         if isinstance(item, InvalidRecord):
             classifications = validation_failed_classifications(item.reasons)
@@ -567,7 +557,7 @@ class ClassifyPipeline:
         print(f"\n\nSuccessfully classified: {successful}")
         print(f"  From cache: {from_cache}")
         print(f"  New fetches: {successful - from_cache - unreadable}")
-        print(f"  Content unreadable, classified from filename: {unreadable}")
+        print(f"  Content unreadable, classified as nothing: {unreadable}")
         if errored:
             print(f"Errored (cause printed above): {errored}")
         if invalid:
@@ -597,10 +587,10 @@ class ClassifyPipeline:
     ) -> list[dict]:
         """Write final JSON output from NDJSON progress file.
 
-        ``unreadable`` is persisted alongside ``from_cache``: a record classified
-        from its filename after a failed fetch is otherwise indistinguishable from
-        one whose content was read, because a file type whose ``content_fields``
-        is empty leaves no ``fetch_failed`` evidence behind.
+        ``unreadable`` is persisted alongside ``from_cache``: an all-not_classified
+        record from a failed fetch is otherwise indistinguishable from one whose
+        content was read but yielded no classification, so the count is the only
+        signal that its dimensions are blank because the bytes were unreachable.
 
         The ``metadata`` block's derived tallies (``processed``, ``failed``,
         ``dropped``) are computed in :meth:`RunMetadata.from_counts`, which documents

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -567,41 +567,36 @@ class TestFileTypeConfigs:
             workers=1,
         ).run()
 
-    def test_fetch_error_keeps_the_row_and_what_the_filename_already_gave(self, tmp_path):
-        """A dropped row is indistinguishable from a file that was never seen. But
-        blanking every dimension is also wrong: `pangenome` is knowable from the
-        extension without reading a byte. Only content-dependent fields go
-        not_classified, annotated with the cause."""
-        from meta_disco.models import CLASSIFIED, NOT_APPLICABLE, NOT_CLASSIFIED
+    def test_fetch_error_yields_a_fully_not_classified_row(self, tmp_path):
+        """We have nothing to say about a file we cannot read (#293): every dimension
+        goes not_classified with the failure as its evidence, even ones the extension
+        alone (`pangenome`) could support. The row is still written — a dropped row is
+        indistinguishable from a file that was never seen (#155)."""
+        from meta_disco.header_classifier import FETCH_FAILED_RULE_ID
+        from meta_disco.models import CLASSIFICATION_FIELDS, NOT_CLASSIFIED
 
         results = self._run_with_failing_fetcher(tmp_path, "graph.gfa", ".gfa")
         assert len(results) == 1, "the unreadable file must still appear in the output"
         cls = results[0]["classifications"]
 
-        # Knowable from the extension alone — must survive a failed fetch.
-        assert cls["data_type"]["value"] == "pangenome"
-        assert cls["data_type"]["status"] == CLASSIFIED
-        assert cls["data_modality"]["value"] == "genomic"
-        assert cls["platform"]["status"] == NOT_APPLICABLE
-        assert cls["assay_type"]["status"] == NOT_APPLICABLE
+        for field in CLASSIFICATION_FIELDS:
+            assert cls[field]["value"] is None
+            assert cls[field]["status"] == NOT_CLASSIFIED
+            reasons = [e["reason"] for e in cls[field]["evidence"] if e.get("rule_id") == FETCH_FAILED_RULE_ID]
+            assert reasons == ["HTTPError: 404 Not Found"], f"{field} must carry the fetch_failed cause"
 
-        # The note lands on the dimension GFA *content* determines (data_type,
-        # which the unread rGFA tags might have refined to pangenome.reference).
-        failed = [e for e in cls["data_type"]["evidence"] if e.get("rule_id") == "fetch_failed"]
-        assert [e["reason"] for e in failed] == ["HTTPError: 404 Not Found"]
+    def test_fetch_error_discards_a_filename_refinement(self, tmp_path):
+        """The `-mc-`/`grch38` tokens would refine data_type and reference_assembly from
+        the name alone — but with content unreadable we do not trust that guess: both go
+        not_classified (#293), the opposite of the pre-#293 filename fallback."""
+        from meta_disco.models import NOT_CLASSIFIED
 
-        # NOT on reference_assembly: GFA content never determines it (no lengths
-        # are parsed), so a note there would say a re-fetch could resolve an
-        # assembly only the filename can supply.
-        assert cls["reference_assembly"]["status"] == NOT_CLASSIFIED
-        assert not [e for e in cls["reference_assembly"]["evidence"] if e.get("rule_id") == "fetch_failed"]
-
-    def test_fetch_error_on_mc_graph_keeps_the_filename_refinement(self, tmp_path):
-        """The `-mc-` token still refines data_type even though content is unreadable."""
         results = self._run_with_failing_fetcher(tmp_path, "hprc-v1.0-mc-grch38.gfa.gz", ".gfa.gz")
         cls = results[0]["classifications"]
-        assert cls["data_type"]["value"] == "pangenome.reference"
-        assert cls["reference_assembly"]["value"] == "GRCh38"
+        assert cls["data_type"]["value"] is None
+        assert cls["data_type"]["status"] == NOT_CLASSIFIED
+        assert cls["reference_assembly"]["value"] is None
+        assert cls["reference_assembly"]["status"] == NOT_CLASSIFIED
 
     def test_fetch_error_reports_unreadable_and_never_counts_as_cached(self, tmp_path):
         """A fetcher raises only after its own cache check missed, so it went to the
@@ -645,10 +640,14 @@ class TestFileTypeConfigs:
         assert content_unreadable is True
         assert was_cached is False, "a fetch that reached the network is not a cache hit"
         assert out is not None
-        # The note is on data_type (what content refines), not on the four others.
+        # Every dimension carries the fetch_failed cause — we assert nothing about
+        # a file we could not read (#293).
+        from meta_disco.header_classifier import FETCH_FAILED_RULE_ID
+        from meta_disco.models import CLASSIFICATION_FIELDS
+
         cls = out.classifications
-        noted = [f for f in cls if any(e["rule_id"] == "fetch_failed" for e in cls[f]["evidence"])]
-        assert noted == ["data_type"]
+        noted = [f for f in cls if any(e["rule_id"] == FETCH_FAILED_RULE_ID for e in cls[f]["evidence"])]
+        assert set(noted) == set(CLASSIFICATION_FIELDS)
 
     def test_unreadable_count_is_persisted_in_run_metadata(self, tmp_path):
         """from_cache is persisted; unreadable must be too, or a consumer cannot tell


### PR DESCRIPTION
Closes #293.

## What changed

On a `FetchError` (404 from the mirror, DNS/connection failure, timeout), the pipeline no longer classifies the file from its name. Every dimension is returned `not_classified`, each carrying the failure reason as evidence.

- **`models.all_not_classified(evidence)`** — new shared builder for an all-`not_classified` record (every `CLASSIFICATION_FIELDS` dim, fresh per-field evidence copy). Both `validation_failed_classifications` and `classify_without_content` now route through it.
- **`classify_without_content(reason)`** — simplified from `(reason, *, name, file_size, file_format, content_fields)`. It no longer runs the tier-1/2 filename rules or appends a per-field note; it returns all-`not_classified`.
- **Removed `FileTypeConfig.content_fields`** — dead after this change; dropped from the dataclass and all 8 configs.
- Progress/summary wording updated ("classified from filename" → "classified as nothing"); the `content_unreadable` count is unchanged.
- Rewrote the fetch-error pipeline tests to the new policy.

## Why

`classify_without_content` had run the filename rules on unreadable content since the early FASTA/GFA classifiers. #155 only changed the *fetcher* to raise `FetchError`; it never changed this downstream policy, and the `content_fields` mechanism only ever *appended a non-assertive note* — it never suppressed the filename value. So a file we could not read was still reported **classified** from its name — e.g. `hg38_cluster_hets.bed` → `reference_assembly=GRCh38` from the `hg38` token alone, despite the content being unreadable. The standing principle is: **we have nothing to say about a file we cannot read.** It surfaced now because BED (many reference-token names + many missing-mirror 404s) is the first type to exercise this shared path at corpus scale.

## Assumptions I made

- **The whole record goes `not_classified`, including `not_applicable`.** Per the decision on #293: a fetch failure asserts *nothing*, so even type-level `not_applicable` dimensions (e.g. a BED's `platform`) are blanked — we did not verify the file, so we make no claim. This is the stricter of the two readings and is what the issue's DoD specifies.
- **The successful-empty-read path is intentionally unchanged.** A BED that *is* read but has no coordinates still classifies `data_modality`/`data_type` from its name — that file was readable; #293 only governs unreadable ones.
- **`content_fields` had no other consumer.** Verified by grep (src/tests/scripts/docs); its per-dimension-attribution intent is abandoned by the "assert nothing" stance, not relocated.
- **The `content_unreadable` count is still the signal for these rows** — an all-`not_classified` fetch-failure row is otherwise indistinguishable from a readable file that yielded no classification.

## How to verify

1. `make test` — 829 pass. Key coverage: `tests/test_pipeline.py::TestFileTypeConfigs` — `test_fetch_error_yields_a_fully_not_classified_row` (every dimension `not_classified` + `fetch_failed` evidence, including `platform`/`assay_type` that were `not_applicable` before), `test_fetch_error_discards_a_filename_refinement` (a `grch38`-token name no longer yields `reference_assembly=GRCh38` on a failed fetch), and `test_fetch_error_reports_unreadable_and_never_counts_as_cached` (all five dims noted).
2. `grep -rn content_fields src/ tests/ scripts/` returns nothing — the dead config is fully removed.
3. In a real run, a fetch failure prints `Content unreadable, classified as nothing — <file>: <reason>` and the summary reports `Content unreadable, classified as nothing: <n>`; the row is written with all five dimensions `not_classified`.

Follows the BED-first-class work (#282). The BED evidence regeneration (#285) should be re-run after this lands so fetch-failed BED files record `not_classified` rather than filename guesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)