### PR TITLE
Route standalone classify runs to output/anvil/partials/ (#315)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,11 @@ validate-metadata:
 # own fresh output/anvil/partials/<timestamp>/ folder. The reports' find_latest_run
 # selects only digit-prefixed run dirs, so the letter-prefixed partials/ folder is
 # skipped (see output_utils.find_latest_run).
-# Each target omits -o so classify_headers.py derives <type>_classifications.json;
-# pass RUN_DIR=... to place it, or leave it unset for the dated-partials default.
+# The per-type targets omit -o so classify_headers.py derives
+# <type>_classifications.json; pass RUN_DIR=... to a per-type target (e.g.
+# `make classify-bam RUN_DIR=...`) to place its output, or leave it unset for the
+# dated-partials default. classify-headers sets its own shared RUN_DIR, so a
+# RUN_DIR passed to classify-headers itself is overridden.
 # RUN_DIR_ARG expands to nothing when RUN_DIR is unset (standalone run).
 RUN_DIR_ARG = $(if $(RUN_DIR),--run-dir $(RUN_DIR))
 

--- a/Makefile
+++ b/Makefile
@@ -84,28 +84,39 @@ download:
 validate-metadata:
 	uv run python scripts/validate_metadata.py
 
-classify-headers: classify-bam classify-vcf classify-fastq classify-fasta classify-gfa classify-tar
+# `make classify-headers` runs the six header types into ONE dated partials folder
+# (a shared RUN_DIR). A standalone `make classify-<type>` run instead lands in its
+# own fresh output/anvil/partials/<timestamp>/ folder. Neither is read by the
+# reports, which consume only full `make classify` runs (see output_utils.find_latest_run).
+# Each target omits -o so classify_headers.py derives <type>_classifications.json;
+# pass RUN_DIR=... to place it, or leave it unset for the dated-partials default.
+# RUN_DIR_ARG expands to nothing when RUN_DIR is unset (standalone run).
+RUN_DIR_ARG = $(if $(RUN_DIR),--run-dir $(RUN_DIR))
+
+classify-headers:
+	$(MAKE) classify-bam classify-vcf classify-fastq classify-fasta classify-gfa classify-tar \
+		RUN_DIR="output/anvil/partials/$$(date +%Y%m%d_%H%M%S)"
 
 classify-bam:
-	uv run python scripts/classify_headers.py --type bam -i data/anvil/anvil_files_metadata.json -o output/anvil/bam_classifications.json -w 4
+	uv run python scripts/classify_headers.py --type bam -i data/anvil/anvil_files_metadata.json $(RUN_DIR_ARG) -w 4
 
 classify-vcf:
-	uv run python scripts/classify_headers.py --type vcf -i data/anvil/anvil_files_metadata.json -o output/anvil/vcf_classifications.json -w 10
+	uv run python scripts/classify_headers.py --type vcf -i data/anvil/anvil_files_metadata.json $(RUN_DIR_ARG) -w 10
 
 classify-fastq:
-	uv run python scripts/classify_headers.py --type fastq -i data/anvil/anvil_files_metadata.json -o output/anvil/fastq_classifications.json -w 10
+	uv run python scripts/classify_headers.py --type fastq -i data/anvil/anvil_files_metadata.json $(RUN_DIR_ARG) -w 10
 
 classify-fasta:
-	uv run python scripts/classify_headers.py --type fasta -i data/anvil/anvil_files_metadata.json -o output/anvil/fasta_classifications.json -w 10
+	uv run python scripts/classify_headers.py --type fasta -i data/anvil/anvil_files_metadata.json $(RUN_DIR_ARG) -w 10
 
 classify-gfa:
-	uv run python scripts/classify_headers.py --type gfa -i data/anvil/anvil_files_metadata.json -o output/anvil/gfa_classifications.json -w 10
+	uv run python scripts/classify_headers.py --type gfa -i data/anvil/anvil_files_metadata.json $(RUN_DIR_ARG) -w 10
 
 classify-tar:
-	uv run python scripts/classify_headers.py --type tar -i data/anvil/anvil_files_metadata.json -o output/anvil/tar_classifications.json -w 10
+	uv run python scripts/classify_headers.py --type tar -i data/anvil/anvil_files_metadata.json $(RUN_DIR_ARG) -w 10
 
 classify-bed:
-	uv run python scripts/classify_headers.py --type bed -i data/anvil/anvil_files_metadata.json -o output/anvil/bed_classifications.json -w 10
+	uv run python scripts/classify_headers.py --type bed -i data/anvil/anvil_files_metadata.json $(RUN_DIR_ARG) -w 10
 
 coverage-report:
 	uv run python scripts/generate_coverage_report.py

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,9 @@ validate-metadata:
 
 # `make classify-headers` runs the six header types into ONE dated partials folder
 # (a shared RUN_DIR). A standalone `make classify-<type>` run instead lands in its
-# own fresh output/anvil/partials/<timestamp>/ folder. Neither is read by the
-# reports, which consume only full `make classify` runs (see output_utils.find_latest_run).
+# own fresh output/anvil/partials/<timestamp>/ folder. The reports' find_latest_run
+# selects only digit-prefixed run dirs, so the letter-prefixed partials/ folder is
+# skipped (see output_utils.find_latest_run).
 # Each target omits -o so classify_headers.py derives <type>_classifications.json;
 # pass RUN_DIR=... to place it, or leave it unset for the dated-partials default.
 # RUN_DIR_ARG expands to nothing when RUN_DIR is unset (standalone run).

--- a/scripts/classify_headers.py
+++ b/scripts/classify_headers.py
@@ -51,7 +51,8 @@ def main():
         help=(
             "Run folder to write <type>_classifications.json into. Omit for a "
             "standalone run, which lands in a fresh output/anvil/partials/<timestamp>/ "
-            "folder (test artifacts the reports never read)."
+            "folder; the reports' find_latest_run selects only digit-prefixed run "
+            "dirs, so the letter-prefixed partials/ folder is skipped."
         ),
     )
     parser.add_argument(
@@ -118,8 +119,9 @@ def main():
     #   -o wins (explicit one-off path); else <type>_classifications.json inside the
     #   run dir (--run-dir, shared by `make classify-headers`); else a fresh dated
     #   partials folder. Standalone/per-type runs are test artifacts under
-    #   output/anvil/partials/ and are deliberately NOT read by the reports, which
-    #   only consume complete `make classify` runs (see output_utils.find_latest_run).
+    #   output/anvil/partials/; the reports' find_latest_run selects only
+    #   digit-prefixed run dirs, so the letter-prefixed partials/ folder is skipped
+    #   (see output_utils.find_latest_run).
     if args.output:
         output_path = args.output
     else:

--- a/scripts/classify_headers.py
+++ b/scripts/classify_headers.py
@@ -11,6 +11,7 @@ Examples:
 import argparse
 import json
 import sys
+from datetime import datetime
 from pathlib import Path
 
 # Add project root to path
@@ -41,7 +42,17 @@ def main():
         "-o",
         type=Path,
         default=None,
-        help="Output classification file (required in batch mode)",
+        help="Output classification file (explicit path; overrides --run-dir)",
+    )
+    parser.add_argument(
+        "--run-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Run folder to write <type>_classifications.json into. Omit for a "
+            "standalone run, which lands in a fresh output/anvil/partials/<timestamp>/ "
+            "folder (test artifacts the reports never read)."
+        ),
     )
     parser.add_argument(
         "--limit",
@@ -103,14 +114,23 @@ def main():
             sys.exit(1)
         return
 
-    # Batch mode
-    if not args.output:
-        parser.error("--output is required in batch mode")
+    # Batch mode — resolve where the output lands:
+    #   -o wins (explicit one-off path); else <type>_classifications.json inside the
+    #   run dir (--run-dir, shared by `make classify-headers`); else a fresh dated
+    #   partials folder. Standalone/per-type runs are test artifacts under
+    #   output/anvil/partials/ and are deliberately NOT read by the reports, which
+    #   only consume complete `make classify` runs (see output_utils.find_latest_run).
+    if args.output:
+        output_path = args.output
+    else:
+        run_dir = args.run_dir or (Path("output/anvil/partials") / datetime.now().strftime("%Y%m%d_%H%M%S"))
+        output_path = run_dir / f"{args.type}_classifications.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
 
     pipeline = ClassifyPipeline(
         config,
         args.input,
-        args.output,
+        output_path,
         evidence_base=args.evidence_base,
         limit=args.limit,
         resume=not args.no_resume,

--- a/src/meta_disco/output_utils.py
+++ b/src/meta_disco/output_utils.py
@@ -25,7 +25,10 @@ def find_latest_run(output_dir: Path) -> Path:
     """Find the most recent timestamped run directory.
 
     Looks for subdirectories whose names start with a digit (e.g., 20260322_112336)
-    and returns the one that sorts last (most recent).
+    and returns the one that sorts last (most recent). Only full `make classify`
+    runs are named this way; the `partials/` folder (standalone/per-type test runs
+    from `make classify-<type>`) starts with a letter and is deliberately skipped,
+    so a partial run never shadows a complete run in the reports.
 
     Raises FileNotFoundError if the output directory or run directories don't exist.
     """

--- a/src/meta_disco/output_utils.py
+++ b/src/meta_disco/output_utils.py
@@ -25,10 +25,12 @@ def find_latest_run(output_dir: Path) -> Path:
     """Find the most recent timestamped run directory.
 
     Looks for subdirectories whose names start with a digit (e.g., 20260322_112336)
-    and returns the one that sorts last (most recent). Only full `make classify`
-    runs are named this way; the `partials/` folder (standalone/per-type test runs
-    from `make classify-<type>`) starts with a letter and is deliberately skipped,
-    so a partial run never shadows a complete run in the reports.
+    and returns the one that sorts last (most recent). By convention, full
+    `make classify` runs write digit-prefixed dirs while the `partials/` folder
+    (standalone/per-type test runs from `make classify-<type>`) starts with a
+    letter, so this digit-prefix filter skips it. The filter keys only on the
+    leading character, so any other digit-prefixed dir here — e.g. one an operator
+    passes via `--run-dir` — would also be considered.
 
     Raises FileNotFoundError if the output directory or run directories don't exist.
     """

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -82,9 +82,10 @@ def test_every_registered_file_type_has_a_makefile_target():
         assert f"\nclassify-{ftype}:" in makefile, (
             f"No `classify-{ftype}` target in the Makefile for registered type {ftype!r}."
         )
-        assert f"{ftype}_classifications.json" in makefile, (
-            f"The classify-{ftype} target does not write "
-            f"{ftype}_classifications.json, which CLASSIFICATION_FILES expects."
+        assert f"--type {ftype}" in makefile, (
+            f"The classify-{ftype} target does not run classify_headers with "
+            f"--type {ftype}; classify_headers.py derives the "
+            f"{ftype}_classifications.json name CLASSIFICATION_FILES expects from it."
         )
         assert f"classify-{ftype} " in makefile or f"classify-{ftype}\n" in makefile, (
             f"classify-{ftype} is defined but not listed as a `classify-headers` prerequisite or in .PHONY."

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -71,6 +71,27 @@ def test_every_phase1_output_is_read_by_the_reports():
     )
 
 
+def _makefile_recipe(makefile: str, target: str) -> str | None:
+    """Return the recipe body (tab-indented lines) of a Makefile target, or None.
+
+    Scoped to the single stanza so an assertion about one target's recipe can't be
+    satisfied by text belonging to a different target.
+    """
+    lines = makefile.splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith(f"{target}:"):
+            recipe = []
+            for follow in lines[i + 1 :]:
+                if follow.startswith("\t"):
+                    recipe.append(follow)
+                elif follow.strip() == "":
+                    continue
+                else:
+                    break
+            return "\n".join(recipe)
+    return None
+
+
 def test_every_registered_file_type_has_a_makefile_target():
     """`make classify-<type>` is the other entry point, and it is hand-written.
 
@@ -82,8 +103,9 @@ def test_every_registered_file_type_has_a_makefile_target():
         assert f"\nclassify-{ftype}:" in makefile, (
             f"No `classify-{ftype}` target in the Makefile for registered type {ftype!r}."
         )
-        assert f"--type {ftype}" in makefile, (
-            f"The classify-{ftype} target does not run classify_headers with "
+        recipe = _makefile_recipe(makefile, f"classify-{ftype}")
+        assert recipe and f"--type {ftype}" in recipe, (
+            f"The classify-{ftype} target's recipe does not run classify_headers with "
             f"--type {ftype}; classify_headers.py derives the "
             f"{ftype}_classifications.json name CLASSIFICATION_FILES expects from it."
         )


### PR DESCRIPTION
Closes #315

## What changed
- **`scripts/classify_headers.py`** — batch mode no longer errors when `-o` is omitted. It resolves the output path in three steps: explicit `-o` wins; else `--run-dir/<type>_classifications.json`; else a fresh `output/anvil/partials/<timestamp>/<type>_classifications.json`. The parent dir is created automatically. Added a `--run-dir` argument.
- **`Makefile`** — per-type `classify-<type>` targets drop the flat `-o output/anvil/<type>_classifications.json` and pass a shared `$(RUN_DIR_ARG)` (`--run-dir` when `RUN_DIR` is set, nothing otherwise). `classify-headers` now runs the six header types into **one** dated partials folder via a shared `RUN_DIR`.
- **`src/meta_disco/output_utils.py`** — documented that `find_latest_run` deliberately skips the `partials/` folder (it starts with a letter, not a digit), so a partial run never shadows a complete run.
- **`tests/test_orchestration.py`** — the per-type target assertion now checks `--type <ftype>` (the filename is derived by the script) instead of the flat `<type>_classifications.json` path in the Makefile.

## Why
The coverage and validation reports read the newest timestamped run dir under `output/anvil/` (`find_latest_run`). But `make classify-<type>` wrote **flat** files (`output/anvil/<type>_classifications.json`) that the reports never read — so a fresh per-type reclassify left the reports showing stale data from an old dated run. This closes that gap: full `make classify` runs keep writing the immutable digit-prefixed dated dirs the reports consume, while standalone/per-type test runs land in `partials/` and are excluded by design.

## Assumptions I made
- **Full runs stay immutable; partials are test artifacts.** Per the approved design, `make classify` (via `classify_run.py`) writes `output/anvil/<timestamp>/` dirs that reports read; `make classify-<type>` / standalone runs go to `output/anvil/partials/<timestamp>/` and are never read by reports. This keeps full runs from being partially overwritten by single-type test runs.
- **The digit-prefix convention is the exclusion mechanism.** `find_latest_run` already selected run dirs by `d.name[0].isdigit()`; `partials/` is letter-prefixed, so it is excluded without any new special-case code. (A `strptime`-based predicate and a shared `run_stamp()`/`classification_filename()` helper were reviewed and deferred to a follow-up to keep this change scoped to the wiring fix.)
- **`-o` remains live** for the full-run path: `classify_run.py` still passes `--output`, so nothing there changes.

## How to verify
Definition of done — classify outputs are wired to what the reports read:

1. **Standalone run lands in partials** — `uv run python scripts/classify_headers.py --type gfa --limit 2`. Expect `Saved to output/anvil/partials/<timestamp>/gfa_classifications.json`.
2. **`--run-dir` is honored** — `make -n classify-gfa RUN_DIR=output/anvil/partials/TEST` shows `--run-dir output/anvil/partials/TEST`; `make -n classify-gfa` (no `RUN_DIR`) shows no `--run-dir` flag.
3. **Reports ignore partials** — with a partials folder present, `python -c "from pathlib import Path; from meta_disco.output_utils import find_latest_run; print(find_latest_run(Path('output/anvil')).name)"` returns a digit-prefixed dir, not `partials`.
4. **Full run still feeds reports** — `make classify` writes a new `output/anvil/<timestamp>/` dir; `make coverage-report` / `make validation-report` then read that dir. (This full corpus run is the operational refresh step, run separately.)
5. **Gate** — `make lint`, `make format-check`, `make type`, and `uv run pytest tests/ --deselect tests/test_evals.py` all pass. (`test_evals` are live-network E2E tests that fail on retired-catalog 404s independent of this change.)