### PR TITLE
Self-consistency linter over classified records (#314)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-schema test-all lint lint-schema lint-all type format format-check classify classify-hprc classify-and-report download validate-metadata classify-bam classify-vcf classify-fastq classify-fasta classify-gfa classify-tar classify-headers classify-bed coverage-report validation-report all-reports download-hprc validate-hprc clean help
+.PHONY: test test-schema test-all lint lint-schema lint-all type format format-check classify classify-hprc classify-and-report download validate-metadata classify-bam classify-vcf classify-fastq classify-fasta classify-gfa classify-tar classify-headers classify-bed consistency-report coverage-report validation-report all-reports download-hprc validate-hprc clean help
 
 help:
 	@echo "meta-disco — AnVIL file metadata classification"
@@ -121,6 +121,9 @@ classify-tar:
 
 classify-bed:
 	uv run python scripts/classify_headers.py --type bed -i data/anvil/anvil_files_metadata.json $(RUN_DIR_ARG) -w 10
+
+consistency-report:
+	uv run python scripts/check_consistency.py
 
 coverage-report:
 	uv run python scripts/generate_coverage_report.py

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Report cross-field self-consistency violations over a classification run (#314).
+
+Report-only spike: prints per-rule violation counts + example contradictions
+(with the offending field, its value, and the evidence behind it). Exits 0 —
+gating is a follow-up once the violation landscape is known.
+
+    uv run python scripts/check_consistency.py                     # latest run
+    uv run python scripts/check_consistency.py --run-dir output/anvil/20260802_170826
+"""
+
+import argparse
+from collections import Counter
+from pathlib import Path
+
+from meta_disco.consistency import check_run, load_rules
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Cross-field self-consistency report over a classification run")
+    parser.add_argument("--run-dir", type=Path, default=None, help="Run directory (default: latest under output/anvil)")
+    parser.add_argument("--examples", type=int, default=3, help="Example violations to show per rule")
+    args = parser.parse_args()
+
+    rules = load_rules()
+    run_dir, total, violations, activations = check_run(args.run_dir, rules)
+
+    print(f"Consistency check over {run_dir} — {total:,} records, {len(rules)} rules")
+    print(f"Total violations: {len(violations):,}\n")
+
+    # "active" = records the rule tested; 0 active means vacuous (no such data),
+    # not verified-clean. Distinguishing the two is the point of showing both.
+    by_rule = Counter(v.rule_id for v in violations)
+    print(f"{'violations':>11}  {'active':>10}  rule")
+    for rule in rules:
+        count = by_rule.get(rule["id"], 0)
+        active = activations.get(rule["id"], 0)
+        note = "  ⚠" if count else ("  (vacuous — no matching records)" if active == 0 else "")
+        print(f"{count:>11,}  {active:>10,}  {rule['id']}{note}")
+
+    if not violations:
+        print("\nNo violations. ✅")
+        return
+
+    print("\nExamples:")
+    shown: Counter = Counter()
+    for v in violations:
+        if shown[v.rule_id] >= args.examples:
+            continue
+        shown[v.rule_id] += 1
+        when_str = ", ".join(f"{k}={val}" for k, val in v.when.items())
+        offending = v.offending_value if v.offending_status == "classified" else f"<{v.offending_status}>"
+        evidence = f"  (evidence: {v.evidence})" if v.evidence else ""
+        print(f"  [{v.rule_id}] {v.file_name} ({v.md5sum[:8]})")
+        print(f"      when {when_str}  →  {v.offending_field}={offending}{evidence}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/meta_disco/consistency.py
+++ b/src/meta_disco/consistency.py
@@ -1,0 +1,190 @@
+"""Self-consistency linter (#314): cross-field semantic invariants over records.
+
+Each rule is declarative data in ``rules/consistency_rules.yaml`` — a ``when``
+(field matchers that make the rule active) and a ``require`` (what must then
+hold). A violation is a concrete internal contradiction: it names the offending
+field, its value/status, and the evidence behind it, caught with no ground truth.
+
+Report-only for now (the #314 spike); wiring it into a hard gate is a follow-up
+once the violation landscape is known.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from meta_disco.models import CLASSIFIED, _entry_value, _field_entry, status_for_value
+from meta_disco.output_utils import CLASSIFICATION_FILES, find_latest_run
+
+_RULES_PATH = Path(__file__).parent / "rules" / "consistency_rules.yaml"
+
+
+@dataclass
+class Violation:
+    """One record failing one rule's ``require`` clause."""
+
+    md5sum: str
+    file_name: str
+    rule_id: str
+    when: dict  # field -> the value that activated the rule
+    offending_field: str
+    offending_value: str | None  # None unless the offending field is classified
+    offending_status: str
+    evidence: str | None  # rule_id/marker of the offending field's first evidence
+
+
+def load_rules(path: Path = _RULES_PATH) -> list[dict]:
+    """Load the declarative invariant set."""
+    data = yaml.safe_load(path.read_text()) or {}
+    return data.get("rules", [])
+
+
+def _dim(record: dict, name: str) -> tuple[str | None, str, list]:
+    """Return the RAW ``(value, status, evidence)`` for one dimension of a record.
+
+    Reuses ``models`` for layout normalization (``_field_entry``) and the status
+    vocabulary (``status_for_value``), so the linter reads records the same way
+    every other consumer does. Deliberately reads the emitted ``status`` verbatim
+    (falling back to ``status_for_value`` only when absent) rather than via
+    ``_entry_status``: that path runs a coherence assertion that *raises* on an
+    incoherent entry, which would abort the whole run on one malformed record. A
+    linter must read what is actually there and keep going — within-field
+    incoherence is caught upstream (``build_field_entry`` / schema validation), not
+    here. Evidence has no shared accessor and is read off the entry.
+    """
+    entry = _field_entry(record, name)
+    value = _entry_value(entry)
+    if isinstance(entry, dict):
+        status = entry.get("status") or status_for_value(value)
+        evidence = entry.get("evidence") or []
+    else:
+        status, evidence = status_for_value(value), []
+    return value, status, evidence
+
+
+def _matches(value: str | None, status: str, matcher) -> bool:
+    """Whether a field's (value, status) satisfies a ``when`` matcher."""
+    if isinstance(matcher, str):
+        return status == CLASSIFIED and value == matcher
+    if "prefix" in matcher:
+        return status == CLASSIFIED and isinstance(value, str) and value.startswith(matcher["prefix"])
+    if "value_in" in matcher:
+        return status == CLASSIFIED and value in matcher["value_in"]
+    if "status" in matcher:
+        return status == matcher["status"]
+    return False
+
+
+def _violates(value: str | None, status: str, matcher: dict) -> bool:
+    """Whether a field's (value, status) UNsatisfies a ``require`` matcher."""
+    if "value_in" in matcher:
+        return status == CLASSIFIED and value not in matcher["value_in"]
+    if "value_not_in" in matcher:
+        return status == CLASSIFIED and value in matcher["value_not_in"]
+    if "status_not" in matcher:
+        return status == matcher["status_not"]
+    if "status" in matcher:
+        return status != matcher["status"]
+    return False
+
+
+def rule_activation(record: dict, rule: dict) -> dict | None:
+    """If the rule's ``when`` matches this record, return the activating field->value
+    map; otherwise None. A rule only tests a record when it is active."""
+    activated = {}
+    for fieldname, matcher in (rule.get("when") or {}).items():
+        value, status, _ = _dim(record, fieldname)
+        if not _matches(value, status, matcher):
+            return None
+        activated[fieldname] = value if status == CLASSIFIED else f"<{status}>"
+    return activated
+
+
+def _check_active(record: dict, rule: dict, activated: dict) -> list[Violation]:
+    """Violations from an already-activated rule against a record.
+
+    Takes the ``activated`` map from :func:`rule_activation` so the ``when`` clause
+    is never re-evaluated by the caller.
+    """
+    violations: list[Violation] = []
+    for req_field, matcher in (rule.get("require") or {}).items():
+        value, status, evidence = _dim(record, req_field)
+        if not _violates(value, status, matcher):
+            continue
+        first = evidence[0] if evidence else {}
+        violations.append(
+            Violation(
+                md5sum=record.get("md5sum") or "",
+                file_name=record.get("file_name") or "",
+                rule_id=rule["id"],
+                when=dict(activated),
+                offending_field=req_field,
+                offending_value=value if status == CLASSIFIED else None,
+                offending_status=status,
+                evidence=first.get("rule_id") or first.get("marker"),
+            )
+        )
+    return violations
+
+
+def check_record(record: dict, rules: list[dict]) -> list[Violation]:
+    """Return every consistency violation for one classified record."""
+    violations: list[Violation] = []
+    for rule in rules:
+        activated = rule_activation(record, rule)
+        if activated is not None:
+            violations.extend(_check_active(record, rule, activated))
+    return violations
+
+
+def iter_records(run_dir: Path):
+    """Yield every classification record (a dict) across a run's classification files.
+
+    Unwraps the ``{"metadata", "classifications"}`` envelope the same way the
+    coverage/validation report loaders do (falling back to a ``results`` key, then
+    an empty list), and skips any non-dict element so an unexpected top-level shape
+    yields nothing rather than iterating stray keys.
+    """
+    for fname in CLASSIFICATION_FILES:
+        path = run_dir / fname
+        if not path.exists():
+            continue
+        data = json.loads(path.read_text())
+        records = data.get("classifications", data.get("results", [])) if isinstance(data, dict) else data
+        for record in records:
+            if isinstance(record, dict):
+                yield record
+
+
+def check_run(
+    run_dir: Path | None = None, rules: list[dict] | None = None
+) -> tuple[Path, int, list[Violation], Counter]:
+    """Run every rule over every record in a run.
+
+    Returns ``(run_dir, record_count, violations, activations)`` where
+    ``activations`` counts, per rule id, how many records the rule was active on —
+    so a zero-violation rule that never activated (vacuous, no such data) is
+    distinguishable from one that was genuinely exercised and stayed clean.
+
+    Activation is evaluated once per (record, rule) and drives both the counter and
+    the ``require`` check.
+    """
+    run_dir = run_dir or find_latest_run(Path("output/anvil"))
+    rules = rules if rules is not None else load_rules()
+    violations: list[Violation] = []
+    activations: Counter = Counter()
+    total = 0
+    for record in iter_records(run_dir):
+        total += 1
+        for rule in rules:
+            activated = rule_activation(record, rule)
+            if activated is None:
+                continue
+            activations[rule["id"]] += 1
+            violations.extend(_check_active(record, rule, activated))
+    return run_dir, total, violations, activations

--- a/src/meta_disco/consistency.py
+++ b/src/meta_disco/consistency.py
@@ -14,14 +14,13 @@ from __future__ import annotations
 import json
 from collections import Counter
 from dataclasses import dataclass
+from importlib.resources import files
 from pathlib import Path
 
 import yaml
 
 from meta_disco.models import CLASSIFIED, _entry_value, _field_entry, status_for_value
 from meta_disco.output_utils import CLASSIFICATION_FILES, find_latest_run
-
-_RULES_PATH = Path(__file__).parent / "rules" / "consistency_rules.yaml"
 
 
 @dataclass
@@ -38,9 +37,20 @@ class Violation:
     evidence: str | None  # rule_id/marker of the offending field's first evidence
 
 
-def load_rules(path: Path = _RULES_PATH) -> list[dict]:
-    """Load the declarative invariant set."""
-    data = yaml.safe_load(path.read_text()) or {}
+def default_consistency_rules_resource():
+    """The bundled ``consistency_rules.yaml`` as an ``importlib.resources`` resource.
+
+    Anchored on this module's package (``{__package__}.rules``) so it resolves from
+    an installed wheel/zip rather than a ``__file__`` walk — mirroring
+    ``rule_loader.default_rules_resource`` (the package-data convention, #164/#166).
+    """
+    return files(f"{__package__}.rules") / "consistency_rules.yaml"
+
+
+def load_rules(resource=None) -> list[dict]:
+    """Load the declarative invariant set (defaults to the bundled package resource)."""
+    resource = resource or default_consistency_rules_resource()
+    data = yaml.safe_load(resource.read_text(encoding="utf-8")) or {}
     return data.get("rules", [])
 
 
@@ -61,7 +71,8 @@ def _dim(record: dict, name: str) -> tuple[str | None, str, list]:
     value = _entry_value(entry)
     if isinstance(entry, dict):
         status = entry.get("status") or status_for_value(value)
-        evidence = entry.get("evidence") or []
+        ev = entry.get("evidence")
+        evidence = ev if isinstance(ev, list) else []
     else:
         status, evidence = status_for_value(value), []
     return value, status, evidence
@@ -117,6 +128,7 @@ def _check_active(record: dict, rule: dict, activated: dict) -> list[Violation]:
         if not _violates(value, status, matcher):
             continue
         first = evidence[0] if evidence else {}
+        evidence_ref = (first.get("rule_id") or first.get("marker")) if isinstance(first, dict) else None
         violations.append(
             Violation(
                 md5sum=record.get("md5sum") or "",
@@ -126,7 +138,7 @@ def _check_active(record: dict, rule: dict, activated: dict) -> list[Violation]:
                 offending_field=req_field,
                 offending_value=value if status == CLASSIFIED else None,
                 offending_status=status,
-                evidence=first.get("rule_id") or first.get("marker"),
+                evidence=evidence_ref,
             )
         )
     return violations

--- a/src/meta_disco/rules/consistency_rules.yaml
+++ b/src/meta_disco/rules/consistency_rules.yaml
@@ -1,0 +1,85 @@
+# Self-consistency invariants (#314) — cross-field semantic rules over CLASSIFIED
+# records. Each violation is a concrete internal contradiction ("these two fields
+# can't both be true"), caught with no ground truth. This is a post-hoc QA layer,
+# separate from the classification rule engine (unified_rules.yaml).
+#
+# Rule shape (evaluated by consistency.py):
+#   id:          stable identifier
+#   description: human-readable statement of the invariant
+#   when:        field -> matcher; the rule is ACTIVE only when every matcher holds
+#                  "<value>"            -> field is classified AND value == <value>
+#                  {prefix: "x."}       -> classified AND value starts with "x."
+#                  {value_in: [...]}    -> classified AND value in list
+#                  {status: <status>}   -> field status == <status>
+#   require:     field -> matcher; a violation is raised when any is UNsatisfied
+#                  {value_in: [...]}    -> violation if classified AND value not in list
+#                  {value_not_in: [...]}-> violation if classified AND value in list
+#                  {status_not: <s>}    -> violation if field status == <s>
+#                  {status: <s>}        -> violation if field status != <s>
+#
+# `value_in`/`value_not_in` only fire on CLASSIFIED fields, so absence of a value
+# is never flagged — only a determined value that contradicts another determined one.
+#
+# Scope note: the flat/deterministic subset only (spike). Conditional rules
+# (reference-applicability #4, degenerate-guard #7, data_type<->modality #2) and
+# index inertness (the propagation question, #312) are deferred follow-ups.
+
+rules:
+  # --- 1. modality <-> assay family -------------------------------------------
+  - id: assay_for_transcriptomic
+    description: A transcriptomic file's assay, if classified, must be RNA-seq.
+    when: {data_modality: {prefix: "transcriptomic."}}
+    require: {assay_type: {value_in: ["RNA-seq"]}}
+
+  - id: assay_for_genomic
+    description: A genomic file's assay, if classified, must be WGS or WES.
+    when: {data_modality: "genomic"}
+    require: {assay_type: {value_in: ["WGS", "WES"]}}
+
+  - id: assay_for_chromatin_accessibility
+    description: A chromatin-accessibility file's assay, if classified, must be ATAC-seq.
+    when: {data_modality: "epigenomic.chromatin_accessibility"}
+    require: {assay_type: {value_in: ["ATAC-seq"]}}
+
+  - id: assay_for_histone_modification
+    description: A histone-modification file's assay, if classified, must be ChIP-seq.
+    when: {data_modality: "epigenomic.histone_modification"}
+    require: {assay_type: {value_in: ["ChIP-seq"]}}
+
+  - id: assay_for_methylation
+    description: A methylation file's assay, if classified, must be Bisulfite-seq or Methylation array.
+    when: {data_modality: "epigenomic.methylation"}
+    require: {assay_type: {value_in: ["Bisulfite-seq", "Methylation array"]}}
+
+  # --- 3. imaging exclusivity -------------------------------------------------
+  - id: imaging_exclusive
+    description: >-
+      A histology image carries no sequencing signal: data_type must be images,
+      and platform / reference_assembly must not be classified (a histology file
+      with platform=ILLUMINA or reference=GRCh38 is unmistakably wrong).
+    when: {data_modality: "imaging.histology"}
+    require:
+      data_type: {value_in: ["images"]}
+      assay_type: {value_in: ["Histology"]}
+      platform: {status_not: "classified"}
+      reference_assembly: {status_not: "classified"}
+
+  # --- 5. platform <-> modality family ----------------------------------------
+  - id: platform_implies_sequencing_modality
+    description: A sequencing platform contradicts a histology modality.
+    when: {platform: {value_in: ["ILLUMINA", "PACBIO", "ONT", "MGI", "ELEMENT", "ULTIMA"]}}
+    require: {data_modality: {value_not_in: ["imaging.histology"]}}
+
+  # --- 6. auxiliary-type inertness (checksum/log; index deferred to #312) ------
+  - id: auxiliary_inert
+    description: >-
+      A checksum or log describes another file and carries no signal of its own,
+      so modality / reference / assay / platform must not be classified (e.g. a
+      .md5 classified genomic is inconsistent). Index inertness is the #312
+      propagation question and is intentionally out of scope here.
+    when: {data_type: {value_in: ["checksum", "log"]}}
+    require:
+      data_modality: {status_not: "classified"}
+      reference_assembly: {status_not: "classified"}
+      assay_type: {status_not: "classified"}
+      platform: {status_not: "classified"}

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -100,6 +100,15 @@ def test_incoherent_entry_does_not_crash():
     assert check_record(rec, RULES) == []  # reads raw status, no ValueError raised
 
 
+def test_malformed_evidence_does_not_crash():
+    # A record whose offending field carries a non-list `evidence` must still be
+    # flagged (with no evidence ref), not abort the run.
+    rec = _rec(data_modality=_c("transcriptomic.bulk"), assay_type=_c("WGS"))
+    rec["classifications"]["assay_type"]["evidence"] = "oops-not-a-list"
+    [viol] = [v for v in check_record(rec, RULES) if v.rule_id == "assay_for_transcriptomic"]
+    assert viol.evidence is None
+
+
 def test_iter_records_unwraps_shapes_and_skips_non_dicts(tmp_path):
     # A 'results'-keyed envelope, plus a stray non-dict element, must not crash and
     # must yield only the dict records.

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,0 +1,110 @@
+"""Tests for the self-consistency linter (#314)."""
+
+import json
+
+from meta_disco.consistency import check_record, iter_records, load_rules
+
+RULES = load_rules()
+
+_DIMS = ("data_modality", "data_type", "reference_assembly", "assay_type", "platform")
+
+
+def _rec(md5="m", name="f.bam", **dims):
+    """Build a record; each dim kwarg is a (value, status) tuple, default not_classified."""
+    classifications = {}
+    for dim in _DIMS:
+        value, status = dims.get(dim, (None, "not_classified"))
+        classifications[dim] = {"value": value, "status": status, "evidence": []}
+    return {"md5sum": md5, "file_name": name, "classifications": classifications}
+
+
+def _c(value):
+    return (value, "classified")
+
+
+NA = (None, "not_applicable")
+NC = (None, "not_classified")
+
+
+def _rule_ids(record):
+    return {v.rule_id for v in check_record(record, RULES)}
+
+
+def test_rules_file_loads_and_is_nonempty():
+    assert RULES, "consistency_rules.yaml produced no rules"
+    assert all("id" in r and "when" in r and "require" in r for r in RULES)
+
+
+def test_clean_genomic_wgs_has_no_violations():
+    rec = _rec(data_modality=_c("genomic"), data_type=_c("alignments"), assay_type=_c("WGS"))
+    assert check_record(rec, RULES) == []
+
+
+def test_genomic_with_unclassified_assay_is_not_flagged():
+    # value_in only fires on a classified field — absence is never a contradiction.
+    rec = _rec(data_modality=_c("genomic"), assay_type=NC)
+    assert check_record(rec, RULES) == []
+
+
+def test_transcriptomic_with_wgs_assay_flags_assay_rule():
+    rec = _rec(data_modality=_c("transcriptomic.bulk"), assay_type=_c("WGS"))
+    ids = _rule_ids(rec)
+    assert "assay_for_transcriptomic" in ids
+    [v] = [x for x in check_record(rec, RULES) if x.rule_id == "assay_for_transcriptomic"]
+    assert v.offending_field == "assay_type"
+    assert v.offending_value == "WGS"
+
+
+def test_histology_with_sequencing_fields_flags_imaging_and_platform_rules():
+    rec = _rec(
+        data_modality=_c("imaging.histology"),
+        data_type=_c("images"),
+        assay_type=_c("Histology"),
+        platform=_c("ILLUMINA"),
+        reference_assembly=NC,
+    )
+    ids = _rule_ids(rec)
+    assert "imaging_exclusive" in ids  # platform must not be classified
+    assert "platform_implies_sequencing_modality" in ids  # sequencing platform vs histology
+
+
+def test_clean_histology_has_no_violations():
+    rec = _rec(
+        data_modality=_c("imaging.histology"),
+        data_type=_c("images"),
+        assay_type=_c("Histology"),
+        platform=NA,
+        reference_assembly=NA,
+    )
+    assert check_record(rec, RULES) == []
+
+
+def test_checksum_classified_genomic_flags_auxiliary_inert():
+    rec = _rec(md5="abc", name="x.md5", data_type=_c("checksum"), data_modality=_c("genomic"))
+    ids = _rule_ids(rec)
+    assert "auxiliary_inert" in ids
+    [v] = [x for x in check_record(rec, RULES) if x.rule_id == "auxiliary_inert"]
+    assert v.offending_field == "data_modality"
+    assert v.offending_value == "genomic"
+
+
+def test_inert_checksum_with_all_not_applicable_is_clean():
+    rec = _rec(data_type=_c("checksum"), data_modality=NA, reference_assembly=NA, assay_type=NA, platform=NA)
+    assert check_record(rec, RULES) == []
+
+
+def test_incoherent_entry_does_not_crash():
+    # An incoherent entry (status 'classified' but value None) is a malformed record
+    # a QA linter must read and keep going on, not abort the whole run over.
+    rec = _rec(data_modality=(None, "classified"), data_type=_c("alignments"))
+    assert check_record(rec, RULES) == []  # reads raw status, no ValueError raised
+
+
+def test_iter_records_unwraps_shapes_and_skips_non_dicts(tmp_path):
+    # A 'results'-keyed envelope, plus a stray non-dict element, must not crash and
+    # must yield only the dict records.
+    run = tmp_path
+    good = _rec(md5="a", data_modality=_c("genomic"))
+    (run / "bam_classifications.json").write_text(json.dumps({"results": [good, "stray"]}))
+    records = list(iter_records(run))
+    assert records == [good]


### PR DESCRIPTION
Closes #314

## What changed
A **report-only self-consistency linter** that flags cross-field contradictions in classified records — no ground truth needed.
- **`src/meta_disco/rules/consistency_rules.yaml`** — the invariants as declarative data (same `when`→`require` idiom as `unified_rules.yaml`): 8 flat rules across modality⟺assay family, imaging exclusivity, platform⟺modality, and checksum/log inertness.
- **`src/meta_disco/consistency.py`** — a small evaluator (`Violation`, `rule_activation`, `check_record`, `check_run`) over the `{value, status, evidence}` output shape, reusing `models`/`output_utils` accessors. No new dependencies.
- **`scripts/check_consistency.py`** + **`consistency-report`** make target — prints per-rule **violations *and* activation counts** (so a vacuous rule with no matching data is distinguishable from one exercised and clean), plus example contradictions with evidence. Exits 0.
- **`tests/test_consistency.py`** — 10 tests (each violation type, absence-is-not-a-violation, incoherent-record robustness, file-shape robustness).

## Why
We had no way to catch mis-classifications without external truth — but the five dimensions constrain each other, so some combinations are internally contradictory (`transcriptomic` + `WGS`; a histology image with an `ILLUMINA` platform; a `.md5` classified `genomic`). This catches rule mis-fires, import↔inference conflicts, and regressions in one pass.

**Result on the fresh 733,992-record run: 0 violations.** 5 rules were genuinely exercised over real data and stayed clean (`assay_for_genomic` 586,752 active, `platform_implies_sequencing_modality` 57,973, `imaging_exclusive` 25,708, `assay_for_transcriptomic` 5,173, `assay_for_methylation` 188); 3 are vacuous (no ATAC/ChIP data in the 13 open datasets; `data_type=checksum/log` is never assigned — ties to #312). So the classifier's output is internally consistent on every deterministic invariant currently testable, and a hard gate on these would be green today.

## Assumptions I made
- **Scope is the flat/deterministic subset only** (this was a spike to see whether any violations exist). The conditional rules — reference-applicability (#4), degenerate-guard (#7), data_type⟺modality (#2) — and index inertness (the propagation question, #312) are deferred follow-ups.
- **Report-only, no gate.** The plan deferred the hard-gate wiring until the violation landscape was known; now that it's 0, a follow-up can safely turn these into a CI gate.
- **The linter reads raw emitted status** (via `status_for_value`, not the coherence-asserting `_entry_status`) so one malformed/incoherent record can never abort the whole run — within-field coherence is enforced upstream (`build_field_entry` / schema validation), not here.
- **`auxiliary_inert` is scoped to checksum/log, not index** — index files intentionally inherit their parent's classification (propagation), so including them would flag ~210K intended records; that's the #312 question, deliberately out of scope.

## How to verify
DoD (#314, reduced to the spike scope):
1. **Documented rule set** — read `src/meta_disco/rules/consistency_rules.yaml` (8 flat invariants, each with a description). ✅
2. **A consistency report over the corpus** — `make consistency-report` (or `uv run python scripts/check_consistency.py --run-dir output/anvil/20260802_170826`). Expect `Total violations: 0` and a per-rule table with `violations` + `active` columns; 3 rules marked `(vacuous — no matching records)`. ✅
3. **Run it and triage the first batch** — 0 violations; nothing to triage (see the run output above). ✅
4. **Tests** — `uv run pytest tests/test_consistency.py` (10 pass). Gate: `make lint`, `make format-check`, `make type` all clean.

Deferred (own tickets, not this PR): the hard-gate CI wiring, and the conditional rules (#2/#4/#7) + index inertness (#312).